### PR TITLE
[VCDA-3238] Use antrea version in tkr bom

### DIFF
--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -116,7 +116,7 @@ write_files:
           wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O $yq_path
           chmod +x $yq_path
           antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
-          if [[ ! -z "$antrea_version" ]]; then
+          if [[ -z "$antrea_version" ]] || [[ "$antrea_version" = "null" ]] || [[ "$antrea_version" = "false" ]]; then
             antrea_version=$default_antrea_version
           else
             antrea_version=$(echo ${antrea_version} | sed "s/v//") # remove leading `v`, which will be added later

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -73,8 +73,65 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')"
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeinit.status successful"
 
+    antrea_version=%s
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
+      if [[ -z "$antrea_version" ]]; then
+        bom_path=/tmp/bom
+        components_path=$bom_path/components.yaml
+        imgpkg_path=/tmp/imgpkg
+        yq_path=/tmp/yq
+        default_antrea_version="0.11.3"
+
+        xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
+        init_k8s_version=$(echo $xml_version_property | sed 's/.*oe:value=\"//; s/\(.*\)-.*/\1/')
+        k8s_version=$(echo ${init_k8s_version} | tr -s "+" "_")
+
+        # install imgpkg, which is needed for getting the components yaml file
+        wget -nv -O- github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 > $imgpkg_path
+        chmod +x $imgpkg_path
+
+        # We need to loop through the `X` value in `tkg.X` because of some TKR unexpected design.
+        # We increment `X`, looking fir a valid tkr bom version.
+        no_tkr_found=false
+        until $imgpkg_path pull -i projects.registry.vmware.com/tkg/tkr-bom:${k8s_version} -o $bom_path
+        do
+          tkg_version=$(echo ${k8s_version//*.})
+          tkg_version=$((tkg_version+1))
+          k8s_version=$(echo ${k8s_version} | sed "s/.$/"$tkg_version"/")
+          if [[ $tkg_version -gt 10 ]]; then
+            no_tkr_found=true
+            break
+          fi
+        done
+
+        if [[ "$no_tkr_found" = true ]] ; then
+          echo "no tkr bom found, will use default component versions"  > /var/log/capvcd/customization/status.log
+          antrea_version=$default_antrea_version
+        fi
+
+        if [[ "$no_tkr_found" = false ]]; then
+          mv $bom_path/*.yaml $components_path
+
+          # install yq for yaml parsing
+          wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O $yq_path
+          chmod +x $yq_path
+          antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
+          if [[ ! -z "$antrea_version" ]]; then
+            antrea_version=$default_antrea_version
+          else
+            antrea_version=$(echo ${antrea_version} | sed "s/v//") # remove leading `v`, which will be added later
+          fi
+
+          rm $yq_path
+        fi
+
+        # cleanup components downloads
+        rm -rf $bom_path $imgpkg_path
+      fi
+      echo "antrea_version: ${antrea_version}"  > /var/log/capvcd/customization/status.log
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status successful"
+
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status in_progress"
-      antrea_version=%s
       antrea_path=/root/antrea-v$antrea_version.yaml
       wget -O $antrea_path https://github.com/vmware-tanzu/antrea/releases/download/v$antrea_version/antrea.yml
       # This does not need to be done from v0.12.0 onwards inclusive

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -90,7 +90,7 @@ write_files:
         k8s_version=$(echo ${init_k8s_version} | tr -s "+" "_")
 
         # install imgpkg, which is needed for getting the components yaml file
-        wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 > $imgpkg_path
+        wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 -O $imgpkg_path
         chmod +x $imgpkg_path
 
         # We need to loop through the `X` value in `tkg.X` because of some TKR unexpected design.

--- a/controllers/cluster_scripts/cloud_init_control_plane.yaml
+++ b/controllers/cluster_scripts/cloud_init_control_plane.yaml
@@ -76,10 +76,13 @@ write_files:
     antrea_version=%s
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status in_progress"
       if [[ -z "$antrea_version" ]]; then
-        bom_path=/tmp/bom
+        tkr_bom_dir=/tmp/tkr_bom
+        mkdir $tkr_bom_dir
+        bom_path=$tkr_bom_dir/bom
+        mkdir $bom_path
         components_path=$bom_path/components.yaml
-        imgpkg_path=/tmp/imgpkg
-        yq_path=/tmp/yq
+        imgpkg_path=$tkr_bom_dir/imgpkg
+        yq_path=$tkr_bom_dir/yq
         default_antrea_version="0.11.3"
 
         xml_version_property=$(vmtoolsd --cmd "info-get guestinfo.ovfenv" | grep "oe:key=\"VERSION\"")
@@ -87,7 +90,7 @@ write_files:
         k8s_version=$(echo ${init_k8s_version} | tr -s "+" "_")
 
         # install imgpkg, which is needed for getting the components yaml file
-        wget -nv -O- github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 > $imgpkg_path
+        wget -nv github.com/vmware-tanzu/carvel-imgpkg/releases/download/v0.24.0/imgpkg-linux-amd64 > $imgpkg_path
         chmod +x $imgpkg_path
 
         # We need to loop through the `X` value in `tkg.X` because of some TKR unexpected design.
@@ -105,7 +108,7 @@ write_files:
         done
 
         if [[ "$no_tkr_found" = true ]] ; then
-          echo "no tkr bom found, will use default component versions"  > /var/log/capvcd/customization/status.log
+          echo "no tkr bom found, will use default component versions"  &>> /var/log/capvcd/customization/status.log
           antrea_version=$default_antrea_version
         fi
 
@@ -118,17 +121,15 @@ write_files:
           antrea_version=$($yq_path e ".components.antrea[0].version" $components_path | sed 's/+.*//')
           if [[ -z "$antrea_version" ]] || [[ "$antrea_version" = "null" ]] || [[ "$antrea_version" = "false" ]]; then
             antrea_version=$default_antrea_version
+            echo "no antrea version found in tkr bom, will use default antrea version: ${default_antrea_version}" &>> /var/log/capvcd/customization/status.log
           else
             antrea_version=$(echo ${antrea_version} | sed "s/v//") # remove leading `v`, which will be added later
           fi
-
-          rm $yq_path
         fi
 
         # cleanup components downloads
-        rm -rf $bom_path $imgpkg_path
+        rm -rf $tkr_bom_dir
       fi
-      echo "antrea_version: ${antrea_version}"  > /var/log/capvcd/customization/status.log
     vmtoolsd --cmd "info-set guestinfo.postcustomization.tkr.get_versions.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cni.install.status in_progress"

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -178,6 +178,7 @@ func patchVCDMachine(ctx context.Context, patchHelper *patch.Helper, vcdMachine 
 const (
 	NetworkConfiguration                   = "guestinfo.postcustomization.networkconfiguration.status"
 	KubeadmInit                            = "guestinfo.postcustomization.kubeinit.status"
+	TkrGetVersions                         = "guestinfo.postcustomization.tkr.get_versions.status"
 	KubectlApplyCni                        = "guestinfo.postcustomization.kubectl.cni.install.status"
 	KubectlApplyCpi                        = "guestinfo.postcustomization.kubectl.cpi.install.status"
 	KubectlApplyCsi                        = "guestinfo.postcustomization.kubectl.csi.install.status"
@@ -190,6 +191,7 @@ const (
 var controlPlanePostCustPhases = []string{
 	NetworkConfiguration,
 	KubeadmInit,
+	TkrGetVersions,
 	KubectlApplyCni,
 	KubectlApplyCpi,
 	KubectlApplyCsi,

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -110,7 +110,7 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 		ClusterResources: ClusterResourcesConfig{
 			CsiVersion: "1.1.0",
 			CpiVersion: "1.1.0",
-			CniVersion: "0.11.3",
+			CniVersion: "", // no default for antrea
 		},
 	}
 

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 type authorizationDetails struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	RefreshToken string `yaml:"refreshToken"`
-	UserOrg string `yaml:"userOrg"`
-	SystemUser string `yaml:"systemUser"`
-	SystemUserPassword string `yaml:"systemUserPassword"`
+	Username               string `yaml:"username"`
+	Password               string `yaml:"password"`
+	RefreshToken           string `yaml:"refreshToken"`
+	UserOrg                string `yaml:"userOrg"`
+	SystemUser             string `yaml:"systemUser"`
+	SystemUserPassword     string `yaml:"systemUserPassword"`
 	SystemUserRefreshToken string `yaml:"systemUserRefreshToken"`
 }
 
@@ -40,8 +40,8 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	assert.NoError(t, err, "There should be no error parsing auth file content.")
 
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
+		"user":    authDetails.Username,
+		"secret":  authDetails.Password,
 		"userOrg": authDetails.UserOrg,
 	})
 	assert.NoError(t, err, "Unable to get VCD client")
@@ -49,55 +49,54 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"getVdcClient": true,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
 	})
 	assert.NoError(t, err, "Unable to get Client with VDC details.")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.RefreshToken,
