### PR TITLE
[VCDA 3514] fix trailing '/' issue

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -77,6 +77,8 @@ func (r *VCDClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	log := ctrl.LoggerFrom(ctx)
 	// Fetch the VCDCluster instance
 	vcdCluster := &infrav1.VCDCluster{}
+	// remove the trailing '/'
+	vcdCluster.Spec.Site = strings.TrimRight(vcdCluster.Spec.Site, "/")
 	if err := r.Client.Get(ctx, req.NamespacedName, vcdCluster); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	yaml "gopkg.in/yaml.v2"
 	"io"
+	"strings"
 )
 
 // VCDConfig :
@@ -134,6 +135,7 @@ func ParseCloudConfig(configReader io.Reader) (*CloudConfig, error) {
 	if err = decoder.Decode(&config); err != nil {
 		return nil, fmt.Errorf("Unable to decode yaml file: [%v]", err)
 	}
+	config.VCD.Host = strings.TrimRight(config.VCD.Host, "/")
 
 	return config, nil
 }


### PR DESCRIPTION
* Handled trailing '/' to avoid broken API paths.
* Done testing on CAPVCD cluster on personal testbed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/85)
<!-- Reviewable:end -->
