### PR TITLE
[VCDA-3349 ]Add admin kubeconfig to entity.status

### DIFF
--- a/pkg/vcdtypes/types.go
+++ b/pkg/vcdtypes/types.go
@@ -286,6 +286,10 @@ type VersionedAddon struct {
 	Version string `json:"version,omitempty"`
 }
 
+type PrivateSection struct {
+	KubeConfig string `json:"kubeConfig,omitempty"`
+}
+
 type Status struct {
 	Phase               string            `json:"phase,omitempty"`
 	Kubernetes          string            `json:"kubernetes,omitempty"`
@@ -301,6 +305,7 @@ type Status struct {
 	Cpi                 VersionedAddon    `json:"cpi,omitempty"`
 	Csi                 VersionedAddon    `json:"csi,omitempty"`
 	CapvcdVersion       string            `json:"capvcdVersion,omitempty"`
+	Private             PrivateSection    `json:"private,omitempty"`
 }
 
 type ClusterSpec struct {

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -207,6 +207,17 @@
           "items": {
             "type": "string"
           }
+        },
+        "private": {
+          "type": "object",
+          "x-vcloud-restricted": "private",
+          "description": "Placeholder for the properties invisible to non-admin users.",
+          "properties": {
+            "kubeConfig": {
+              "type": "string",
+              "description": "Admin kube config to access the Kubernetes cluster."
+            }
+          }
         }
       },
       "additionalProperties": true

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -566,11 +566,14 @@ sigs.k8s.io/cluster-api/errors
 sigs.k8s.io/cluster-api/feature
 sigs.k8s.io/cluster-api/util
 sigs.k8s.io/cluster-api/util/annotations
+sigs.k8s.io/cluster-api/util/certs
 sigs.k8s.io/cluster-api/util/conditions
 sigs.k8s.io/cluster-api/util/container
+sigs.k8s.io/cluster-api/util/kubeconfig
 sigs.k8s.io/cluster-api/util/labels
 sigs.k8s.io/cluster-api/util/patch
 sigs.k8s.io/cluster-api/util/predicates
+sigs.k8s.io/cluster-api/util/secret
 sigs.k8s.io/cluster-api/util/version
 # sigs.k8s.io/controller-runtime v0.10.3
 ## explicit


### PR DESCRIPTION
* Add private section for kubeconfig in entity.status
* Fetch kubeconfig for the cluster and populate it in vcdcluster_controller.go
* Tested by creating a cluster and checked if kubeconfig section is getting populated.
* Used the kubeconfig in the status section to access the created cluster
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/67)
<!-- Reviewable:end -->
