### PR TITLE
New RDE schema 1.1.0 and an associated example

### DIFF
--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -1,0 +1,146 @@
+{
+  "kind": "CAPVCDCluster",
+  "spec": {
+    "capiYaml": "ABCDEFGHIJKLMNOPQRS",
+    "VKPSpec": {
+      "isVKPCluster": true,
+      "markForDelete": {
+        "forceDelete": false
+      }
+    },
+    "commandSpec": {
+      "commandList": {}
+    }
+  },
+  "metadata": {
+    "orgName": "ABCDEFGHIJKLMNOPQRSTUVWXYZA",
+    "virtualDataCenterName": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "name": "ABCDEFGH",
+    "site": "ABCD"
+  },
+  "apiVersion": "ABCDEFG",
+  "status": {
+    "vkp": {
+      "operation": {
+        "state": "provisioning;provisioned;error;deleting",
+        "events": [
+          {"attempt1":["InstalledKind_timestamp", "InstalledCAPI_timestamp", "AppliedCAPIYaml_timestamp"]},
+          {"attempt2":["InstalledKind_timestamp", "InstalledCAPI_timestamp", "..clustertctlMove_timestamp"]}
+        ],
+        "errors": [
+          {"attempt1":["clusterCreationFailed_timestamp"]},
+          {"attempt2":[]}],
+        "workerTimestamp":["vkpInstanceId:WorkerId:timestamp"],
+        "deleteTimestamp":"",
+        "scriptOutput":[{"attempt1":".."},{"attempt2":".."}]
+      }
+    },
+    "capvcd": {
+      "phase": "ABCDEFGHIJKLMNOPQRSTUVWX",
+      "kubernetes": "ABCDEFGHIJKLMNOPQRST",
+      "errors":["Machine<name>creationFailed_timestamp, "],
+      "conditions":[],
+      "k8sNetwork": {
+        "cni": {
+          "name": "ABCDEFGHIJKLMN"
+        },
+        "pods": {
+          "cidrBlocks": []
+        },
+        "services": {
+          "cidrBlocks": []
+        }
+      },
+      "uid": "ABCD",
+      "parentUid": "ABCDEFGHIJKLMNOPQRST",
+      "userIntendsToUseItAsAManagementCluster": false,
+      "clusterApiStatus": {
+        "phase": "ABCDEFGHIJKLMNOPQ",
+        "apiEndpoints": []
+      },
+      "nodeStatus": {
+        "node1": "running",
+        "node2": "provisioning"
+      },
+      "clusterResourceSet": [
+        {
+          "name": "cni",
+          "details": {
+            "version": "1.1.0"
+          }
+        },
+        {
+          "name": "csi",
+          "details": {
+            "version": "1.1.0"
+          }
+        },
+        {
+          "name": "cpi",
+          "details": {
+            "version": "1.1.0"
+          }
+        },
+        {
+          "name": "defaultStorageClass",
+          "details": {
+            "retainPolicy": "delete",
+            "storageClassName": "defaultSC",
+            "vcdStorageProfileName": "Any",
+            "fileSystem": "ext4"
+          }
+        }
+      ],
+      "capvcdVersion": "ABCD",
+      "vcdProperties": {
+        "orgName": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
+        "virtualDataCenterName": "ABCDEFGHIJKLMNOPQRSTUVWX",
+        "ovdcNetworkName": "ABCDEFGHIJKLMNOPQ",
+        "site": "ABCDEFGHIJKLMNOPQRSTUVWX"
+      },
+      "vcdResourceSet": [
+        {
+          "type": "vApp",
+          "id": "",
+          "name": ""
+        },
+        {
+          "type": "virtualService",
+          "id": "",
+          "name": ""
+        },
+        {
+          "type": "DnatRule",
+          "id": "",
+          "name": ""
+        }
+      ]
+    },
+    "csi":{
+      "name":"cloud director storage provider",
+      "version": "1.1.2",
+      "vcdResourceSet": [
+        {
+          "type": "disk",
+          "id": "",
+          "name": "disk_clustername"
+
+        }
+      ],
+      "errors":["loginFailed_timestamp", "diskAttachFailed_timestamp"]
+    },
+    "cpi": {
+      "name":"cloud director external cloud provider",
+      "version": "1.1.2",
+      "vcdResourceSet": [
+        {
+          "type": "vip",
+          "id": "",
+          "name": "vs_cluster_name"
+
+        }
+      ],
+      "errors":["loginFailed_timestamp", "nodeFailed_timestamp", "vsCreationFailed_timestamp"]
+    }
+  }
+}

