### PR TITLE
Populate config with userorg when username is not specified

### DIFF
--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -146,6 +146,9 @@ func SetAuthorization(config *CloudConfig) error {
 			config.VCD.UserOrg = strings.TrimSuffix(config.VCD.Org, "\n")
 		}
 	}
+	if config.VCD.UserOrg == "" {
+		config.VCD.UserOrg = strings.TrimSuffix(config.VCD.Org, "\n")
+	}
 
 	secret, err := ioutil.ReadFile("/etc/kubernetes/vcloud/basic-auth/password")
 	if err != nil {


### PR DESCRIPTION
* Currently when only the refresh token is specified, userOrg will be left empty and hence the call to get access token from refresh token will faill
* Fix: populate userOrg details in the config when username is not specified
* Refresh token login was broken since the changes to make use of GoVCD for token related operation
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/60)
<!-- Reviewable:end -->
