### PR TITLE
[VCDA-3198, VCDA-3199] Check if VS not pending to retry with reconciliation and worker controller thread increase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ build-within-docker:
 	go build -ldflags "-X github.com/akrishnakuma/cluster-api-provider-cloud-director/version.Version=$(version)" -o /build/vcloud/cluster-api-provider-cloud-director main.go
 
 capi: generate fmt vet
-	docker build -f Dockerfile . -t cluster-api-provider-cloud-director:$(version).latest
-	docker tag cluster-api-provider-cloud-director:$(version).latest $(IMG)
+	docker build -f Dockerfile . -t cluster-api-provider-cloud-director:$(version)
+	docker tag cluster-api-provider-cloud-director:$(version) $(IMG)
 	docker push $(IMG)
 	touch out/$@

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -43,11 +43,8 @@ write_files:
       echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
-      # sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
       # also remove ipv6 localhost entry from /etc/hosts
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
-      # systemctl daemon-reload
-      # systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -43,11 +43,11 @@ write_files:
       echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
-      sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
+      # sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
       # also remove ipv6 localhost entry from /etc/hosts
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
-      systemctl daemon-reload
-      systemctl restart containerd
+      # systemctl daemon-reload
+      # systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status in_progress"

--- a/controllers/cluster_scripts/cloud_init_node.yaml
+++ b/controllers/cluster_scripts/cloud_init_node.yaml
@@ -19,11 +19,8 @@ write_files:
       echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
       echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
       sudo sysctl -p
-      sed -i '/SystemdCgroup[ ]*=[ ]*true/d' /etc/containerd/config.toml || true
       # also remove ipv6 localhost entry from /etc/hosts
       sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
