### PR TITLE
VCDA-3267: wait for CPI to detach disks before shutting down node

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -814,6 +814,19 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			}
 		}
 		if vm != nil {
+			// check if there are any disks attached to the VM
+			if vm.VM.VmSpecSection != nil && vm.VM.VmSpecSection.DiskSection != nil {
+				for _, diskSettings := range vm.VM.VmSpecSection.DiskSection.DiskSettings {
+					if diskSettings.Disk != nil {
+						klog.Infof("Cannot delete VM [%s] until named disk [%s] is detached",
+							vm.VM.Name, diskSettings.Disk.Name)
+						return ctrl.Result{}, fmt.Errorf(
+							"error delete VM [%s] since named disk [%s] is attached",
+							vm.VM.Name, diskSettings.Disk.Name)
+					}
+				}
+			}
+
 			// power-off the VM if it is powered on
 			vmStatus, err := vm.GetStatus()
 			if err != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -818,10 +818,10 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			if vm.VM.VmSpecSection != nil && vm.VM.VmSpecSection.DiskSection != nil {
 				for _, diskSettings := range vm.VM.VmSpecSection.DiskSection.DiskSettings {
 					if diskSettings.Disk != nil {
-						klog.Infof("Cannot delete VM [%s] until named disk [%s] is detached",
-							vm.VM.Name, diskSettings.Disk.Name)
+						log.Info("Cannot delete VM until named disk is detached from VM (by CSI)",
+							"vm", vm.VM.Name, "disk", diskSettings.Disk.Name)
 						return ctrl.Result{}, fmt.Errorf(
-							"error delete VM [%s] since named disk [%s] is attached",
+							"error deleting VM [%s] since named disk [%s] is attached to VM (by CSI)",
 							vm.VM.Name, diskSettings.Disk.Name)
 					}
 				}


### PR DESCRIPTION
If there is a disk attached, we need to wait until the CSI controller detaches it so that VCD does not put disks in an inconsistent state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/41)
<!-- Reviewable:end -->
