### PR TITLE
VCDA-3502: Add parentUid and useAsManagementCluster support for v1beta1 VCDCluster

### DIFF
--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -13,6 +13,8 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	dst.Spec.DefaultStorageClassOptions = &v1beta1.DefaultStorageClassOptions{}
 	dst.Spec.RDEId = ""
+	dst.Spec.ParentUID = ""
+	dst.Spec.UseAsManagementCluster = false // defaults to false
 	return nil
 }
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -111,16 +111,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.AddGeneratedConversionFunc((*VCDMachineSpec)(nil), (*v1beta1.VCDMachineSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1alpha4_VCDMachineSpec_To_v1beta1_VCDMachineSpec(a.(*VCDMachineSpec), b.(*v1beta1.VCDMachineSpec), scope)
-	}); err != nil {
-		return err
-	}
-	if err := s.AddGeneratedConversionFunc((*v1beta1.VCDMachineSpec)(nil), (*VCDMachineSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
-		return Convert_v1beta1_VCDMachineSpec_To_v1alpha4_VCDMachineSpec(a.(*v1beta1.VCDMachineSpec), b.(*VCDMachineSpec), scope)
-	}); err != nil {
-		return err
-	}
 	if err := s.AddGeneratedConversionFunc((*VCDMachineStatus)(nil), (*v1beta1.VCDMachineStatus)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1alpha4_VCDMachineStatus_To_v1beta1_VCDMachineStatus(a.(*VCDMachineStatus), b.(*v1beta1.VCDMachineStatus), scope)
 	}); err != nil {
@@ -181,8 +171,18 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}); err != nil {
 		return err
 	}
+	if err := s.AddConversionFunc((*VCDMachineSpec)(nil), (*v1beta1.VCDMachineSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1alpha4_VCDMachineSpec_To_v1beta1_VCDMachineSpec(a.(*VCDMachineSpec), b.(*v1beta1.VCDMachineSpec), scope)
+	}); err != nil {
+		return err
+	}
 	if err := s.AddConversionFunc((*v1beta1.VCDClusterSpec)(nil), (*VCDClusterSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		return Convert_v1beta1_VCDClusterSpec_To_v1alpha4_VCDClusterSpec(a.(*v1beta1.VCDClusterSpec), b.(*VCDClusterSpec), scope)
+	}); err != nil {
+		return err
+	}
+	if err := s.AddConversionFunc((*v1beta1.VCDMachineSpec)(nil), (*VCDMachineSpec)(nil), func(a, b interface{}, scope conversion.Scope) error {
+		return Convert_v1beta1_VCDMachineSpec_To_v1alpha4_VCDMachineSpec(a.(*v1beta1.VCDMachineSpec), b.(*VCDMachineSpec), scope)
 	}); err != nil {
 		return err
 	}
@@ -343,6 +343,8 @@ func autoConvert_v1beta1_VCDClusterSpec_To_v1alpha4_VCDClusterSpec(in *v1beta1.V
 	// WARNING: in.DefaultStorageClassOptions requires manual conversion: does not exist in peer-type
 	out.DefaultComputePolicy = in.DefaultComputePolicy
 	// WARNING: in.RDEId requires manual conversion: does not exist in peer-type
+	// WARNING: in.ParentUID requires manual conversion: does not exist in peer-type
+	// WARNING: in.UseAsManagementCluster requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -404,7 +406,17 @@ func Convert_v1beta1_VCDMachine_To_v1alpha4_VCDMachine(in *v1beta1.VCDMachine, o
 
 func autoConvert_v1alpha4_VCDMachineList_To_v1beta1_VCDMachineList(in *VCDMachineList, out *v1beta1.VCDMachineList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta1.VCDMachine)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta1.VCDMachine, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha4_VCDMachine_To_v1beta1_VCDMachine(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -415,7 +427,17 @@ func Convert_v1alpha4_VCDMachineList_To_v1beta1_VCDMachineList(in *VCDMachineLis
 
 func autoConvert_v1beta1_VCDMachineList_To_v1alpha4_VCDMachineList(in *v1beta1.VCDMachineList, out *VCDMachineList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]VCDMachine)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]VCDMachine, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_VCDMachine_To_v1alpha4_VCDMachine(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -500,7 +522,17 @@ func Convert_v1beta1_VCDMachineTemplate_To_v1alpha4_VCDMachineTemplate(in *v1bet
 
 func autoConvert_v1alpha4_VCDMachineTemplateList_To_v1beta1_VCDMachineTemplateList(in *VCDMachineTemplateList, out *v1beta1.VCDMachineTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]v1beta1.VCDMachineTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]v1beta1.VCDMachineTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1alpha4_VCDMachineTemplate_To_v1beta1_VCDMachineTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 
@@ -511,7 +543,17 @@ func Convert_v1alpha4_VCDMachineTemplateList_To_v1beta1_VCDMachineTemplateList(i
 
 func autoConvert_v1beta1_VCDMachineTemplateList_To_v1alpha4_VCDMachineTemplateList(in *v1beta1.VCDMachineTemplateList, out *VCDMachineTemplateList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]VCDMachineTemplate)(unsafe.Pointer(&in.Items))
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]VCDMachineTemplate, len(*in))
+		for i := range *in {
+			if err := Convert_v1beta1_VCDMachineTemplate_To_v1alpha4_VCDMachineTemplate(&(*in)[i], &(*out)[i], s); err != nil {
+				return err
+			}
+		}
+	} else {
+		out.Items = nil
+	}
 	return nil
 }
 

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -74,6 +74,10 @@ type VCDClusterSpec struct {
 	DefaultComputePolicy string `json:"defaultComputePolicy,omitempty"`
 	// + optional
 	RDEId string `json:"rdeId,omitempty"`
+	// +optional
+	ParentUID string `json:"parentUid,omitempty"`
+	// +optional
+	UseAsManagementCluster bool `json:"useAsManagementCluster"`
 }
 
 // VCDClusterStatus defines the observed state of VCDCluster

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -237,10 +237,10 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 				Phase:        "",
 				ApiEndpoints: []vcdtypes.ApiEndpoints{},
 			},
