### PR TITLE
[VCDA-3385] Update CAPVCD RDE with only CAPI yaml

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -37,10 +37,10 @@ import (
 const (
 	CAPVCDTypeVendor  = "vmware"
 	CAPVCDTypeNss     = "capvcdCluster"
-	CAPVCDTypeVersion = "1.0.0"
+	CAPVCDTypeVersion = "1.1.0"
 
 	CAPVCDClusterKind             = "CAPVCDCluster"
-	CAPVCDClusterEntityApiVersion = "capvcd.vmware.com/v1.0"
+	CAPVCDClusterEntityApiVersion = "capvcd.vmware.com/v1.1"
 	CAPVCDClusterCniName          = "antrea" // TODO: Get the correct value for CNI name
 	VcdCsiName                    = "cloud-director-named-disk-csi-driver"
 	VcdCpiName                    = "cloud-provider-for-cloud-director"
@@ -142,49 +142,50 @@ func patchVCDCluster(ctx context.Context, patchHelper *patch.Helper, vcdCluster 
 	)
 }
 
+// TODO: Remove uncommented code when decision to only keep capi.yaml as part of RDE spec is finalized
 func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *clusterv1.Cluster,
 	vcdCluster *infrav1.VCDCluster) (*swagger.DefinedEntity, error) {
 	org := vcdCluster.Spec.Org
 	vdc := vcdCluster.Spec.Ovdc
-	ovdcNetwork := vcdCluster.Spec.OvdcNetwork
+	//ovdcNetwork := vcdCluster.Spec.OvdcNetwork
 
 	kcpList, err := getAllKubeadmControlPlaneForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return nil, fmt.Errorf("error getting KubeadmControlPlane objects for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
-	topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
+	//topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
 	kubernetesVersion := ""
 	for _, kcp := range kcpList.Items {
-		vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
-		if err != nil {
-			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
-		}
-		topologyControlPlane := vcdtypes.ControlPlane{
-			Count:        *kcp.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
-			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
-		}
-		topologyControlPlanes = append(topologyControlPlanes, topologyControlPlane)
+		//vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
+		//if err != nil {
+		//	return nil, fmt.Errorf("error getting the VCDMachineTemplate object from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
+		//}
+		//topologyControlPlane := vcdtypes.ControlPlane{
+		//	Count:        *kcp.Spec.Replicas,
+		//	SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+		//	TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
+		//}
+		//topologyControlPlanes = append(topologyControlPlanes, topologyControlPlane)
 		kubernetesVersion = kcp.Spec.Version
 	}
 
-	mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
-	if err != nil {
-		return nil, fmt.Errorf("error getting the MachineDeployments for cluster [%s]: [%v]", vcdCluster.Name, err)
-	}
-	topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
-	for _, md := range mdList.Items {
-		vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
-		if err != nil {
-			return nil, fmt.Errorf("error getting the VCDMachineTemplate object from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
-		}
-		topologyWorker := vcdtypes.Workers{
-			Count:        *md.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
-			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
-		}
-		topologyWorkers = append(topologyWorkers, topologyWorker)
-	}
+	//mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
+	//if err != nil {
+	//	return nil, fmt.Errorf("error getting the MachineDeployments for cluster [%s]: [%v]", vcdCluster.Name, err)
+	//}
+	//topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
+	//for _, md := range mdList.Items {
+	//	vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
+	//	if err != nil {
+	//		return nil, fmt.Errorf("error getting the VCDMachineTemplate object from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
+	//	}
+	//	topologyWorker := vcdtypes.Workers{
+	//		Count:        *md.Spec.Replicas,
+	//		SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+	//		TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
+	//	}
+	//	topologyWorkers = append(topologyWorkers, topologyWorker)
+	//}
 	rde := &swagger.DefinedEntity{
 		EntityType: CAPVCDEntityTypeID,
 		Name:       vcdCluster.Name,
@@ -199,27 +200,27 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 			Site: vcdCluster.Spec.Site,
 		},
 		Spec: vcdtypes.ClusterSpec{
-			Settings: vcdtypes.Settings{
-				OvdcNetwork: ovdcNetwork,
-				Network: vcdtypes.Network{
-					Cni: vcdtypes.Cni{
-						Name: CAPVCDClusterCniName,
-					},
-					Pods: vcdtypes.Pods{
-						CidrBlocks: cluster.Spec.ClusterNetwork.Pods.CIDRBlocks,
-					},
-					Services: vcdtypes.Services{
-						CidrBlocks: cluster.Spec.ClusterNetwork.Services.CIDRBlocks,
-					},
-				},
-			},
-			Topology: vcdtypes.Topology{
-				ControlPlane: topologyControlPlanes,
-				Workers:      topologyWorkers,
-			},
-			Distribution: vcdtypes.Distribution{
-				Version: kubernetesVersion,
-			},
+			//Settings: vcdtypes.Settings{
+			//	OvdcNetwork: ovdcNetwork,
+			//	Network: vcdtypes.Network{
+			//		Cni: vcdtypes.Cni{
+			//			Name: CAPVCDClusterCniName,
+			//		},
+			//		Pods: vcdtypes.Pods{
+			//			CidrBlocks: cluster.Spec.ClusterNetwork.Pods.CIDRBlocks,
+			//		},
+			//		Services: vcdtypes.Services{
+			//			CidrBlocks: cluster.Spec.ClusterNetwork.Services.CIDRBlocks,
+			//		},
+			//	},
+			//},
+			//Topology: vcdtypes.Topology{
+			//	ControlPlane: topologyControlPlanes,
+			//	Workers:      topologyWorkers,
+			//},
+			//Distribution: vcdtypes.Distribution{
+			//	Version: kubernetesVersion,
+			//},
 		},
 		Status: vcdtypes.Status{
 			Phase: ClusterApiStatusPhaseNotReady,
@@ -290,6 +291,7 @@ func (r *VCDClusterReconciler) constructAndCreateRDEFromCluster(ctx context.Cont
 	return rdeID, nil
 }
 
+// TODO: Remove uncommented code when decision to only keep capi.yaml as part of RDE spec is finalized
 func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *clusterv1.Cluster, vcdCluster *infrav1.VCDCluster, workloadVCDClient *vcdclient.Client) error {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -313,56 +315,56 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		updatePatch["Metadata.Site"] = vcdCluster.Spec.Site
 	}
 
-	networkName := vcdCluster.Spec.OvdcNetwork
-	if networkName != capvcdEntity.Spec.Settings.OvdcNetwork {
-		updatePatch["Spec.Settings.OvdcNetwork"] = networkName
-	}
+	//networkName := vcdCluster.Spec.OvdcNetwork
+	//if networkName != capvcdEntity.Spec.Settings.OvdcNetwork {
+	//	updatePatch["Spec.Settings.OvdcNetwork"] = networkName
+	//}
 
 	kcpList, err := getAllKubeadmControlPlaneForCluster(ctx, r.Client, *cluster)
 	if err != nil {
 		return fmt.Errorf("error getting all KubeadmControlPlane objects for cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
-	topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
+	//topologyControlPlanes := make([]vcdtypes.ControlPlane, len(kcpList.Items))
 	kubernetesVersion := ""
-	for idx, kcp := range kcpList.Items {
-		vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
-		if err != nil {
-			return fmt.Errorf("error getting VCDMachineTemplate from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
-		}
-		topologyControlPlane := vcdtypes.ControlPlane{
-			Count:        *kcp.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
-			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
-		}
-		topologyControlPlanes[idx] = topologyControlPlane
+	for _, kcp := range kcpList.Items {
+		//vcdMachineTemplate, err := getVCDMachineTemplateFromKCP(ctx, r.Client, kcp)
+		//if err != nil {
+		//	return fmt.Errorf("error getting VCDMachineTemplate from KCP [%s] for cluster [%s]: [%v]", kcp.Name, cluster.Name, err)
+		//}
+		//topologyControlPlane := vcdtypes.ControlPlane{
+		//	Count:        *kcp.Spec.Replicas,
+		//	SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+		//	TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
+		//}
+		//topologyControlPlanes[idx] = topologyControlPlane
 		kubernetesVersion = kcp.Spec.Version
 	}
 
-	mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
-	if err != nil {
-		return fmt.Errorf("error getting getting all MachineDeployment for cluster [%s]: [%v]", vcdCluster.Name, err)
-	}
-	topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
-	for idx, md := range mdList.Items {
-		vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
-		if err != nil {
-			return fmt.Errorf("error getting VCDMachineTemplate from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
-		}
-		topologyWorker := vcdtypes.Workers{
-			Count:        *md.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
-			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
-		}
-		topologyWorkers[idx] = topologyWorker
-	}
+	//mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
+	//if err != nil {
+	//	return fmt.Errorf("error getting getting all MachineDeployment for cluster [%s]: [%v]", vcdCluster.Name, err)
+	//}
+	//topologyWorkers := make([]vcdtypes.Workers, len(mdList.Items))
+	//for idx, md := range mdList.Items {
+	//	vcdMachineTemplate, err := getVCDMachineTemplateFromMachineDeployment(ctx, r.Client, md)
+	//	if err != nil {
+	//		return fmt.Errorf("error getting VCDMachineTemplate from MachineDeployment [%s] for cluster [%s]: [%v]", md.Name, cluster.Name, err)
+	//	}
+	//	topologyWorker := vcdtypes.Workers{
+	//		Count:        *md.Spec.Replicas,
+	//		SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+	//		TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
+	//	}
+	//	topologyWorkers[idx] = topologyWorker
+	//}
 
-	// The following code only updates the spec portion of the RDE
-	if !reflect.DeepEqual(capvcdEntity.Spec.Topology.ControlPlane, topologyControlPlanes) {
-		updatePatch["Spec.Topology.ControlPlane"] = topologyControlPlanes
-	}
-	if !reflect.DeepEqual(capvcdEntity.Spec.Topology.Workers, topologyWorkers) {
-		updatePatch["Spec.Topology.Workers"] = topologyWorkers
-	}
+	//The following code only updates the spec portion of the RDE
+	//if !reflect.DeepEqual(capvcdEntity.Spec.Topology.ControlPlane, topologyControlPlanes) {
+	//	updatePatch["Spec.Topology.ControlPlane"] = topologyControlPlanes
+	//}
+	//if !reflect.DeepEqual(capvcdEntity.Spec.Topology.Workers, topologyWorkers) {
+	//	updatePatch["Spec.Topology.Workers"] = topologyWorkers
+	//}
 	capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
 	if err != nil {
 		log.Error(err,
@@ -379,9 +381,9 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		updatePatch["Status.Kubernetes"] = kubernetesVersion
 	}
 
-	if capvcdEntity.Spec.Distribution.Version != kubernetesVersion {
-		updatePatch["Spec.Distribution.Version"] = kubernetesVersion
-	}
+	//if capvcdEntity.Spec.Distribution.Version != kubernetesVersion {
+	//	updatePatch["Spec.Distribution.Version"] = kubernetesVersion
+	//}
 
 	if capvcdEntity.Status.Uid != vcdCluster.Status.InfraId {
 		updatePatch["Status.Uid"] = vcdCluster.Status.InfraId

--- a/pkg/vcdtypes/types.go
+++ b/pkg/vcdtypes/types.go
@@ -304,10 +304,10 @@ type Status struct {
 }
 
 type ClusterSpec struct {
-	Settings     Settings     `json:"settings"`
-	Topology     Topology     `json:"topology"`
-	Distribution Distribution `json:"distribution"`
-	CapiYaml     string       `json:"capiYaml,omitempty"`
+	//Settings     Settings     `json:"settings"`
+	//Topology     Topology     `json:"topology"`
+	//Distribution Distribution `json:"distribution"`
+	CapiYaml string `json:"capiYaml,omitempty"`
 }
 
 type CAPVCDEntity struct {

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -1,0 +1,249 @@
+{
+  "definitions": {
+    "distribution": {
+      "type": "object",
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "network": {
+      "type": "object",
+      "description": "The network-related settings for the cluster.",
+      "properties": {
+        "cni": {
+          "type": "object",
+          "description": "The CNI to use.",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "pods": {
+          "type": "object",
+          "description": "The network settings for Kubernetes pods.",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "description": "Specifies a range of IP addresses to use for Kubernetes pods.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "type": "object",
+          "description": "The network settings for Kubernetes services",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "description": "The range of IP addresses to use for Kubernetes services",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "required": [
+    "kind",
+    "spec",
+    "metadata",
+    "apiVersion"
+  ],
+  "properties": {
+    "kind": {
+      "enum": [
+        "CAPVCDCluster"
+      ],
+      "type": "string",
+      "description": "The kind of the Kubernetes cluster."
+    },
+    "spec": {
+      "type": "object",
+      "description": "The user specification of the desired state of the cluster.",
+      "properties": {
+        "capiYaml": {
+          "type": "string",
+          "description": "CAPI Yaml specification of the CAPVCD cluster"
+        }
+      },
+      "additionalProperties": true
+    },
+    "status": {
+      "type": "object",
+      "x-vcloud-restricted": "protected",
+      "description": "The current status of the cluster.",
+      "properties": {
+        "phase": {
+          "type": "string"
+        },
+        "kubernetes": {
+          "type": "string"
+        },
+        "network": {
+          "$ref": "#/definitions/network"
+        },
+        "uid": {
+          "type": "string",
+          "description": "unique ID of the cluster"
+        },
+        "parentUid": {
+          "type": "string",
+          "description": "unique ID of the parent management cluster"
+        },
+        "isManagementCluster": {
+          "type": "boolean",
+          "description": "Does this RDE represent a management cluster?"
+        },
+        "clusterApiStatus": {
+          "type": "object",
+          "properties": {
+            "phase": {
+              "type": "string",
+              "description": "The phase describing the control plane infrastructure deployment."
+            },
+            "apiEndpoints": {
+              "type": "array",
+              "description": "Control Plane load balancer endpoints",
+              "items": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "nodeStatus": {
+          "additionalProperties": {
+            "type": "string",
+            "properties": {}
+          }
+        },
+        "cni": {
+          "type": "object",
+          "description": "Information regarding the CNI used to deploy the cluster",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "name of the CNI used in the cluster"
+            },
+            "version": {
+              "type": "string",
+              "description": "version of the CNI used in the cluster"
+            }
+          }
+        },
+        "csi": {
+          "type": "object",
+          "description": "details about CSI used in the cluster",
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "version of the CSI used"
+            }
+          }
+        },
+        "cpi": {
+          "type": "object",
+          "description": "details about CPI used in the cluster",
+          "properties": {
+            "version": {
+              "type": "string",
+              "description": "version of the CPI used"
+            }
+          }
+        },
+        "capvcdVersion": {
+          "type": "string",
+          "description": "version of the CAPVCD used to deploy the cluster"
+        },
+        "cloudProperties": {
+          "type": "object",
+          "description": "The details specific to Cloud Director in which the cluster is hosted.",
+          "properties": {
+            "orgName": {
+              "type": "string",
+              "description": "The name of the Organization in which cluster needs to be created or managed."
+            },
+            "virtualDataCenterName": {
+              "type": "string",
+              "description": "The name of the Organization Virtual data center in which the cluster need to be created or managed."
+            },
+            "ovdcNetworkName": {
+              "type": "string",
+              "description": "The name of the Organization Virtual data center network to which cluster is connected."
+            },
+            "site": {
+              "type": "string",
+              "description": "Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
+            }
+          },
+          "additionalProperties": true
+        },
+        "persistentVolumes": {
+          "type": "array",
+          "description": "VCD references to the list of persistent volumes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "virtualIPs": {
+          "type": "array",
+          "description": "Array of virtual IPs consumed by the cluster.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "orgName",
+        "virtualDataCenterName",
+        "name",
+        "site"
+      ],
+      "properties": {
+        "orgName": {
+          "type": "string",
+          "description": "The name of the Organization in which cluster needs to be created or managed."
+        },
+        "virtualDataCenterName": {
+          "type": "string",
+          "description": "The name of the Organization Virtual data center in which the cluster need to be created or managed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the cluster."
+        },
+        "site": {
+          "type": "string",
+          "description": "Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
+        }
+      },
+      "additionalProperties": true
+    },
+    "apiVersion": {
+      "type": "string",
+      "default": "capvcd.vmware.com/v1.0",
+      "description": "The version of the payload format"
+    }
+  },
+  "additionalProperties": true
+}

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -247,3 +247,4 @@
   },
   "additionalProperties": true
 }
+


### PR DESCRIPTION
* Create a new capvcd schema file (1.1.0) and include only capi yaml in the spec
* Changes to remove update to any other field other than capi.yaml from the RDE spec

@sahithi @ltimothy7 
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/65)
<!-- Reviewable:end -->
