### PR TITLE
Fix log messages and example input

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -510,7 +510,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	if err != nil {
 		if vsError, ok := err.(*vcdclient.VirtualServicePendingError); ok {
-			log.Error(err, "Error getting load balancer for cluster [%s]. Virtual Service [%s] is still pending", vcdCluster.Name, vsError.VirtualServiceName)
+			log.Error(err, "Error getting load balancer. Virtual Service is still pending", "virtualServiceName", vsError.VirtualServiceName)
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
@@ -519,7 +519,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			[]string{}, r.VcdClient.TCPPort)
 		if err != nil {
 			if vsError, ok := err.(*vcdclient.VirtualServicePendingError); ok {
-				log.Error(err, "Error creating load balancer for cluster [%s]. Virtual Service [%s] is still pending", vcdCluster.Name, vsError.VirtualServiceName)
+				log.Error(err, "Error creating load balancer for cluster. Virtual Service is still pending", "virtualServiceName", vsError.VirtualServiceName)
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 			}
 			return ctrl.Result{}, errors.Wrapf(err, "Error creating create load balancer [%s] for the cluster [%s]: [%v]",

--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -81,14 +81,12 @@ spec:
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cloud-provider: external
     joinConfiguration:
       nodeRegistration:
         criSocket: /run/containerd/containerd.sock
         kubeletExtraArgs:
-          cgroup-driver: cgroupfs
           eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
           cloud-provider: external
   machineTemplate:
@@ -128,7 +126,6 @@ spec:
         nodeRegistration:
           criSocket: /run/containerd/containerd.sock
           kubeletExtraArgs:
-            cgroup-driver: cgroupfs
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             cloud-provider: external
 ---


### PR DESCRIPTION
- log messages should use key-value pairs and not string formatting
- fix examples/capi-quickstart.yaml - remove cgroup-driver parameter


Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/27)
<!-- Reviewable:end -->
