### PR TITLE
[VCDA-3180, VCDA-3190, VCDA-3175] Code refactors and fetch CAPVCD version automatically

### DIFF
--- a/api/v1alpha4/vcdcluster_types.go
+++ b/api/v1alpha4/vcdcluster_types.go
@@ -67,7 +67,7 @@ type VCDClusterStatus struct {
 	// +optional
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 	// +optional
-	RDEId string `json:"RDEId,omitempty"`
+	InfraId string `json:"infraId,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -79,8 +79,6 @@ spec:
           status:
             description: VCDClusterStatus defines the observed state of VCDCluster
             properties:
-              RDEId:
-                type: string
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
@@ -125,6 +123,8 @@ spec:
                   - type
                   type: object
                 type: array
+              infraId:
+                type: string
               ready:
                 description: Ready denotes that the vcd cluster (infrastructure) is
                   ready.

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -43,9 +43,11 @@ write_files:
       echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
-      # also remove ipv6 localhost entry from /etc/hosts
       sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
+      # also remove ipv6 localhost entry from /etc/hosts
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
+      systemctl daemon-reload
+      systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -44,6 +44,7 @@ write_files:
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
       # also remove ipv6 localhost entry from /etc/hosts
+      sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 

--- a/controllers/cluster_scripts/cloud_init_node.yaml
+++ b/controllers/cluster_scripts/cloud_init_node.yaml
@@ -19,8 +19,11 @@ write_files:
       echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
+      sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
       # also remove ipv6 localhost entry from /etc/hosts
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
+      systemctl daemon-reload
+      systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status in_progress"

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -7,6 +7,7 @@ package controllers
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"github.com/antihax/optional"
 	"github.com/google/uuid"
@@ -226,7 +227,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			},
 			NodeStatus:          make(map[string]string),
 			IsManagementCluster: false,
-			CapvcdVersion:       "0.5.0", // TODO: Discuss with Arun on how to get the CAPVCD version.
+			CapvcdVersion:       r.VcdClient.CAPVCDVersion,
 			ParentUID:           r.VcdClient.ManagementClusterRDEId,
 			Csi: vcdtypes.VersionedAddon{
 				Name:    VcdCsiName,
@@ -276,7 +277,7 @@ func (r *VCDClusterReconciler) constructAndCreateRDEFromCluster(ctx context.Cont
 		return "", fmt.Errorf("error occurred during RDE creation for the cluster [%s]; error refreshing task: [%s]", vcdCluster.Name, task.Task.HREF)
 	}
 	rdeID := task.Task.Owner.ID
-	log.Info("Created defined entity for cluster", "RDEId", rdeID)
+	log.Info("Created defined entity for cluster", "InfraId", rdeID)
 	return rdeID, nil
 }
 
@@ -284,9 +285,9 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	log := ctrl.LoggerFrom(ctx)
 
 	updatePatch := make(map[string]interface{})
-	_, capvcdEntity, err := workloadVCDClient.GetCAPVCDEntity(ctx, vcdCluster.Status.RDEId)
+	_, capvcdEntity, err := workloadVCDClient.GetCAPVCDEntity(ctx, vcdCluster.Status.InfraId)
 	if err != nil {
-		return fmt.Errorf("failed to get RDE with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.RDEId, vcdCluster.Name, err)
+		return fmt.Errorf("failed to get RDE with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.InfraId, vcdCluster.Name, err)
 	}
 	// TODO(VCDA-3107): Should we be updating org and vdc information here.
 	org := vcdCluster.Spec.Org
@@ -372,8 +373,8 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		updatePatch["Spec.Distribution.Version"] = kubernetesVersion
 	}
 
-	if capvcdEntity.Status.Uid != vcdCluster.Status.RDEId {
-		updatePatch["Status.Uid"] = vcdCluster.Status.RDEId
+	if capvcdEntity.Status.Uid != vcdCluster.Status.InfraId {
+		updatePatch["Status.Uid"] = vcdCluster.Status.InfraId
 	}
 
 	if capvcdEntity.Status.Phase != cluster.Status.Phase {
@@ -410,24 +411,24 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		updatePatch["Status.NodeStatus"] = updatedNodeStatus
 	}
 
-	updatedRDE, err := workloadVCDClient.PatchRDE(ctx, updatePatch, vcdCluster.Status.RDEId)
+	updatedRDE, err := workloadVCDClient.PatchRDE(ctx, updatePatch, vcdCluster.Status.InfraId)
 	if err != nil {
-		return fmt.Errorf("failed to update defined entity with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.RDEId, vcdCluster.Name, err)
+		return fmt.Errorf("failed to update defined entity with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.InfraId, vcdCluster.Name, err)
 	}
 
 	if updatedRDE.State != RDEStatusResolved {
 		// try to resolve the defined entity
 		entityState, resp, err := workloadVCDClient.ApiClient.DefinedEntityApi.ResolveDefinedEntity(ctx, updatedRDE.Id)
 		if err != nil {
-			return fmt.Errorf("failed to resolve defined entity with ID [%s] for cluster [%s]", vcdCluster.Status.RDEId, vcdCluster.Name)
+			return fmt.Errorf("failed to resolve defined entity with ID [%s] for cluster [%s]", vcdCluster.Status.InfraId, vcdCluster.Name)
 		}
 		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("error while resolving defined entity with ID [%s] for cluster [%s] with message: [%s]", vcdCluster.Status.RDEId, vcdCluster.Name, entityState.Message)
+			return fmt.Errorf("error while resolving defined entity with ID [%s] for cluster [%s] with message: [%s]", vcdCluster.Status.InfraId, vcdCluster.Name, entityState.Message)
 		}
 		if entityState.State != RDEStatusResolved {
-			return fmt.Errorf("defined entity resolution failed for RDE with ID [%s] for cluster [%s] with message: [%s]", vcdCluster.Status.RDEId, vcdCluster.Name, entityState.Message)
+			return fmt.Errorf("defined entity resolution failed for RDE with ID [%s] for cluster [%s] with message: [%s]", vcdCluster.Status.InfraId, vcdCluster.Name, entityState.Message)
 		}
-		log.Info("Resolved defined entity of cluster", "RDEId", vcdCluster.Status.RDEId)
+		log.Info("Resolved defined entity of cluster", "InfraId", vcdCluster.Status.InfraId)
 	}
 	return nil
 }
@@ -441,8 +442,9 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		vcdCluster.Spec.Ovdc, vcdCluster.Name, vcdCluster.Spec.OvdcNetwork, r.VcdClient.IPAMSubnet,
 		r.VcdClient.VcdAuthConfig.UserOrg, vcdCluster.Spec.UserCredentialsContext.Username,
 		vcdCluster.Spec.UserCredentialsContext.Password, vcdCluster.Spec.UserCredentialsContext.RefreshToken,
-		true, vcdCluster.Status.RDEId, r.VcdClient.OneArm, 0, 0, r.VcdClient.TCPPort,
-		true, "", r.VcdClient.CsiVersion, r.VcdClient.CpiVersion, r.VcdClient.CniVersion)
+		true, vcdCluster.Status.InfraId, r.VcdClient.OneArm, 0, 0, r.VcdClient.TCPPort,
+		true, "", r.VcdClient.CsiVersion, r.VcdClient.CpiVersion, r.VcdClient.CniVersion,
+		r.VcdClient.CAPVCDVersion)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Error creating VCD client to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
 	}
@@ -456,7 +458,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// NOTE: Since RDE is used just as a book-keeping mechanism, we should not fail reconciliation if RDE operations fail
 	// create RDE for cluster
-	if vcdCluster.Status.RDEId == "" {
+	if vcdCluster.Status.InfraId == "" {
 		nameFilter := &swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{
 			Filter: optional.NewString(fmt.Sprintf("name==%s", vcdCluster.Name)),
 		}
@@ -479,28 +481,28 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 				if err != nil {
 					log.Error(err, "Error creating RDE for the cluster")
 				} else {
-					vcdCluster.Status.RDEId = rdeID
+					vcdCluster.Status.InfraId = rdeID
 				}
 			} else {
-				log.Info("RDE for the cluster is already present; skipping RDE creation", "RDEId",
+				log.Info("RDE for the cluster is already present; skipping RDE creation", "InfraId",
 					definedEntities.Values[0].Id)
-				vcdCluster.Status.RDEId = definedEntities.Values[0].Id
+				vcdCluster.Status.InfraId = definedEntities.Values[0].Id
 			}
 		}
 	}
 
 	// If there is no specified RDE ID, self-generate one and use. We need UUIDs to single-instance
 	// cleanly in the Virtual Services etc.
-	if vcdCluster.Status.RDEId == "" {
+	if vcdCluster.Status.InfraId == "" {
 		rdeID := NoRdePrefix + uuid.New().String()
-		log.Info("Error retrieving RDEId. Hence using a self-generated UUID", "UUID", rdeID)
-		vcdCluster.Status.RDEId = rdeID
+		log.Info("Error retrieving InfraId. Hence using a self-generated UUID", "UUID", rdeID)
+		vcdCluster.Status.InfraId = rdeID
 	}
 
 	// TODO: What should be the prefix if cluster creation fails here?
 	// create load balancer for the cluster. Only one-arm load balancer is fully tested.
-	virtualServiceNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.RDEId
-	lbPoolNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.RDEId
+	virtualServiceNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId
+	lbPoolNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId
 
 	controlPlaneNodeIP, err := gateway.GetLoadBalancer(ctx, fmt.Sprintf("%s-tcp", virtualServiceNamePrefix))
 	//TODO: Sahithi: Check if error is really because of missing virtual service.
@@ -522,21 +524,33 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	log.Info(fmt.Sprintf("Control plane endpoint for the cluster is [%s]", controlPlaneNodeIP))
 
-	if !strings.HasPrefix(vcdCluster.Status.RDEId, NoRdePrefix) {
-		_, resp, _, err := workloadVCDClient.ApiClient.DefinedEntityApi.GetDefinedEntity(ctx, vcdCluster.Status.RDEId)
+	if !strings.HasPrefix(vcdCluster.Status.InfraId, NoRdePrefix) {
+		_, resp, _, err := workloadVCDClient.ApiClient.DefinedEntityApi.GetDefinedEntity(ctx, vcdCluster.Status.InfraId)
 		if err != nil {
-			log.Error(err, "Error retrieving RDE for the cluster from VCD", "RDEId", vcdCluster.Status.RDEId)
+			log.Error(err, "Error retrieving RDE for the cluster from VCD", "InfraId", vcdCluster.Status.InfraId)
 		}
 		if resp == nil {
-			log.Error(nil, "Error retrieving RDE for the cluster from VCD; obtained an empty response", "RDEId", vcdCluster.Status.RDEId)
+			log.Error(nil, "Error retrieving RDE for the cluster from VCD; obtained an empty response", "InfraId", vcdCluster.Status.InfraId)
 		} else if resp.StatusCode != http.StatusOK {
-			log.Error(nil, "Error retrieving RDE for the cluster from VCD", "RDEId", vcdCluster.Status.RDEId)
+			log.Error(nil, "error retrieving RDE for the cluster from VCD", "InfraId", vcdCluster.Status.InfraId)
 		}
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			if err = r.reconcileRDE(ctx, cluster, vcdCluster, workloadVCDClient); err != nil {
-				log.Error(err, "Error occurred during RDE reconciliation", "RDEId", vcdCluster.Status.RDEId)
+				log.Error(err, "Error occurred during RDE reconciliation", "InfraId", vcdCluster.Status.InfraId)
 			}
 		}
+	}
+
+	// create VApp
+	vdcManager := vcdclient.VdcManager{
+		VdcName: workloadVCDClient.ClusterOVDCName,
+		OrgName: workloadVCDClient.ClusterOrgName,
+		Client:  workloadVCDClient,
+		Vdc:     workloadVCDClient.Vdc,
+	}
+	_, err = vdcManager.GetOrCreateVApp(vcdCluster.Name, workloadVCDClient.NetworkName)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "GetOrCreateVApp call failed with error: [%v]", vcdCluster.Name)
 	}
 
 	// Update the vcdCluster resource with updated information
@@ -568,8 +582,9 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 		vcdCluster.Spec.Ovdc, vcdCluster.Name, vcdCluster.Spec.OvdcNetwork, r.VcdClient.IPAMSubnet,
 		r.VcdClient.VcdAuthConfig.UserOrg, vcdCluster.Spec.UserCredentialsContext.Username,
 		vcdCluster.Spec.UserCredentialsContext.Password, vcdCluster.Spec.UserCredentialsContext.RefreshToken,
-		true, vcdCluster.Status.RDEId, r.VcdClient.OneArm, 0, 0, r.VcdClient.TCPPort,
-		true, "", r.VcdClient.CsiVersion, r.VcdClient.CpiVersion, r.VcdClient.CniVersion)
+		true, vcdCluster.Status.InfraId, r.VcdClient.OneArm, 0, 0, r.VcdClient.TCPPort,
+		true, "", r.VcdClient.CsiVersion, r.VcdClient.CpiVersion, r.VcdClient.CniVersion,
+		r.VcdClient.CAPVCDVersion)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Error occurred during cluster deletion; unable to create client for the workload cluster [%s]", vcdCluster.Name)
 	}
@@ -582,8 +597,8 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 	}
 
 	// Delete the load balancer components
-	virtualServiceNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.RDEId
-	lbPoolNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.RDEId
+	virtualServiceNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId
+	lbPoolNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId
 	err = gateway.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Error occurred during cluster [%s] deletion; unable to delete the load balancer [%s]: [%v]", vcdCluster.Name, virtualServiceNamePrefix, err)
@@ -618,39 +633,39 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 
 	// TODO: If RDE deletion fails, should we throw an error during reconciliation?
 	// Delete RDE
-	if vcdCluster.Status.RDEId != "" && !strings.HasPrefix(vcdCluster.Status.RDEId, NoRdePrefix) {
+	if vcdCluster.Status.InfraId != "" && !strings.HasPrefix(vcdCluster.Status.InfraId, NoRdePrefix) {
 		definedEntities, resp, err := workloadVCDClient.ApiClient.DefinedEntityApi.GetDefinedEntitiesByEntityType(ctx,
 			CAPVCDTypeVendor, CAPVCDTypeNss, CAPVCDTypeVersion, 1, 25,
 			&swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{
-				Filter: optional.NewString(fmt.Sprintf("id==%s", vcdCluster.Status.RDEId)),
+				Filter: optional.NewString(fmt.Sprintf("id==%s", vcdCluster.Status.InfraId)),
 			})
 		if err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; failed to fetch defined entities by entity type [%s] and ID [%s] for cluster [%s]", CAPVCDEntityTypeID, vcdCluster.Status.RDEId, vcdCluster.Name)
+			return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; failed to fetch defined entities by entity type [%s] and ID [%s] for cluster [%s]", CAPVCDEntityTypeID, vcdCluster.Status.InfraId, vcdCluster.Name)
 		}
 		if resp.StatusCode != http.StatusOK {
-			return ctrl.Result{}, errors.Errorf("Error occurred during RDE deletion; error while fetching defined entities by entity type [%s] and ID [%s] for cluster [%s]", CAPVCDEntityTypeID, vcdCluster.Status.RDEId, vcdCluster.Name)
+			return ctrl.Result{}, errors.Errorf("Error occurred during RDE deletion; error while fetching defined entities by entity type [%s] and ID [%s] for cluster [%s]", CAPVCDEntityTypeID, vcdCluster.Status.InfraId, vcdCluster.Name)
 		}
 		if len(definedEntities.Values) > 0 {
 			// resolve defined entity before deleting
 			entityState, resp, err := workloadVCDClient.ApiClient.DefinedEntityApi.ResolveDefinedEntity(ctx,
-				vcdCluster.Status.RDEId)
+				vcdCluster.Status.InfraId)
 			if err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; error occurred while resolving defined entity [%s] with ID [%s] before deleting", vcdCluster.Name, vcdCluster.Status.RDEId)
+				return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; error occurred while resolving defined entity [%s] with ID [%s] before deleting", vcdCluster.Name, vcdCluster.Status.InfraId)
 			}
 			if resp.StatusCode != http.StatusOK {
-				log.Error(nil, "Error occurred during RDE deletion; failed to resolve RDE with ID [%s] for cluster [%s]: [%s]", vcdCluster.Status.RDEId, vcdCluster.Name, entityState.Message)
+				log.Error(nil, "Error occurred during RDE deletion; failed to resolve RDE with ID [%s] for cluster [%s]: [%s]", vcdCluster.Status.InfraId, vcdCluster.Name, entityState.Message)
 			}
 			resp, err = workloadVCDClient.ApiClient.DefinedEntityApi.DeleteDefinedEntity(ctx,
-				vcdCluster.Status.RDEId, nil)
+				vcdCluster.Status.InfraId, nil)
 			if err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; failed to execute delete defined entity call for RDE with ID [%s]", vcdCluster.Status.RDEId)
+				return ctrl.Result{}, errors.Wrapf(err, "Error occurred during RDE deletion; failed to execute delete defined entity call for RDE with ID [%s]", vcdCluster.Status.InfraId)
 			}
 			if resp.StatusCode != http.StatusNoContent {
-				return ctrl.Result{}, errors.Errorf("Error occurred during RDE deletion; error deleting defined entity associated with the cluster. RDE id: [%s]", vcdCluster.Status.RDEId)
+				return ctrl.Result{}, errors.Errorf("Error occurred during RDE deletion; error deleting defined entity associated with the cluster. RDE id: [%s]", vcdCluster.Status.InfraId)
 			}
 			log.Info("Successfully deleted the (RDE) defined entity of the cluster")
 		} else {
-			log.Info("Attempted deleting the RDE, but corresponding defined entity is not found", "RDEId", vcdCluster.Status.RDEId)
+			log.Info("Attempted deleting the RDE, but corresponding defined entity is not found", "RDEId", vcdCluster.Status.InfraId)
 		}
 	}
 	log.Info("Successfully deleted all the infra resources of the cluster")

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -550,7 +550,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	_, err = vdcManager.GetOrCreateVApp(vcdCluster.Name, workloadVCDClient.NetworkName)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "GetOrCreateVApp call failed with error: [%v]", vcdCluster.Name)
+		return ctrl.Result{}, errors.Wrapf(err, "Error creating Infra vApp for the cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
 
 	// Update the vcdCluster resource with updated information

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -499,7 +499,6 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		vcdCluster.Status.InfraId = rdeID
 	}
 
-	// TODO: What should be the prefix if cluster creation fails here?
 	// create load balancer for the cluster. Only one-arm load balancer is fully tested.
 	virtualServiceNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId
 	lbPoolNamePrefix := vcdCluster.Name + "-" + vcdCluster.Status.InfraId

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -486,7 +486,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	vm, err := vApp.GetVMByName(machine.Name, true)
 	if err != nil && err != govcd.ErrorEntityNotFound {
 		return ctrl.Result{}, errors.Wrapf(err, "Error provisioning infrastructure for the machine; unable to query for VM [%s] in vApp [%s]",
-			vm.VM.Name, vAppName)
+			machine.Name, vAppName)
 	} else if err == govcd.ErrorEntityNotFound {
 		vmExists = false
 	}

--- a/main.go
+++ b/main.go
@@ -7,10 +7,12 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"flag"
 	"fmt"
 	"os"
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha4"
+	"strings"
 	"time"
 
 	"k8s.io/klog"
@@ -37,6 +39,9 @@ import (
 	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha4"
 	//+kubebuilder:scaffold:imports
 )
+
+//go:embed release/version
+var capVCDVersion string
 
 var (
 	myscheme = runtime.NewScheme()
@@ -85,6 +90,7 @@ func getVcdClientFromConfig(inputMap map[string]interface{}) (*vcdclient.Client,
 		EndIPAddress:   cloudConfig.LB.OneArm.EndIP,
 	}
 	getVdcClient := true
+	trimmedCapvcdVersion := strings.Trim(capVCDVersion, "\n")
 	// TODO (Sahithi: Let this method take the cloudConfig as a param instead of individual properties)
 	return vcdclient.NewVCDClientFromSecrets(
 		cloudConfig.VCD.Host,
@@ -108,6 +114,7 @@ func getVcdClientFromConfig(inputMap map[string]interface{}) (*vcdclient.Client,
 		cloudConfig.ClusterResources.CsiVersion,
 		cloudConfig.ClusterResources.CpiVersion,
 		cloudConfig.ClusterResources.CniVersion,
+		trimmedCapvcdVersion,
 	)
 }
 

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	CsiVersion             string
 	CpiVersion             string
 	CniVersion             string
+	CAPVCDVersion          string
 }
 
 func (client *Client) RefreshBearerToken() error {
@@ -130,7 +131,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	networkName string, ipamSubnet string, userOrg string, user string, password string,
 	refreshToken string, insecure bool, clusterID string, oneArm *OneArm, httpPort int32,
 	httpsPort int32, tcpPort int32, getVdcClient bool, managementClusterRDEId string,
-	csiVersion string, cpiVersion string, cniVersion string) (*Client, error) {
+	csiVersion string, cpiVersion string, cniVersion string, capvcdVersion string) (*Client, error) {
 
 	// TODO: validation of parameters
 
@@ -153,7 +154,8 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 			clientSingleton.ManagementClusterRDEId == managementClusterRDEId &&
 			clientSingleton.CsiVersion == csiVersion &&
 			clientSingleton.CpiVersion == cpiVersion &&
-			clientSingleton.CniVersion == cniVersion {
+			clientSingleton.CniVersion == cniVersion &&
+			clientSingleton.CAPVCDVersion == capvcdVersion {
 			return clientSingleton, nil
 		}
 	}
@@ -184,6 +186,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 		CsiVersion:             csiVersion,
 		CpiVersion:             cpiVersion,
 		CniVersion:             cniVersion,
+		CAPVCDVersion:          capvcdVersion,
 	}
 
 	if getVdcClient {

--- a/pkg/vcdclient/common_system_test.go
+++ b/pkg/vcdclient/common_system_test.go
@@ -13,6 +13,7 @@ package vcdclient
 import (
 	"fmt"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/config"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -64,6 +65,11 @@ func getInt32ValStrict(val interface{}, defaultVal int32) int32 {
 func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 
 	testConfigFilePath := filepath.Join(gitRoot, "testdata/config_test.yaml")
+	capvcdVersionFile := filepath.Join(gitRoot, "release/version")
+	capvcdVersion, err := ioutil.ReadFile(capvcdVersionFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CAPVCD version from file [%s]: [%v]", capvcdVersionFile, err)
+	}
 	configReader, err := os.Open(testConfigFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to open file [%s]: [%v]", testConfigFilePath, err)
@@ -136,5 +142,6 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 		cloudConfig.ClusterResources.CsiVersion,
 		cloudConfig.ClusterResources.CpiVersion,
 		cloudConfig.ClusterResources.CniVersion,
+		string(capvcdVersion),
 	)
 }

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1059,9 +1059,6 @@ func (gateway *GatewayManager) CreateLoadBalancer(ctx context.Context, virtualSe
 			klog.V(3).Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
 			continue
 		}
-		if err = gateway.waitForVirtualServiceStart(ctx, virtualServiceName); err != nil {
-			return "", fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
-		}
 
 		virtualServiceIP := externalIP
 		if client.OneArm != nil {
@@ -1165,9 +1162,6 @@ func (gateway *GatewayManager) CreateL4LoadBalancer(ctx context.Context, virtual
 
 			klog.V(3).Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
 			continue
-		}
-		if err = gateway.waitForVirtualServiceStart(ctx, virtualServiceName); err != nil {
-			return "", fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
 		}
 
 		virtualServiceIP := externalIP

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -1166,6 +1166,9 @@ func (gateway *GatewayManager) CreateL4LoadBalancer(ctx context.Context, virtual
 			klog.V(3).Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
 			continue
 		}
+		if err = gateway.waitForVirtualServiceStart(ctx, virtualServiceName); err != nil {
+			return "", fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
+		}
 
 		virtualServiceIP := externalIP
 		if gateway.Client.OneArm != nil {


### PR DESCRIPTION
* moved VApp creation logic to vcdcluster_controller.go
* renamed vcdCluster.Status.RDEId to vcdCluster.Status.InfraId
* Fetch CAPVCD version automatically from release/version

@sahithi @ltimothy7 
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/22)
<!-- Reviewable:end -->
