### PR TITLE
VCDA-3469: Update RDE.Spec.CapiYaml only if empty

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -367,14 +367,16 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	if !reflect.DeepEqual(capvcdEntity.Spec.Topology.Workers, topologyWorkers) {
 		updatePatch["Spec.Topology.Workers"] = topologyWorkers
 	}
-	capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
-	if err != nil {
-		log.Error(err,
-			"error during RDE reconciliation: failed to construct capi yaml from kubernetes resources of cluster")
-	}
 
-	if err == nil && capvcdEntity.Spec.CapiYaml != capiYaml {
-		updatePatch["Spec.CapiYaml"] = capiYaml
+	// UI can create CAPVCD clusters in future which can populate capiYaml in RDE.Spec, so we only want to populate if capiYaml is empty
+	if capvcdEntity.Spec.CapiYaml == "" {
+		capiYaml, err := getCapiYaml(ctx, r.Client, *cluster, *vcdCluster)
+		if err != nil {
+			log.Error(err,
+				"error during RDE reconciliation: failed to construct capi yaml from kubernetes resources of cluster")
+		} else {
+			updatePatch["Spec.CapiYaml"] = capiYaml
+		}
 	}
 
 	// Updating status portion of the RDE in the following code


### PR DESCRIPTION
* Only populate RDE.Spec.CapiYaml if is it initially empty, otherwise don't update it
* Testing Done:
    - Created brand new cluster -> RDE.Spec.CapiYaml gets populated with initial spec -> update capi yaml specs -> RDE.Spec.CapiYaml doesn't get updated as it is no longer empty

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/105)
<!-- Reviewable:end -->
