### PR TITLE
Rename ComputePolicy property in VCDMachineSpec to SizingPolicy

### DIFF
--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -428,7 +428,7 @@ func autoConvert_v1alpha4_VCDMachineSpec_To_v1beta1_VCDMachineSpec(in *VCDMachin
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	out.Catalog = in.Catalog
 	out.Template = in.Template
-	out.ComputePolicy = in.ComputePolicy
+	out.SizingPolicy = in.ComputePolicy
 	out.Bootstrapped = in.Bootstrapped
 	return nil
 }
@@ -442,7 +442,7 @@ func autoConvert_v1beta1_VCDMachineSpec_To_v1alpha4_VCDMachineSpec(in *v1beta1.V
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
 	out.Catalog = in.Catalog
 	out.Template = in.Template
-	out.ComputePolicy = in.ComputePolicy
+	out.ComputePolicy = in.SizingPolicy
 	out.Bootstrapped = in.Bootstrapped
 	return nil
 }

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -73,7 +73,7 @@ type VCDClusterSpec struct {
 	// +optional
 	DefaultComputePolicy string `json:"defaultComputePolicy,omitempty"`
 	// + optional
-	RDEId string `json:"rdeId"`
+	RDEId string `json:"rdeId,omitempty"`
 }
 
 // VCDClusterStatus defines the observed state of VCDCluster

--- a/api/v1beta1/vcdmachine_types.go
+++ b/api/v1beta1/vcdmachine_types.go
@@ -45,7 +45,8 @@ type VCDMachineSpec struct {
 	// +optional
 	Template string `json:"template,omitempty"`
 
-	// SizingPolicy is the sizing policy to be used on this machine
+	// SizingPolicy is the sizing policy to be used on this machine.
+	// If no sizing policy is specified, default sizing policy will be used to create the nodes
 	// +optional
 	SizingPolicy string `json:"sizingPolicy,omitempty"`
 

--- a/api/v1beta1/vcdmachine_types.go
+++ b/api/v1beta1/vcdmachine_types.go
@@ -45,9 +45,9 @@ type VCDMachineSpec struct {
 	// +optional
 	Template string `json:"template,omitempty"`
 
-	// ComputePolicy is the compute policy to be used on this machine
+	// SizingPolicy is the sizing policy to be used on this machine
 	// +optional
-	ComputePolicy string `json:"computePolicy,omitempty"`
+	SizingPolicy string `json:"sizingPolicy,omitempty"`
 
 	// Bootstrapped is true when the kubeadm bootstrapping has been run
 	// against this machine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -165,7 +165,8 @@ spec:
                 type: string
               sizingPolicy:
                 description: SizingPolicy is the sizing policy to be used on this
-                  machine
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               template:
                 description: TemplatePath is the path of the template OVA that is

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -159,13 +159,13 @@ spec:
               catalog:
                 description: Catalog hosting templates
                 type: string
-              computePolicy:
-                description: ComputePolicy is the compute policy to be used on this
-                  machine
-                type: string
               providerID:
                 description: ProviderID will be the container name in ProviderID format
                   (vmware-cloud-director://<vm id>)
+                type: string
+              sizingPolicy:
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine
                 type: string
               template:
                 description: TemplatePath is the path of the template OVA that is

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
@@ -117,7 +117,8 @@ spec:
                         type: string
                       sizingPolicy:
                         description: SizingPolicy is the sizing policy to be used
-                          on this machine
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       template:
                         description: TemplatePath is the path of the template OVA

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
@@ -111,13 +111,13 @@ spec:
                       catalog:
                         description: Catalog hosting templates
                         type: string
-                      computePolicy:
-                        description: ComputePolicy is the compute policy to be used
-                          on this machine
-                        type: string
                       providerID:
                         description: ProviderID will be the container name in ProviderID
                           format (vmware-cloud-director://<vm id>)
+                        type: string
+                      sizingPolicy:
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine
                         type: string
                       template:
                         description: TemplatePath is the path of the template OVA

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -164,7 +164,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		}
 		topologyControlPlane := vcdtypes.ControlPlane{
 			Count:        *kcp.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyControlPlanes = append(topologyControlPlanes, topologyControlPlane)
@@ -183,7 +183,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		}
 		topologyWorker := vcdtypes.Workers{
 			Count:        *md.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyWorkers = append(topologyWorkers, topologyWorker)
@@ -334,7 +334,7 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		}
 		topologyControlPlane := vcdtypes.ControlPlane{
 			Count:        *kcp.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyControlPlanes[idx] = topologyControlPlane
@@ -353,7 +353,7 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		}
 		topologyWorker := vcdtypes.Workers{
 			Count:        *md.Spec.Replicas,
-			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.ComputePolicy,
+			SizingClass:  vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			TemplateName: vcdMachineTemplate.Spec.Template.Spec.Template,
 		}
 		topologyWorkers[idx] = topologyWorker

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -550,7 +550,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.Info("Adding infra VM for the machine")
 		err = vdcManager.AddNewVM(machine.Name, vApp.VApp.Name, 1,
 			vcdMachine.Spec.Catalog, vcdMachine.Spec.Template, "",
-			vcdMachine.Spec.ComputePolicy, "", false)
+			vcdMachine.Spec.SizingPolicy, "", false)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "Error provisioning infrastructure for the machine; unable to create VM [%s] in vApp [%s]",
 				machine.Name, vApp.VApp.Name)


### PR DESCRIPTION
ticket: VCDA-3453
 
* Rename property computePolicy to sizingPolicy in VCDMachineSpec
* Use conversion-gen to re-generate conversion code

Testing:
* create cluster in v1beta1
* create cluster in v1alpha4 and upgrade hub version to v1beta1

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/91)
<!-- Reviewable:end -->
