### PR TITLE
[VCDA-3152] Add additional properties to RDE

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -16,6 +16,7 @@ import (
 )
 
 func yamlWithoutStatus(obj interface{}) (string, error) {
+	// Redact the password and refresh token
 	// get yaml string for obj
 	objInByteArr, err := yaml.Marshal(obj)
 	if err != nil {

--- a/controllers/convert_objects.go
+++ b/controllers/convert_objects.go
@@ -33,23 +33,23 @@ func yamlWithoutStatus(obj interface{}) (string, error) {
 	}
 
 	if _, ok := objMap["typemeta"]; ok {
-		typeMetaMap, ok := objMap["typemeta"].(map[string]interface{})
+		typeMetaMap, ok := objMap["typemeta"].(map[interface{}]interface{})
 		if !ok {
-			return "", fmt.Errorf("failed to convert typemeta [%v] to map[string]interface{}: [%v]", objMap["typemeta"], err)
+			return "", fmt.Errorf("failed to convert typemeta [%v] to map[interface{}]interface{}: [%v]", objMap["typemeta"], err)
 		}
 		for k, v := range typeMetaMap {
-			objMap[k] = v
+			objMap[k.(string)] = v
 		}
 		delete(objMap, "typemeta")
 	}
 
 	if _, ok := objMap["objectmeta"]; ok {
-		objectMetaMap, ok := objMap["objectmeta"].(map[string]interface{})
+		objectMetaMap, ok := objMap["objectmeta"].(map[interface{}]interface{})
 		if !ok {
-			return "", fmt.Errorf("failed to convert objectmeta [%v] to map[string]interface{}: [%v]", objMap["objectmeta"], err)
+			return "", fmt.Errorf("failed to convert objectmeta [%v] to map[interface{}]interface{}: [%v]", objMap["objectmeta"], err)
 		}
 		for k, _ := range objectMetaMap {
-			if k != "name" && k != "namespace" {
+			if k.(string) != "name" && k.(string) != "namespace" {
 				delete(objectMetaMap, k)
 			}
 		}
@@ -58,7 +58,7 @@ func yamlWithoutStatus(obj interface{}) (string, error) {
 	}
 
 	// marshal back to a string
-	output, err := yaml.Marshal(obj)
+	output, err := yaml.Marshal(objMap)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal modified object: [%v]", err)
 	}

--- a/controllers/convert_objects.go
+++ b/controllers/convert_objects.go
@@ -1,0 +1,219 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"github.com/pkg/errors"
+	infrav1 "github.com/vmware/cluster-api-provider-cloud-director/api/v1alpha4"
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
+	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+func yamlWithoutStatus(obj interface{}) (string, error) {
+	// get yaml string for obj
+	objInByteArr, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal object: [%v]", err)
+	}
+
+	objMap := make(map[string]interface{})
+	if err := yaml.Unmarshal(objInByteArr, &objMap); err != nil {
+		return "", fmt.Errorf("failed to unmarshal object to map[string]interface{}: [%v]", err)
+	}
+
+	// delete status key
+	if _, ok := objMap["status"]; ok {
+		delete(objMap, "status")
+	}
+
+	if _, ok := objMap["typemeta"]; ok {
+		typeMetaMap, ok := objMap["typemeta"].(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("failed to convert typemeta [%v] to map[string]interface{}: [%v]", objMap["typemeta"], err)
+		}
+		for k, v := range typeMetaMap {
+			objMap[k] = v
+		}
+		delete(objMap, "typemeta")
+	}
+
+	if _, ok := objMap["objectmeta"]; ok {
+		objectMetaMap, ok := objMap["objectmeta"].(map[string]interface{})
+		if !ok {
+			return "", fmt.Errorf("failed to convert objectmeta [%v] to map[string]interface{}: [%v]", objMap["objectmeta"], err)
+		}
+		for k, _ := range objectMetaMap {
+			if k != "name" && k != "namespace" {
+				delete(objectMetaMap, k)
+			}
+		}
+		objMap["metadata"] = objectMetaMap
+		delete(objMap, "objectmeta")
+	}
+
+	// marshal back to a string
+	output, err := yaml.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal modified object: [%v]", err)
+	}
+	return string(output), nil
+}
+
+func getAllMachineDeploymentsForCluster(ctx context.Context, cli client.Client, c clusterv1.Cluster) (*clusterv1.MachineDeploymentList, error) {
+	mdListLabels := map[string]string{clusterv1.ClusterLabelName: c.Name}
+	mdList := &clusterv1.MachineDeploymentList{}
+	if err := cli.List(ctx, mdList, client.InNamespace(c.Namespace), client.MatchingLabels(mdListLabels)); err != nil {
+		return nil, errors.Wrapf(err, "error getting machine deployments for the cluster [%s]", c.Name)
+	}
+	return mdList, nil
+}
+
+func getAllKubeadmControlPlaneForCluster(ctx context.Context, cli client.Client, c clusterv1.Cluster) (*kcpv1.KubeadmControlPlaneList, error) {
+	kcpListLabels := map[string]string{clusterv1.ClusterLabelName: c.Name}
+	kcpList := &kcpv1.KubeadmControlPlaneList{}
+
+	if err := cli.List(ctx, kcpList, client.InNamespace(c.Namespace), client.MatchingLabels(kcpListLabels)); err != nil {
+		return nil, errors.Wrapf(err, "error getting all kubeadm control planes for the cluster [%s]", c.Name)
+	}
+	return kcpList, nil
+}
+
+func getVCDMachineTemplateFromKCP(ctx context.Context, cli client.Client, kcp kcpv1.KubeadmControlPlane) (*infrav1.VCDMachineTemplate, error) {
+	vcdMachineTemplateRef := kcp.Spec.MachineTemplate.InfrastructureRef
+	vcdMachineTemplate := &infrav1.VCDMachineTemplate{}
+	vcdMachineTemplateKey := types.NamespacedName{
+		Namespace: vcdMachineTemplateRef.Namespace,
+		Name:      vcdMachineTemplateRef.Name,
+	}
+	if err := cli.Get(ctx, vcdMachineTemplateKey, vcdMachineTemplate); err != nil {
+		return nil, fmt.Errorf("failed to get VCDMachineTemplate by name [%s] from KCP [%s]: [%v]", vcdMachineTemplateRef.Name, kcp.Name, err)
+	}
+
+	return vcdMachineTemplate, nil
+}
+
+func getVCDMachineTemplateFromMachineDeployment(ctx context.Context, cli client.Client, md clusterv1.MachineDeployment) (*infrav1.VCDMachineTemplate, error) {
+	vcdMachineTemplateRef := md.Spec.Template.Spec.InfrastructureRef
+	vcdMachineTemplate := &infrav1.VCDMachineTemplate{}
+	vcdMachineTemplateKey := client.ObjectKey{
+		Namespace: vcdMachineTemplateRef.Namespace,
+		Name:      vcdMachineTemplateRef.Name,
+	}
+	if err := cli.Get(ctx, vcdMachineTemplateKey, vcdMachineTemplate); err != nil {
+		return nil, fmt.Errorf("failed to get VCDMachineTemplate by name [%s] from machine deployment [%s]: [%v]", vcdMachineTemplateRef.Name, md.Name, err)
+	}
+
+	return vcdMachineTemplate, nil
+}
+
+func getMachineListFromCluster(ctx context.Context, cli client.Client, cluster clusterv1.Cluster) (*clusterv1.MachineList, error) {
+	machineListLabels := map[string]string{clusterv1.ClusterLabelName: cluster.Name}
+	machineList := &clusterv1.MachineList{}
+	if err := cli.List(ctx, machineList, client.InNamespace(cluster.Namespace), client.MatchingLabels(machineListLabels)); err != nil {
+		return nil, errors.Wrapf(err, "error getting machine list for the cluster [%s]", cluster.Name)
+	}
+	return machineList, nil
+}
+
+func getVCDMachineTemplateByObjRef(ctx context.Context, cli client.Client, objRef v1.ObjectReference) (*infrav1.VCDMachineTemplate, error) {
+	vcdMachineTemplate := &infrav1.VCDMachineTemplate{}
+	vcdMachineTemplateKey := client.ObjectKey{
+		Namespace: objRef.Namespace,
+		Name:      objRef.Name,
+	}
+	if err := cli.Get(ctx, vcdMachineTemplateKey, vcdMachineTemplate); err != nil {
+		return nil, fmt.Errorf("failed to get VCDMachineTemplate by ObjectReference [%v]: [%v]", objRef, err)
+	}
+
+	return vcdMachineTemplate, nil
+}
+
+func getKubeadmConfigTemplateByObjRef(ctx context.Context, cli client.Client, objRef v1.ObjectReference) (*v1alpha4.KubeadmConfigTemplate, error) {
+	kubeadmConfigTemplate := &v1alpha4.KubeadmConfigTemplate{}
+	kubeadmConfigTemplateKey := client.ObjectKey{
+		Namespace: objRef.Namespace,
+		Name:      objRef.Name,
+	}
+	if err := cli.Get(ctx, kubeadmConfigTemplateKey, kubeadmConfigTemplate); err != nil {
+		return nil, fmt.Errorf("failed to get KubeadmConfigTemplate by ObjectReference [%v]: [%v]", objRef, err)
+	}
+
+	return kubeadmConfigTemplate, nil
+}
+
+func getCapiYaml(ctx context.Context, cli client.Client, cluster clusterv1.Cluster, vcdCluster infrav1.VCDCluster) (string, error) {
+	capiYamlObjects := []interface{}{
+		cluster,
+		vcdCluster,
+	}
+
+	kcpList, err := getAllKubeadmControlPlaneForCluster(ctx, cli, cluster)
+	if err != nil {
+		return "", fmt.Errorf("failed to get all KCPs from Cluster object: [%v]", err)
+	}
+
+	mdList, err := getAllMachineDeploymentsForCluster(ctx, cli, cluster)
+	if err != nil {
+		return "", fmt.Errorf("failed to get all the MachineDeployments from Cluster: [%v]", err)
+	}
+
+	vcdMachineTemplateNameToObjRef := make(map[string]v1.ObjectReference)
+	for _, kcp := range kcpList.Items {
+		vcdMachineTemplateNameToObjRef[kcp.Spec.MachineTemplate.InfrastructureRef.Name] = kcp.Spec.MachineTemplate.InfrastructureRef
+	}
+
+	kubeadmConfigTemplateNameToObjRef := make(map[string]*v1.ObjectReference)
+	for _, md := range mdList.Items {
+		vcdMachineTemplateNameToObjRef[md.Spec.Template.Spec.InfrastructureRef.Name] = md.Spec.Template.Spec.InfrastructureRef
+		kubeadmConfigTemplateNameToObjRef[md.Spec.Template.Spec.Bootstrap.ConfigRef.Name] = md.Spec.Template.Spec.Bootstrap.ConfigRef
+	}
+
+	vcdMachineTemplates := make([]*infrav1.VCDMachineTemplate, 0)
+	for _, objRef := range vcdMachineTemplateNameToObjRef {
+		vcdMachineTemplate, err := getVCDMachineTemplateByObjRef(ctx, cli, objRef)
+		if err != nil {
+			return "", fmt.Errorf("failed to get VCDMachineTemplate by ObjectReference [%v]: [%v]", objRef, err)
+		}
+		vcdMachineTemplates = append(vcdMachineTemplates, vcdMachineTemplate)
+	}
+
+	kubeadmConfigTemplates := make([]*v1alpha4.KubeadmConfigTemplate, 0)
+	for _, objRef := range kubeadmConfigTemplateNameToObjRef {
+		kubeadmConifgTemplate, err := getKubeadmConfigTemplateByObjRef(ctx, cli, *objRef)
+		if err != nil {
+			return "", fmt.Errorf("failed to get KubeadmConfigTemplate by ObjectReference [%v]: [%v]", objRef, err)
+		}
+		kubeadmConfigTemplates = append(kubeadmConfigTemplates, kubeadmConifgTemplate)
+	}
+
+	// add objects
+	for _, vcdMachineTemplate := range vcdMachineTemplates {
+		capiYamlObjects = append(capiYamlObjects, *vcdMachineTemplate)
+	}
+	for _, kubeadmConfigTemplate := range kubeadmConfigTemplates {
+		capiYamlObjects = append(capiYamlObjects, *kubeadmConfigTemplate)
+	}
+	for _, kcp := range kcpList.Items {
+		capiYamlObjects = append(capiYamlObjects, kcp)
+	}
+	for _, md := range mdList.Items {
+		capiYamlObjects = append(capiYamlObjects, md)
+	}
+	yamlObjects := make([]string, len(capiYamlObjects))
+	for idx, obj := range capiYamlObjects {
+		yamlString, err := yamlWithoutStatus(obj)
+		if err != nil {
+			return "", fmt.Errorf("failed to convert object to yaml: [%v]", err)
+		}
+		yamlObjects[idx] = yamlString
+	}
+
+	return strings.Join(yamlObjects, "---\n"), nil
+
+}

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -206,8 +206,8 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
 		}
 		topologyControlPlane := vcdtypes.ControlPlane{
-			Count:       *kcp.Spec.Replicas,
-			SizingClass: vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			Count:        *kcp.Spec.Replicas,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyControlPlanes = append(topologyControlPlanes, topologyControlPlane)
@@ -225,8 +225,8 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
 		}
 		topologyWorker := vcdtypes.Workers{
-			Count:       *md.Spec.Replicas,
-			SizingClass: vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			Count:        *md.Spec.Replicas,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyWorkers = append(topologyWorkers, topologyWorker)
@@ -269,13 +269,13 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			},
 		},
 		Status: vcdtypes.Status{
-			Phase:      ClusterApiStatusPhaseNotReady,
+			Phase: ClusterApiStatusPhaseNotReady,
 			// TODO: Discuss with sahithi if "kubernetes" needs to be removed from the RDE.
 			Kubernetes: kubernetesVersion,
 			CloudProperties: vcdtypes.CloudProperties{
-				Site: vcdCluster.Spec.Site,
-				Org:  org,
-				Vdc:  vdc,
+				Site:   vcdCluster.Spec.Site,
+				Org:    org,
+				Vdc:    vdc,
 				SshKey: "", // TODO: Should add ssh key as part of vcdCluster representation
 			},
 			ClusterAPIStatus: vcdtypes.ClusterApiStatus{
@@ -284,7 +284,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			},
 			NodeStatus:          make(map[string]string),
 			IsManagementCluster: false,
-			CapvcdVersion: "0.5.0", // TODO: Discuss with Arun on how to get the CAPVCD version.
+			CapvcdVersion:       "0.5.0", // TODO: Discuss with Arun on how to get the CAPVCD version.
 		},
 	}
 