-			NodeStatus:          make(map[string]string),
-			IsManagementCluster: false,
-			CapvcdVersion:       r.Config.ClusterResources.CapvcdVersion,
-			ParentUID:           r.Config.ManagementClusterRDEId,
+			NodeStatus:             make(map[string]string),
+			UseAsManagementCluster: vcdCluster.Spec.UseAsManagementCluster,
+			CapvcdVersion:          r.Config.ClusterResources.CapvcdVersion,
+			ParentUID:              vcdCluster.Spec.ParentUID,
 			Csi: vcdtypes.VersionedAddon{
 				Name:    VcdCsiName,
 				Version: r.Config.ClusterResources.CsiVersion, // TODO: get CPI, CNI, CSI versions from the CLusterResourceSet objects
@@ -393,6 +393,15 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	if capvcdEntity.Status.Phase != cluster.Status.Phase {
 		updatePatch["Status.Phase"] = cluster.Status.Phase
 	}
+
+	if capvcdEntity.Status.ParentUID != vcdCluster.Spec.ParentUID {
+		updatePatch["Status.ParentUID"] = vcdCluster.Spec.ParentUID
+	}
+
+	if capvcdEntity.Status.UseAsManagementCluster != vcdCluster.Spec.UseAsManagementCluster {
+		updatePatch["Status.UseAsManagementCluster"] = vcdCluster.Spec.UseAsManagementCluster
+	}
+
 	clusterApiStatusPhase := ClusterApiStatusPhaseNotReady
 	if cluster.Status.ControlPlaneReady {
 		clusterApiStatusPhase = ClusterApiStatusPhaseReady

--- a/pkg/vcdtypes/types.go
+++ b/pkg/vcdtypes/types.go
@@ -291,21 +291,21 @@ type PrivateSection struct {
 }
 
 type Status struct {
-	Phase               string            `json:"phase,omitempty"`
-	Kubernetes          string            `json:"kubernetes,omitempty"`
-	Uid                 string            `json:"uid,omitempty"`
-	ClusterAPIStatus    ClusterApiStatus  `json:"clusterApiStatus,omitempty"`
-	CloudProperties     CloudProperties   `json:"cloudProperties,omitempty"`
-	PersistentVolumes   []string          `json:"persistentVolumes,omitempty"`
-	VirtualIPs          []string          `json:"virtualIPs,omitempty"`
-	NodeStatus          map[string]string `json:"nodeStatus,omitempty"`
-	ParentUID           string            `json:"parentUid,omitempty"`
-	IsManagementCluster bool              `json:"isManagementCluster,omitempty"`
-	Cni                 VersionedAddon    `json:"cni,omitempty"`
-	Cpi                 VersionedAddon    `json:"cpi,omitempty"`
-	Csi                 VersionedAddon    `json:"csi,omitempty"`
-	CapvcdVersion       string            `json:"capvcdVersion,omitempty"`
-	Private             PrivateSection    `json:"private,omitempty"`
+	Phase                  string            `json:"phase,omitempty"`
+	Kubernetes             string            `json:"kubernetes,omitempty"`
+	Uid                    string            `json:"uid,omitempty"`
+	ClusterAPIStatus       ClusterApiStatus  `json:"clusterApiStatus,omitempty"`
+	CloudProperties        CloudProperties   `json:"cloudProperties,omitempty"`
+	PersistentVolumes      []string          `json:"persistentVolumes,omitempty"`
+	VirtualIPs             []string          `json:"virtualIPs,omitempty"`
+	NodeStatus             map[string]string `json:"nodeStatus,omitempty"`
+	ParentUID              string            `json:"parentUid,omitempty"`
+	UseAsManagementCluster bool              `json:"useAsManagementCluster"`
+	Cni                    VersionedAddon    `json:"cni,omitempty"`
+	Cpi                    VersionedAddon    `json:"cpi,omitempty"`
+	Csi                    VersionedAddon    `json:"csi,omitempty"`
+	CapvcdVersion          string            `json:"capvcdVersion,omitempty"`
+	Private                PrivateSection    `json:"private,omitempty"`
 }
 
 type ClusterSpec struct {


### PR DESCRIPTION
* Added optional `parentUid` - Parent's Management Cluster Unique ID
* Added optional `useAsManagementCluster` - Intent to use cluster as a management cluster; removed omitempty to show `false` as false is considered empty
* Regenerated `zz_generated.conversion.go` from conversion gen tool
* Added fields in `reconcileRDE` to update RDE Status to be same with cluster spec
* Testing Done:
  - Applied capi yaml -> used Postman for RDE details -> update values and reapply capi yaml -> see updated change after sometime in Postman RDE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/101)
<!-- Reviewable:end -->