-		"userOrg": authDetails.UserOrg,
+		"userOrg":      authDetails.UserOrg,
 	})
 	assert.NoError(t, err, "Unable to get VCD Client")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 
-
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"host": "https://some-random-address",
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
+		"host":    "https://some-random-address",
+		"user":    authDetails.Username,
+		"secret":  authDetails.Password,
 		"userOrg": authDetails.UserOrg,
 	})
 	assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"network": "",
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
+		"user":    authDetails.Username,
+		"secret":  authDetails.Password,
 		"userOrg": authDetails.UserOrg,
 	})
 	assert.Error(t, err, "Error should be obtained for missing network")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"oneArm": nil,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
+		"oneArm":  nil,
+		"user":    authDetails.Username,
+		"secret":  authDetails.Password,
 		"userOrg": authDetails.UserOrg,
 	})
 	assert.NoError(t, err, "There should be no error for missing OneArm")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
+		"user":    authDetails.SystemUser,
+		"secret":  authDetails.SystemUserPassword,
 		"userOrg": "system",
 	})
 	assert.NoError(t, err, "Unable to get VCD client for system administrator")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
+		"user":    authDetails.SystemUser,
+		"secret":  authDetails.SystemUserPassword,
 		"userOrg": "system",
 		"network": "",
 	})
@@ -105,7 +104,7 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.SystemUserRefreshToken,
-		"userOrg": "system",
+		"userOrg":      "system",
 	})
 	assert.NoError(t, err, "Unable to get VCD client for system administrator")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")


### PR DESCRIPTION
Testing done:
TKGm 1.3.0 ova: no antrea in tkr -> uses 0.11.3 antrea default
1.4.0 -> uses 0.11.3 antrea in tkr
1.4.1 -> uses 0.13.3 in tkr
Can specify cni and override tkr version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/57)
<!-- Reviewable:end -->