@@ -360,8 +360,8 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 			return fmt.Errorf("error getting VCDMachineTemplate from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
 		}
 		topologyControlPlane := vcdtypes.ControlPlane{
-			Count:       *kcp.Spec.Replicas,
-			SizingClass: vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			Count:        *kcp.Spec.Replicas,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyControlPlanes[idx] = topologyControlPlane
@@ -379,8 +379,8 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 			return fmt.Errorf("error getting VCDMachineTemplate from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
 		}
 		topologyWorker := vcdtypes.Workers{
-			Count:       *md.Spec.Replicas,
-			SizingClass: vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			Count:        *md.Spec.Replicas,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyWorkers[idx] = topologyWorker
@@ -393,11 +393,11 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	if !reflect.DeepEqual(capvcdEntity.Spec.Topology.Workers, topologyWorkers) {
 		updatePatch["Spec.Topology.Workers"] = topologyWorkers
 	}
-
-	capiYaml, err := r.getCapiYaml(vcdCluster, cluster)
+	capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
 	if err != nil {
-
+		klog.Errorf("______________DEBUG: error occurred: [%v]", err)
 	}
+	klog.Infof("-------------------DEBUG: capiYaml: \n[%s]", capiYaml)
 
 	// Updating status portion of the RDE in the following code
 	// TODO: Delete "kubernetes" string in RDE. Discuss with Sahithi

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -18,12 +18,10 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"net/http"
 	"reflect"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
-	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
@@ -57,62 +55,6 @@ type VCDClusterReconciler struct {
 	client.Client
 	Scheme    *runtime.Scheme
 	VcdClient *vcdclient.Client
-}
-
-func (r *VCDClusterReconciler) getAllMachineDeploymentsForCluster(ctx context.Context, c clusterv1.Cluster) (*clusterv1.MachineDeploymentList, error) {
-	mdListLabels := map[string]string{clusterv1.ClusterLabelName: c.Name}
-	mdList := &clusterv1.MachineDeploymentList{}
-	if err := r.Client.List(ctx, mdList, client.InNamespace(c.Namespace), client.MatchingLabels(mdListLabels)); err != nil {
-		return nil, errors.Wrapf(err, "error getting machine deployments for the cluster [%s]", c.Name)
-	}
-	return mdList, nil
-}
-
-func (r *VCDClusterReconciler) getAllKubeadmControlPlaneForCluster(ctx context.Context, c clusterv1.Cluster) (*kcpv1.KubeadmControlPlaneList, error) {
-	kcpListLabels := map[string]string{clusterv1.ClusterLabelName: c.Name}
-	kcpList := &kcpv1.KubeadmControlPlaneList{}
-
-	if err := r.Client.List(ctx, kcpList, client.InNamespace(c.Namespace), client.MatchingLabels(kcpListLabels)); err != nil {
-		return nil, errors.Wrapf(err, "error getting all kubeadm control planes for the cluster [%s]", c.Name)
-	}
-	return kcpList, nil
-}
-
-func (r *VCDClusterReconciler) getVCDMachineTemplateFromKCP(ctx context.Context, kcp kcpv1.KubeadmControlPlane) (*infrav1.VCDMachineTemplate, error) {
-	vcdMachineTemplateRef := kcp.Spec.MachineTemplate.InfrastructureRef
-	vcdMachineTemplate := &infrav1.VCDMachineTemplate{}
-	vcdMachineTemplateKey := types.NamespacedName{
-		Namespace: vcdMachineTemplateRef.Namespace,
-		Name:      vcdMachineTemplateRef.Name,
-	}
-	if err := r.Client.Get(ctx, vcdMachineTemplateKey, vcdMachineTemplate); err != nil {
-		return nil, fmt.Errorf("failed to get VCDMachineTemplate by name [%s] from KCP [%s]: [%v]", vcdMachineTemplateRef.Name, kcp.Name, err)
-	}
-
-	return vcdMachineTemplate, nil
-}
-
-func (r *VCDClusterReconciler) getVCDMachineTemplateFromMachineDeployment(ctx context.Context, md clusterv1.MachineDeployment) (*infrav1.VCDMachineTemplate, error) {
-	vcdMachineTemplateRef := md.Spec.Template.Spec.InfrastructureRef
-	vcdMachineTemplate := &infrav1.VCDMachineTemplate{}
-	vcdMachineTemplateKey := client.ObjectKey{
-		Namespace: vcdMachineTemplateRef.Namespace,
-		Name:      vcdMachineTemplateRef.Name,
-	}
-	if err := r.Client.Get(ctx, vcdMachineTemplateKey, vcdMachineTemplate); err != nil {
-		return nil, fmt.Errorf("failed to get VCDMachineTemplate by name [%s] from machine deployment [%s]: [%v]", vcdMachineTemplateRef.Name, md.Name, err)
-	}
-
-	return vcdMachineTemplate, nil
-}
-
-func (r *VCDClusterReconciler) getMachineListFromCluster(ctx context.Context, cluster clusterv1.Cluster) (*clusterv1.MachineList, error) {
-	machineListLabels := map[string]string{clusterv1.ClusterLabelName: cluster.Name}
-	machineList := &clusterv1.MachineList{}
-	if err := r.Client.List(ctx, machineList, client.InNamespace(cluster.Namespace), client.MatchingLabels(machineListLabels)); err != nil {
-		return nil, errors.Wrapf(err, "error getting machine list for the cluster [%s]", cluster.Name)
-	}
-	return machineList, nil
 }
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdclusters,verbs=get;list;watch;create;update;patch;delete
@@ -194,14 +136,14 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 	vdc := vcdCluster.Spec.Ovdc
 	ovdcNetwork := vcdCluster.Spec.OvdcNetwork
 
-	kcpList, err := r.getAllKubeadmControlPlaneForCluster(ctx, *cluster)
+	kcpList, err := getAllKubeadmControlPlaneForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return nil, fmt.Errorf("error getting KubeadmControlPlane objects for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
 	topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
 	kubernetesVersion := ""
 	for _, kcp := range kcpList.Items {
-		vcdMachineTemplate, err := r.getVCDMachineTemplateFromKCP(ctx, kcp)
+		vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
 		if err != nil {
 			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
 		}
@@ -214,13 +156,13 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		kubernetesVersion = kcp.Spec.Version
 	}
 
-	mdList, err := r.getAllMachineDeploymentsForCluster(ctx, *cluster)
+	mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return nil, fmt.Errorf("error getting the MachineDeployments for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
 	topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
 	for _, md := range mdList.Items {
-		vcdMachineTemplate, err := r.getVCDMachineTemplateFromMachineDeployment(ctx, md)
+		vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
 		if err != nil {
 			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
 		}
@@ -247,7 +189,6 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		Spec: vcdtypes.ClusterSpec{
 			Settings: vcdtypes.Settings{
 				OvdcNetwork: ovdcNetwork,
-				SshKey:      "", // TODO: Should add ssh key as part of vcdCluster representation
 				Network: vcdtypes.Network{
 					Cni: vcdtypes.Cni{
 						Name: CAPVCDClusterCniName,
@@ -273,10 +214,9 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			// TODO: Discuss with sahithi if "kubernetes" needs to be removed from the RDE.
 			Kubernetes: kubernetesVersion,
 			CloudProperties: vcdtypes.CloudProperties{
-				Site:   vcdCluster.Spec.Site,
-				Org:    org,
-				Vdc:    vdc,
-				SshKey: "", // TODO: Should add ssh key as part of vcdCluster representation
+				Site: vcdCluster.Spec.Site,
+				Org:  org,
+				Vdc:  vdc,
 			},
 			ClusterAPIStatus: vcdtypes.ClusterApiStatus{
 				Phase:        "",
@@ -285,6 +225,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			NodeStatus:          make(map[string]string),
 			IsManagementCluster: false,
 			CapvcdVersion:       "0.5.0", // TODO: Discuss with Arun on how to get the CAPVCD version.
+			ParentUID:           r.VcdClient.ManagementClusterRDEId,
 		},
 	}
 
@@ -348,14 +289,14 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		updatePatch["Spec.Settings.OvdcNetwork"] = networkName
 	}
 
-	kcpList, err := r.getAllKubeadmControlPlaneForCluster(ctx, *cluster)
+	kcpList, err := getAllKubeadmControlPlaneForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return fmt.Errorf("error getting all KubeadmControlPlane objects for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
 	topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
 	kubernetesVersion := ""
 	for idx, kcp := range kcpList.Items {
-		vcdMachineTemplate, err := r.getVCDMachineTemplateFromKCP(ctx, kcp)
+		vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
 		if err != nil {
 			return fmt.Errorf("error getting VCDMachineTemplate from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
 		}
@@ -368,13 +309,13 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		kubernetesVersion = kcp.Spec.Version
 	}
 
-	mdList, err := r.getAllMachineDeploymentsForCluster(ctx, *cluster)
+	mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return fmt.Errorf("error getting getting all MachineDeployment for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
 	topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
 	for idx, md := range mdList.Items {
-		vcdMachineTemplate, err := r.getVCDMachineTemplateFromMachineDeployment(ctx, md)
+		vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
 		if err != nil {
 			return fmt.Errorf("error getting VCDMachineTemplate from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
 		}
@@ -395,9 +336,12 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	}
 	capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
 	if err != nil {
-		klog.Errorf("______________DEBUG: error occurred: [%v]", err)
+		return fmt.Errorf("failed to get the capi yaml resources for cluster [%s]: [%v]", cluster.Name, err)
 	}
-	klog.Infof("-------------------DEBUG: capiYaml: \n[%s]", capiYaml)
+
+	if capvcdEntity.Spec.CapiYaml != capiYaml {
+		updatePatch["Spec.CapiYaml"] = capiYaml
+	}
 
 	// Updating status portion of the RDE in the following code
 	// TODO: Delete "kubernetes" string in RDE. Discuss with Sahithi
@@ -434,7 +378,7 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	}
 
 	// update node status. Needed to remove stray nodes which were already deleted
-	machineList, err := r.getMachineListFromCluster(ctx, *cluster)
+	machineList, err := getMachineListFromCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return fmt.Errorf("error getting machine list for cluster with name [%s]: [%v]", cluster.Name, err)
 	}

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -336,10 +336,10 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	}
 	capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
 	if err != nil {
-		return fmt.Errorf("failed to get the capi yaml resources for cluster [%s]: [%v]", cluster.Name, err)
+		klog.Errorf("failed to construct capi yaml using kubernetes resources for cluster [%s]: [%v]", cluster.Name, err)
 	}
 
-	if capvcdEntity.Spec.CapiYaml != capiYaml {
+	if err == nil && capvcdEntity.Spec.CapiYaml != capiYaml {
 		updatePatch["Spec.CapiYaml"] = capiYaml
 	}
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -171,7 +171,6 @@ func patchVCDMachine(ctx context.Context, patchHelper *patch.Helper, vcdMachine 
 
 const (
 	NetworkConfiguration                   = "guestinfo.postcustomization.networkconfiguration.status"
-	StoreSshKey                            = "guestinfo.postcustomization.store.sshkey.status"
 	KubeadmInit                            = "guestinfo.postcustomization.kubeinit.status"
 	KubectlApplyCni                        = "guestinfo.postcustomization.kubectl.cni.install.status"
 	KubectlApplyCpi                        = "guestinfo.postcustomization.kubectl.cpi.install.status"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
 	"time"
 
 	"k8s.io/klog"
@@ -51,6 +52,7 @@ func init() {
 	utilruntime.Must(clusterv1.AddToScheme(myscheme))
 	utilruntime.Must(kcpv1.AddToScheme(myscheme))
 	utilruntime.Must(infrastructurev1alpha4.AddToScheme(myscheme))
+	utilruntime.Must(v1alpha4.AddToScheme(myscheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/vcdtypes/types.go
+++ b/pkg/vcdtypes/types.go
@@ -262,15 +262,13 @@ type Network struct {
 
 type Settings struct {
 	OvdcNetwork string  `json:"ovdcNetwork,omitempty"`
-	SshKey      string  `json:"sshKey,omitempty"`
 	Network     Network `json:"network,omitempty"`
 }
 
 type CloudProperties struct {
-	Site   string `json:"site,omitempty"`
-	Org    string `json:"orgName,omitempty"`
-	Vdc    string `json:"virtualDataCenterName,omitempty"`
-	SshKey string `json:"sshKey,omitempty"`
+	Site string `json:"site,omitempty"`
+	Org  string `json:"orgName,omitempty"`
+	Vdc  string `json:"virtualDataCenterName,omitempty"`
 }
 
 type ApiEndpoints struct {

--- a/pkg/vcdtypes/types.go
+++ b/pkg/vcdtypes/types.go
@@ -222,17 +222,19 @@ type Metadata struct {
 }
 
 type ControlPlane struct {
-	SizingClass string `json:"sizingClass,omitempty"`
-	Count       int32  `json:"count,omitempty"`
+	SizingClass  string `json:"sizingClass,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	TemplateName string `json:"templateName,omitempty"`
 }
 
 type Workers struct {
-	SizingClass string `json:"sizingClass,omitempty"`
-	Count       int32  `json:"count,omitempty"`
+	SizingClass  string `json:"sizingClass,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	TemplateName string `json:"templateName,omitempty"`
 }
 
 type Distribution struct {
-	TemplateName string `json:"templateName,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type Topology struct {
@@ -265,11 +267,10 @@ type Settings struct {
 }
 
 type CloudProperties struct {
-	Site         string       `json:"site,omitempty"`
-	Org          string       `json:"orgName,omitempty"`
-	Vdc          string       `json:"virtualDataCenterName,omitempty"`
-	Distribution Distribution `json:"distribution,omitempty"`
-	SshKey       string       `json:"sshKey,omitempty"`
+	Site   string `json:"site,omitempty"`
+	Org    string `json:"orgName,omitempty"`
+	Vdc    string `json:"virtualDataCenterName,omitempty"`
+	SshKey string `json:"sshKey,omitempty"`
 }
 
 type ApiEndpoints struct {
@@ -280,6 +281,11 @@ type ApiEndpoints struct {
 type ClusterApiStatus struct {
 	Phase        string         `json:"phase,omitempty"`
 	ApiEndpoints []ApiEndpoints `json:"apiEndpoints,omitempty"`
+}
+
+type VersionedAddon struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type Status struct {
@@ -293,12 +299,17 @@ type Status struct {
 	NodeStatus          map[string]string `json:"nodeStatus,omitempty"`
 	ParentUID           string            `json:"parentUid,omitempty"`
 	IsManagementCluster bool              `json:"isManagementCluster,omitempty"`
+	Cni                 VersionedAddon    `json:"cni,omitempty"`
+	Cpi                 VersionedAddon    `json:"cpi,omitempty"`
+	Csi                 VersionedAddon    `json:"csi,omitempty"`
+	CapvcdVersion       string            `json:"capvcdVersion,omitempty"`
 }
 
 type ClusterSpec struct {
 	Settings     Settings     `json:"settings"`
 	Topology     Topology     `json:"topology"`
 	Distribution Distribution `json:"distribution"`
+	CapiYaml     string       `json:"capiYaml,omitempty"`
 }
 
 type CAPVCDEntity struct {

--- a/schema/schema_1_0_0.json
+++ b/schema/schema_1_0_0.json
@@ -139,8 +139,8 @@
         },
         "capiYaml": {
           "type": "string",
-          "description": "input used to create the cluster"
-        },
+          "description": "CAPI Yaml specification of the CAPVCD cluster"
+        }
       },
       "additionalProperties": true
     },

--- a/schema/schema_1_0_0.json
+++ b/schema/schema_1_0_0.json
@@ -128,10 +128,6 @@
               "type": "string",
               "description": "Name of the Organization's virtual data center network"
             },
-            "sshKey": {
-              "type": "string",
-              "description": "The ssh key that users can use to log into the node VMs without explicitly providing passwords."
-            },
             "network": {
               "$ref": "#/definitions/network"
             }
@@ -254,10 +250,6 @@
             "ovdcNetworkName": {
               "type": "string",
               "description": "The name of the Organization Virtual data center network to which cluster is connected."
-            },
-            "sshKey": {
-              "type": "string",
-              "description": "The ssh key that users can use to log into the node VMs without explicitly providing passwords."
             },
             "site": {
               "type": "string",

--- a/schema/schema_1_0_0.json
+++ b/schema/schema_1_0_0.json
@@ -3,10 +3,10 @@
     "distribution": {
       "type": "object",
       "required": [
-        "templateName"
+        "version"
       ],
       "properties": {
-        "templateName": {
+        "version": {
           "type": "string"
         }
       },
@@ -90,6 +90,10 @@
                 "sizingClass": {
                   "type": "string",
                   "description": "The compute sizing policy with which control-plane node needs to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                },
+                "templateName": {
+                  "type": "string",
+                  "description": "template name for the set of nodes"
                 }
               },
               "additionalProperties": true
@@ -107,6 +111,10 @@
                 "sizingClass": {
                   "type": "string",
                   "description": "The compute sizing policy with which worker nodes need to be provisioned in a given \"ovdc\". The specified sizing policy is expected to be pre-published to the given ovdc."
+                },
+                "templateName": {
+                  "type": "string",
+                  "description": "template name for the set of nodes"
                 }
               },
               "additionalProperties": true
@@ -132,7 +140,11 @@
         },
         "distribution": {
           "$ref": "#/definitions/distribution"
-        }
+        },
+        "capiYaml": {
+          "type": "string",
+          "description": "input used to create the cluster"
+        },
       },
       "additionalProperties": true
     },
@@ -189,6 +201,44 @@
             "properties": {}
           }
         },
+        "cni": {
+          "type": "object",
+          "description": "Information regarding the CNI used to deploy the cluster",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "name of the CNI used in the cluster"
+            },
+            "version": {
+              "type": "string",
+              "description": "version of the CNI used in the cluster"
+            }
+          }
+        },
+        "csi": {
+          "type": "object",
+          "description": "details about CSI used in the cluster",
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "version of the CSI used"
+            }
+          }
+        },
+        "cpi": {
+          "type": "object",
+          "description": "details about CPI used in the cluster",
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "version of the CPI used"
+            }
+          }
+        },
+        "capvcdVersion": {
+          "type": "string",
+          "description": "version of the CAPVCD used to deploy the cluster"
+        },
         "cloudProperties": {
           "type": "object",
           "description": "The details specific to Cloud Director in which the cluster is hosted.",
@@ -204,9 +254,6 @@
             "ovdcNetworkName": {
               "type": "string",
               "description": "The name of the Organization Virtual data center network to which cluster is connected."
-            },
-            "distribution": {
-              "$ref": "#/definitions/distribution"
             },
             "sshKey": {
               "type": "string",


### PR DESCRIPTION
Defined entity: 
```
 {
            "id": "urn:vcloud:entity:vmware:capvcd:02387512-9b48-46f3-b72b-11ba8172e016",
            "entityType": "urn:vcloud:type:vmware:capvcd:1.0.0",
            "name": "capi-cluster",
            "externalId": null,
            "entity": {
                "kind": "CAPVCDCluster",
                "spec": {
                    "capiYaml": "apiversion: cluster.x-k8s.io/v1alpha4\nkind: Cluster\nmetadata:\n  name: capi-cluster\n  namespace: default\nspec:\n  clusternetwork:\n    apiserverport: null\n    pods:\n      cidrblocks:\n      - 192.168.0.0/16\n    servicedomain: k8s.test\n    services:\n      cidrblocks:\n      - 10.96.0.0/12\n  controlplaneendpoint:\n    host: 10.150.161.96\n    port: 6443\n  controlplaneref:\n    apiversion: controlplane.cluster.x-k8s.io/v1alpha4\n    fieldpath: \"\"\n    kind: KubeadmControlPlane\n    name: capi-control-plane\n    namespace: default\n    resourceversion: \"\"\n    uid: \"\"\n  infrastructureref:\n    apiversion: infrastructure.cluster.x-k8s.io/v1alpha4\n    fieldpath: \"\"\n    kind: VCDCluster\n    name: capi-cluster\n    namespace: default\n    resourceversion: \"\"\n    uid: \"\"\n  paused: false\n  topology: null\n---\napiversion: infrastructure.cluster.x-k8s.io/v1alpha4\nkind: VCDCluster\nmetadata:\n  name: capi-cluster\n  namespace: default\nspec:\n  controlplaneendpoint:\n    host: 10.150.161.94\n    port: 6443\n  defaultcomputepolicy: \"\"\n  org: test_org\n  ovdc: test_orgvdc\n  ovdcnetwork: test_orgvdc_net\n  site: https://bos1-vcloud-static-170-210.eng.vmware.com\n  usercredentialscontext:\n    password: vmware\n    refreshtoken: \"\"\n    username: user_admin\n---\napiversion: infrastructure.cluster.x-k8s.io/v1alpha4\nkind: VCDMachineTemplate\nmetadata:\n  name: capi-control-plane\n  namespace: default\nspec:\n  template:\n    spec:\n      bootstrapped: false\n      catalog: cse-cat\n      computepolicy: 2core2gb\n      providerid: null\n      template: ubuntu-2004-kube-v1.20.8+vmware.1-tkg.1-17589475007677388652\n---\napiversion: infrastructure.cluster.x-k8s.io/v1alpha4\nkind: VCDMachineTemplate\nmetadata:\n  name: capi-md0\n  namespace: default\nspec:\n  template:\n    spec:\n      bootstrapped: false\n      catalog: cse-cat\n      computepolicy: \"\"\n      providerid: null\n      template: ubuntu-2004-kube-v1.20.8+vmware.1-tkg.1-17589475007677388652\n---\napiversion: bootstrap.cluster.x-k8s.io/v1alpha4\nkind: KubeadmConfigTemplate\nmetadata:\n  name: capi-md0\n  namespace: default\nspec:\n  template:\n    spec:\n      clusterconfiguration: null\n      disksetup: null\n      files: []\n      format: \"\"\n      initconfiguration: null\n      joinconfiguration:\n        cacertpath: \"\"\n        controlplane: null\n        discovery:\n          bootstraptoken: null\n          file: null\n          timeout: null\n          tlsbootstraptoken: \"\"\n        noderegistration:\n          crisocket: /run/containerd/containerd.sock\n          ignorepreflighterrors: []\n          kubeletextraargs:\n            cgroup-driver: cgroupfs\n            cloud-provider: external\n            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%\n          name: \"\"\n          taints: []\n        typemeta:\n          apiversion: \"\"\n          kind: \"\"\n      mounts: []\n      ntp: null\n      postkubeadmcommands: []\n      prekubeadmcommands: []\n      useexperimentalretryjoin: false\n      users: []\n      verbosity: null\n---\napiversion: controlplane.cluster.x-k8s.io/v1alpha4\nkind: KubeadmControlPlane\nmetadata:\n  name: capi-control-plane\n  namespace: default\nspec:\n  kubeadmconfigspec:\n    clusterconfiguration:\n      apiserver:\n        certsans:\n        - localhost\n        - 127.0.0.1\n        controlplanecomponent:\n          extraargs: {}\n          extravolumes: []\n        timeoutforcontrolplane: null\n      certificatesdir: \"\"\n      clustername: \"\"\n      controllermanager:\n        extraargs:\n          enable-hostpath-provisioner: \"true\"\n        extravolumes: []\n      controlplaneendpoint: \"\"\n      dns:\n        imagemeta:\n          imagerepository: projects.registry.vmware.com/tkg\n          imagetag: v1.7.0-vmware.12\n      etcd:\n        external: null\n        local:\n          datadir: \"\"\n          extraargs: {}\n          imagemeta:\n            imagerepository: projects.registry.vmware.com/tkg\n            imagetag: v3.4.13-vmware.14\n          peercertsans: []\n          servercertsans: []\n      featuregates: {}\n      imagerepository: projects.registry.vmware.com/tkg\n      kubernetesversion: \"\"\n      networking:\n        dnsdomain: \"\"\n        podsubnet: \"\"\n        servicesubnet: \"\"\n      scheduler:\n        extraargs: {}\n        extravolumes: []\n      typemeta:\n        apiversion: \"\"\n        kind: \"\"\n    disksetup: null\n    files: []\n    format: \"\"\n    initconfiguration:\n      bootstraptokens: []\n      localapiendpoint:\n        advertiseaddress: \"\"\n        bindport: 0\n      noderegistration:\n        crisocket: /run/containerd/containerd.sock\n        ignorepreflighterrors: []\n        kubeletextraargs:\n          cgroup-driver: cgroupfs\n          cloud-provider: external\n          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%\n        name: \"\"\n        taints: []\n      typemeta:\n        apiversion: \"\"\n        kind: \"\"\n    joinconfiguration:\n      cacertpath: \"\"\n      controlplane: null\n      discovery:\n        bootstraptoken: null\n        file: null\n        timeout: null\n        tlsbootstraptoken: \"\"\n      noderegistration:\n        crisocket: /run/containerd/containerd.sock\n        ignorepreflighterrors: []\n        kubeletextraargs:\n          cgroup-driver: cgroupfs\n          cloud-provider: external\n          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%\n        name: \"\"\n        taints: []\n      typemeta:\n        apiversion: \"\"\n        kind: \"\"\n    mounts: []\n    ntp: null\n    postkubeadmcommands: []\n    prekubeadmcommands: []\n    useexperimentalretryjoin: false\n    users: []\n    verbosity: null\n  machinetemplate:\n    infrastructureref:\n      apiversion: infrastructure.cluster.x-k8s.io/v1alpha4\n      fieldpath: \"\"\n      kind: VCDMachineTemplate\n      name: capi-control-plane\n      namespace: default\n      resourceversion: \"\"\n      uid: \"\"\n    nodedraintimeout: null\n    objectmeta:\n      annotations: {}\n      labels: {}\n  replicas: 1\n  rolloutafter: null\n  rolloutstrategy:\n    rollingupdate:\n      maxsurge:\n        intval: 1\n        strval: \"\"\n        type: 0\n    type: RollingUpdate\n  version: v1.20.8-vmware.1\n---\napiversion: cluster.x-k8s.io/v1alpha4\nkind: MachineDeployment\nmetadata:\n  name: capi-md0\n  namespace: default\nspec:\n  clustername: capi-cluster\n  minreadyseconds: 0\n  paused: false\n  progressdeadlineseconds: 600\n  replicas: 1\n  revisionhistorylimit: 1\n  selector:\n    matchexpressions: []\n    matchlabels:\n      cluster.x-k8s.io/cluster-name: capi-cluster\n      cluster.x-k8s.io/deployment-name: capi-md0\n  strategy:\n    rollingupdate:\n      deletepolicy: null\n      maxsurge:\n        intval: 1\n        strval: \"\"\n        type: 0\n      maxunavailable:\n        intval: 0\n        strval: \"\"\n        type: 0\n    type: RollingUpdate\n  template:\n    objectmeta:\n      annotations: {}\n      labels:\n        cluster.x-k8s.io/cluster-name: capi-cluster\n        cluster.x-k8s.io/deployment-name: capi-md0\n    spec:\n      bootstrap:\n        configref:\n          apiversion: bootstrap.cluster.x-k8s.io/v1alpha4\n          fieldpath: \"\"\n          kind: KubeadmConfigTemplate\n          name: capi-md0\n          namespace: default\n          resourceversion: \"\"\n          uid: \"\"\n        datasecretname: null\n      clustername: capi-cluster\n      failuredomain: null\n      infrastructureref:\n        apiversion: infrastructure.cluster.x-k8s.io/v1alpha4\n        fieldpath: \"\"\n        kind: VCDMachineTemplate\n        name: capi-md0\n        namespace: default\n        resourceversion: \"\"\n        uid: \"\"\n      nodedraintimeout: null\n      providerid: null\n      version: v1.20.8-vmware.1\n",
                    "settings": {
                        "network": {
                            "cni": {
                                "name": "antrea"
                            },
                            "pods": {
                                "cidrBlocks": [
                                    "192.168.0.0/16"
                                ]
                            },
                            "services": {
                                "cidrBlocks": [
                                    "10.96.0.0/12"
                                ]
                            }
                        },
                        "ovdcNetwork": "test_orgvdc_net"
                    },
                    "topology": {
                        "workers": [
                            {
                                "count": 1,
                                "templateName": "ubuntu-2004-kube-v1.20.8+vmware.1-tkg.1-17589475007677388652"
                            }
                        ],
                        "controlPlane": [
                            {
                                "count": 1,
                                "sizingClass": "2core2gb",
                                "templateName": "ubuntu-2004-kube-v1.20.8+vmware.1-tkg.1-17589475007677388652"
                            }
                        ]
                    },
                    "distribution": {
                        "version": "v1.20.8-vmware.1"
                    }
                },
                "status": {
                    "cni": {},
                    "cpi": {},
                    "csi": {},
                    "uid": "urn:vcloud:entity:vmware:capvcd:02387512-9b48-46f3-b72b-11ba8172e016",
                    "phase": "Provisioned",
                    "parentUid": "urn:vcloud:entity:vmware:capvcd:203e6783-9c2f-40f0-bd54-a01b2dec5952",
                    "kubernetes": "v1.20.8-vmware.1",
                    "nodeStatus": {
                        "capi-control-plane-9z698": "Provisioning",
                        "capi-md0-6f48568f9-frjll": "Pending"
                    },
                    "capvcdVersion": "0.5.0",
                    "cloudProperties": {
                        "site": "https://bos1-vcloud-static-170-210.eng.vmware.com",
                        "orgName": "test_org",
                        "virtualDataCenterName": "test_orgvdc"
                    },
                    "clusterApiStatus": {
                        "phase": "Not Ready",
                        "apiEndpoints": [
                            {
                                "host": "10.150.161.94",
                                "port": 6443
                            }
                        ]
                    }
                },
                "metadata": {
                    "name": "capi-cluster",
                    "site": "https://bos1-vcloud-static-170-210.eng.vmware.com",
                    "orgName": "test_org",
                    "virtualDataCenterName": "test_orgvdc"
                },
                "apiVersion": "capvcd.vmware.com/v1.0"
            },
            "state": "RESOLVED",
            "owner": {
                "name": "user_admin",
                "id": "urn:vcloud:user:550526b2-6c49-47cd-b880-42d3761d9735"
            },
            "org": {
                "name": "test_org",
                "id": "urn:vcloud:org:a6934a6d-5371-4546-b437-a32ceeefab2b"
            }
        }
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/13)
<!-- Reviewable:end -->
