### PR TITLE
Change names in capi-quickstart objects

### DIFF
--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -15,7 +15,7 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
     kind: KubeadmControlPlane
-    name: capi-control-plane # name of the KubeadmControlPlane object associated with the cluster.
+    name: capi-cluster-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: default # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
@@ -41,7 +41,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: VCDMachineTemplate
 metadata:
-  name: capi-control-plane
+  name: capi-cluster-control-plane
   namespace: default
 spec:
   template:
@@ -53,7 +53,7 @@ spec:
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
 kind: KubeadmControlPlane
 metadata:
-  name: capi-control-plane
+  name: capi-cluster-control-plane
   namespace: default
 spec:
   kubeadmConfigSpec:
@@ -93,7 +93,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
       kind: VCDMachineTemplate
-      name: capi-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
+      name: capi-cluster-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: default # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: 1 # desired number of control plane nodes for the cluster
   version: v1.20.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.
@@ -101,7 +101,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
 kind: VCDMachineTemplate
 metadata:
-  name: capi-md0
+  name: capi-cluster-md0
   namespace: default
 spec:
   template:
@@ -113,7 +113,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
 kind: KubeadmConfigTemplate
 metadata:
-  name: capi-md0
+  name: capi-cluster-md0
   namespace: default
 spec:
   template:
@@ -132,7 +132,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
-  name: capi-md0
+  name: capi-cluster-md0
   namespace: default
 spec:
   clusterName: capi-cluster # name of the Cluster object
@@ -145,12 +145,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
           kind: KubeadmConfigTemplate
-          name: capi-md0 # name of the KubeadmConfigTemplate object
+          name: capi-cluster-md0 # name of the KubeadmConfigTemplate object
           namespace: default # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: capi-cluster # name of the Cluster object
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
         kind: VCDMachineTemplate
-        name: capi-md0 # name of the VCDMachineTemplate object used to deploy worker nodes
+        name: capi-cluster-md0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: default # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes
       version: v1.20.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the worker nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.


### PR DESCRIPTION
Change object names in examples to enable easy find and replace to create clusters with different names

Signed-off-by: Aniruddha Shamasundar aniruddha.9794@gmail.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/45)
<!-- Reviewable:end -->