-      systemctl daemon-reload
-      systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.node.join.status in_progress"

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 )
@@ -675,8 +676,9 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *VCDClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VCDClusterReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.VCDCluster{}).
+		WithOptions(options).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 	flag.DurationVar(&syncPeriod, "sync-period", 30*time.Second,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 	flag.IntVar(&concurrency, "concurrency", 10,
-		"The number of docker machines to process simultaneously")
+		"The number of VCD machines to process simultaneously")
 
 	opts := zap.Options{
 		Development: true,

--- a/main.go
+++ b/main.go
@@ -178,7 +178,9 @@ func main() {
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		VcdClient: vcdClient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: concurrency,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VCDCluster")
 		os.Exit(1)
 	}

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -13,18 +13,16 @@ package vcdclient
 import (
 	"context"
 	"fmt"
+	"github.com/antihax/optional"
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/peterhellberg/link"
+	swaggerClient "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdswaggerclient"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"k8s.io/klog"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
-
-	"github.com/antihax/optional"
-	swaggerClient "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdswaggerclient"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
-	"k8s.io/klog"
 )
 
 type GatewayManager struct {
@@ -899,7 +897,7 @@ func (gateway *GatewayManager) createVirtualService(ctx context.Context, virtual
 			taskURL, err)
 	}
 
-	if err = gateway.waitForVirtualServiceStart(ctx, virtualServiceName); err != nil {
+	if err = gateway.checkIfVirtualServiceIsPending(ctx, virtualServiceName); err != nil {
 		return nil, fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
 	}
 
@@ -921,32 +919,28 @@ func (gateway *GatewayManager) createVirtualService(ctx context.Context, virtual
 	return virtualServiceRef, nil
 }
 
-func (gateway *GatewayManager) waitForVirtualServiceStart(ctx context.Context, virtualServiceName string) error {
+func (gateway *GatewayManager) checkIfVirtualServiceIsPending(ctx context.Context, virtualServiceName string) error {
 	client := gateway.Client
 	if client.GatewayRef == nil {
 		return fmt.Errorf("gateway reference should not be nil")
 	}
 
-	duration := 30 * time.Minute
-	for startTime := time.Now(); time.Since(startTime) < duration; {
-		vsSummary, err := gateway.getVirtualService(ctx, virtualServiceName)
-		if err != nil {
-			return fmt.Errorf("unable to get summary for LB VS [%s]: [%v]", virtualServiceName, err)
-		}
-		if vsSummary == nil {
-			return fmt.Errorf("unable to get summary of virtual service [%s]: [%v]", virtualServiceName, err)
-		}
-		if vsSummary.HealthStatus == "UP" || vsSummary.HealthStatus == "DOWN" {
-			klog.Infof("Completed waiting for [%s] since healthStatus is [%s]",
-				virtualServiceName, vsSummary.HealthStatus)
-			return nil
-		}
-		klog.Infof("Waiting for [%s] since healthStatus is still [%s]",
+	klog.V(3).Infof("Checking if virtual service [%s] is still pending", virtualServiceName)
+	vsSummary, err := gateway.getVirtualService(ctx, virtualServiceName)
+	if err != nil {
+		return fmt.Errorf("unable to get summary for LB VS [%s]: [%v]", virtualServiceName, err)
+	}
+	if vsSummary == nil {
+		return fmt.Errorf("unable to get summary of virtual service [%s]: [%v]", virtualServiceName, err)
+	}
+	if vsSummary.HealthStatus == "UP" || vsSummary.HealthStatus == "DOWN" {
+		klog.Infof("Completed waiting for [%s] since healthStatus is [%s]",
 			virtualServiceName, vsSummary.HealthStatus)
-		time.Sleep(5 * time.Second)
+		return nil
 	}
 
-	return fmt.Errorf("unable to start Virtual Service [%s] in time [%v]", virtualServiceName, duration)
+	klog.Errorf("Virtual service [%s] is still pending", virtualServiceName)
+	return fmt.Errorf("unable to start Virtual Service [%s]; virtual service is still in pending state", virtualServiceName)
 }
 
 func (gateway *GatewayManager) deleteVirtualService(ctx context.Context, virtualServiceName string,
@@ -963,7 +957,7 @@ func (gateway *GatewayManager) deleteVirtualService(ctx context.Context, virtual
 	}
 	if vsSummary == nil {
 		if failIfAbsent {
-			return fmt.Errorf("Virtual Service [%s] does not exist", virtualServiceName)
+			return fmt.Errorf("virtual service [%s] does not exist", virtualServiceName)
 		}
 
 		return nil
@@ -1055,8 +1049,10 @@ func (gateway *GatewayManager) CreateLoadBalancer(ctx context.Context, virtualSe
 				return "", fmt.Errorf("Virtual Service [%s] found with unexpected loadbalancer pool [%s]",
 					virtualServiceName, lbPoolName)
 			}
-
 			klog.V(3).Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
+			if err = gateway.checkIfVirtualServiceIsPending(ctx, virtualServiceName); err != nil {
+				return "", fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
+			}
 			continue
 		}
 
@@ -1160,7 +1156,10 @@ func (gateway *GatewayManager) CreateL4LoadBalancer(ctx context.Context, virtual
 					virtualServiceName, lbPoolName)
 			}
 
-			klog.V(3).Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
+			klog.Infof("LoadBalancer Virtual Service [%s] already exists", virtualServiceName)
+			if err = gateway.checkIfVirtualServiceIsPending(ctx, virtualServiceName); err != nil {
+				return "", fmt.Errorf("unable to wait for virtual service [%s]: [%v]", virtualServiceName, err)
+			}
 			continue
 		}
 

--- a/pkg/vcdclient/gateway.go
+++ b/pkg/vcdclient/gateway.go
@@ -942,12 +942,12 @@ func (gateway *GatewayManager) checkIfVirtualServiceIsPending(ctx context.Contex
 		return fmt.Errorf("unable to get summary of virtual service [%s]: [%v]", virtualServiceName, err)
 	}
 	if vsSummary.HealthStatus == "UP" || vsSummary.HealthStatus == "DOWN" {
-		klog.Infof("Completed waiting for [%s] since healthStatus is [%s]",
+		klog.V(3).Infof("Completed waiting for [%s] since healthStatus is [%s]",
 			virtualServiceName, vsSummary.HealthStatus)
 		return nil
 	}
 
-	klog.Errorf("Virtual service [%s] is still pending", virtualServiceName)
+	klog.Errorf("Virtual service [%s] is still pending. Virtual service status: [%s]", virtualServiceName, vsSummary.HealthStatus)
 	return &VirtualServicePendingError{
 		VirtualServiceName: virtualServiceName,
 	}


### PR DESCRIPTION
* Remove the retries in checkIfVSNotPending function. Make reconciliation retry the check
* Increase the worker controller threads to 10
* Remove lines to force systemd in cloud init scripts.

Testing done:
* Removed all the VS and checked if the cluster is waiting for VS to come up before attempting creation of a machine

@arunmk @ltimothy7 @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/26)
<!-- Reviewable:end -->
