### PR TITLE
First set of RDE schema changes for the next version of CAPVCD

### DIFF
--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -85,137 +85,142 @@
       "x-vcloud-restricted": "protected",
       "description": "The current status of the cluster.",
       "properties": {
-        "phase": {
-          "type": "string"
-        },
-        "kubernetes": {
-          "type": "string"
-        },
-        "network": {
-          "$ref": "#/definitions/network"
-        },
-        "uid": {
-          "type": "string",
-          "description": "unique ID of the cluster"
-        },
-        "parentUid": {
-          "type": "string",
-          "description": "unique ID of the parent management cluster"
-        },
-        "isManagementCluster": {
-          "type": "boolean",
-          "description": "Does this RDE represent a management cluster?"
-        },
-        "clusterApiStatus": {
+        "capvcd": {
           "type": "object",
           "properties": {
             "phase": {
-              "type": "string",
-              "description": "The phase describing the control plane infrastructure deployment."
+              "type": "string"
             },
-            "apiEndpoints": {
-              "type": "array",
-              "description": "Control Plane load balancer endpoints",
-              "items": {
-                "host": {
-                  "type": "string"
+            "kubernetes": {
+              "type": "string"
+            },
+            "network": {
+              "$ref": "#/definitions/network"
+            },
+            "uid": {
+              "type": "string",
+              "description": "unique ID of the cluster"
+            },
+            "parentUid": {
+              "type": "string",
+              "description": "unique ID of the parent management cluster"
+            },
+            "isManagementCluster": {
+              "type": "boolean",
+              "description": "Does this RDE represent a management cluster?"
+            },
+            "clusterApiStatus": {
+              "type": "object",
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "description": "The phase describing the control plane infrastructure deployment."
                 },
-                "port": {
-                  "type": "integer"
+                "apiEndpoints": {
+                  "type": "array",
+                  "description": "Control Plane load balancer endpoints",
+                  "items": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
-            }
-          }
-        },
-        "nodeStatus": {
-          "additionalProperties": {
-            "type": "string",
-            "properties": {}
-          }
-        },
-        "cni": {
-          "type": "object",
-          "description": "Information regarding the CNI used to deploy the cluster",
-          "properties": {
-            "name": {
-              "type": "string",
-              "description": "name of the CNI used in the cluster"
             },
-            "version": {
-              "type": "string",
-              "description": "version of the CNI used in the cluster"
-            }
-          }
-        },
-        "csi": {
-          "type": "object",
-          "description": "details about CSI used in the cluster",
-          "properties": {
-            "version": {
-              "type": "string",
-              "description": "version of the CSI used"
-            }
-          }
-        },
-        "cpi": {
-          "type": "object",
-          "description": "details about CPI used in the cluster",
-          "properties": {
-            "version": {
-              "type": "string",
-              "description": "version of the CPI used"
-            }
-          }
-        },
-        "capvcdVersion": {
-          "type": "string",
-          "description": "version of the CAPVCD used to deploy the cluster"
-        },
-        "cloudProperties": {
-          "type": "object",
-          "description": "The details specific to Cloud Director in which the cluster is hosted.",
-          "properties": {
-            "orgName": {
-              "type": "string",
-              "description": "The name of the Organization in which cluster needs to be created or managed."
+            "nodeStatus": {
+              "additionalProperties": {
+                "type": "string",
+                "properties": {}
+              }
             },
-            "virtualDataCenterName": {
-              "type": "string",
-              "description": "The name of the Organization Virtual data center in which the cluster need to be created or managed."
+            "cni": {
+              "type": "object",
+              "description": "Information regarding the CNI used to deploy the cluster",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "name of the CNI used in the cluster"
+                },
+                "version": {
+                  "type": "string",
+                  "description": "version of the CNI used in the cluster"
+                }
+              }
             },
-            "ovdcNetworkName": {
-              "type": "string",
-              "description": "The name of the Organization Virtual data center network to which cluster is connected."
+            "csi": {
+              "type": "object",
+              "description": "details about CSI used in the cluster",
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "description": "version of the CSI used"
+                }
+              }
             },
-            "site": {
+            "cpi": {
+              "type": "object",
+              "description": "details about CPI used in the cluster",
+              "properties": {
+                "version": {
+                  "type": "string",
+                  "description": "version of the CPI used"
+                }
+              }
+            },
+            "capvcdVersion": {
               "type": "string",
-              "description": "Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
-            }
-          },
-          "additionalProperties": true
-        },
-        "persistentVolumes": {
-          "type": "array",
-          "description": "VCD references to the list of persistent volumes.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "virtualIPs": {
-          "type": "array",
-          "description": "Array of virtual IPs consumed by the cluster.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "private": {
-          "type": "object",
-          "x-vcloud-restricted": "private",
-          "description": "Placeholder for the properties invisible to non-admin users.",
-          "properties": {
-            "kubeConfig": {
-              "type": "string",
-              "description": "Admin kube config to access the Kubernetes cluster."
+              "description": "version of the CAPVCD used to deploy the cluster"
+            },
+            "cloudProperties": {
+              "type": "object",
+              "description": "The details specific to Cloud Director in which the cluster is hosted.",
+              "properties": {
+                "orgName": {
+                  "type": "string",
+                  "description": "The name of the Organization in which cluster needs to be created or managed."
+                },
+                "virtualDataCenterName": {
+                  "type": "string",
+                  "description": "The name of the Organization Virtual data center in which the cluster need to be created or managed."
+                },
+                "ovdcNetworkName": {
+                  "type": "string",
+                  "description": "The name of the Organization Virtual data center network to which cluster is connected."
+                },
+                "site": {
+                  "type": "string",
+                  "description": "Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
+                }
+              },
+              "additionalProperties": true
+            },
+            "persistentVolumes": {
+              "type": "array",
+              "description": "VCD references to the list of persistent volumes.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "virtualIPs": {
+              "type": "array",
+              "description": "Array of virtual IPs consumed by the cluster.",
+              "items": {
+                "type": "string"
+              }
+            },
+            "private": {
+              "type": "object",
+              "x-vcloud-restricted": "private",
+              "description": "Placeholder for the properties invisible to non-admin users.",
+              "properties": {
+                "kubeConfig": {
+                  "type": "string",
+                  "description": "Admin kube config to access the Kubernetes cluster."
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
For the next version of CAPVCD, we are going to introduce new functionality into CAPI yaml that requires RDE version increment (support of storage-profiles, GPU profiles, default storage class). This change-set increments the RDE version and modifies the general structure of RDE.status. All of the CAPVCD properties are put under RDE.status.CAPVCD section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/70)
<!-- Reviewable:end -->