--- a/schema/WIP_schema_1_1_0.json
+++ b/schema/WIP_schema_1_1_0.json
@@ -1,0 +1,202 @@
+{
+  "definitions": {
+    "k8sNetwork": {
+      "type": "object",
+      "description": "The network-related settings for the cluster.",
+      "properties": {
+        "cni": {
+          "type": "object",
+          "description": "The CNI to use.",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "pods": {
+          "type": "object",
+          "description": "The network settings for Kubernetes pods.",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "description": "Specifies a range of IP addresses to use for Kubernetes pods.",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "services": {
+          "type": "object",
+          "description": "The network settings for Kubernetes services",
+          "properties": {
+            "cidrBlocks": {
+              "type": "array",
+              "description": "The range of IP addresses to use for Kubernetes services",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "kind": {
+      "enum": [
+        "CAPVCDCluster", "VKPCluster"
+      ],
+      "type": "string",
+      "description": "The kind of the Kubernetes cluster."
+    },
+    "spec": {
+      "type": "object",
+      "properties": {
+        "capiYaml": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "capiYaml"
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "orgName": {
+          "type": "string",
+          "description": "The name of the Organization in which cluster needs to be created or managed."
+        },
+        "virtualDataCenterName": {
+          "type": "string",
+          "description": "The name of the Organization Virtual data center in which the cluster need to be created or managed."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the cluster."
+        },
+        "site": {
+          "type": "string",
+          "description": "Fully Qualified Domain Name of the VCD site in which the cluster is deployed"
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "x-vcloud-restricted": "protected",
+      "properties": {
+        "capvcd": {
+          "type": "object",
+          "properties": {
+            "phase": {
+              "type": "string"
+            },
+            "kubernetes": {
+              "type": "string"
+            },
+            "errors": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "k8sNetwork": {
+              "$ref": "#/definitions/k8sNetwork"
+            },
+            "uid": {
+              "type": "string"
+            },
+            "parentUid": {
+              "type": "string"
+            },
+            "userIntendsToUseItAsAManagementCluster": {
+              "type": "boolean"
+            },
+            "clusterApiStatus": {
+              "type": "object",
+              "properties": {
+                "phase": {
+                  "type": "string",
+                  "description": "The phase describing the control plane infrastructure deployment."
+                },
+                "apiEndpoints": {
+                  "type": "array",
+                  "description": "Control Plane load balancer endpoints",
+                  "items": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            },
+            "nodeStatus": {
+              "additionalProperties": {
+                "type": "string",
+                "properties": {}
+              }
+            },
+            "clusterResourceSet": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {}
+              }
+            },
+            "capvcdVersion": {
+              "type": "string"
+            },
+            "vcdProperties": {
+              "type": "object",
+              "properties": {
+                "orgName": {
+                  "type": "string"
+                },
+                "virtualDataCenterName": {
+                  "type": "string"
+                },
+                "ovdcNetworkName": {
+                  "type": "string"
+                },
+                "site": {
+                  "type": "string"
+                }
+              }
+            },
+            "private": {
+              "type": "object",
+              "x-vcloud-restricted": "private",
+              "description": "Placeholder for the properties invisible to non-admin users.",
+              "properties": {
+                "kubeConfig": {
+                  "type": "string",
+                  "description": "Admin kube config to access the Kubernetes cluster."
+                }
+              }
+            },
+            "vcdResourceSet": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {}
+
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "kind",
+    "spec",
+    "metadata"
+  ]
+}


### PR DESCRIPTION
This changeset has the work in progress schema file for RDE 1.1.0 and also an associated example instance.
Once the Go types have been created in the code, then we can delete the existing rde 1.1.0 schema and rename the newly introduced json file to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/77)
<!-- Reviewable:end -->
