### PR TITLE
[VCDA-3533] Delete the vApp if and only if rdeId (matches) present in the vApp

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -723,8 +723,10 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 		if !vcdCluster.Status.VAppMetadataUpdated {
 			return ctrl.Result{}, errors.Errorf("Error occurred during cluster deletion; Field [VAppMetadataUpdated] is %t", vcdCluster.Status.VAppMetadataUpdated)
 		}
-		vAppMetadataFound, err := vdcManager.ValidateMetadata(vApp, CapvcdInfraId, vcdCluster.Status.InfraId)
-		if !vAppMetadataFound {
+		metadataInfraId, err := vdcManager.GetMetadataByKey(vApp, CapvcdInfraId)
+
+		// checking the metadata value and vcdCluster.Status.InfraId are equal or not
+		if metadataInfraId != vcdCluster.Status.InfraId {
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Error occurred during cluster deletion; vApp [%s] matadata not found", vcdCluster.Name))
 			}

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -720,10 +720,9 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 	}
 	if vApp != nil {
 		//Delete the vApp if and only if rdeId (matches) present in the vApp
-		//if !vcdCluster.Status.VAppMetadataUpdated {
-		//	return ctrl.Result{}, errors.Errorf("Error occurred during cluster deletion; Field [VAppMetadataUpdated] is %t", vcdCluster.Status.VAppMetadataUpdated)
-		//}
-		//vcdCluster.Status.VAppMetadataUpdated = true
+		if !vcdCluster.Status.VAppMetadataUpdated {
+			return ctrl.Result{}, errors.Errorf("Error occurred during cluster deletion; Field [VAppMetadataUpdated] is %t", vcdCluster.Status.VAppMetadataUpdated)
+		}
 		vAppMetadataFound, err := vdcManager.ValidateMetadata(vApp, CapvcdInfraId, vcdCluster.Status.InfraId)
 		if !vAppMetadataFound {
 			if err != nil {

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -724,12 +724,11 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 			return ctrl.Result{}, errors.Errorf("Error occurred during cluster deletion; Field [VAppMetadataUpdated] is %t", vcdCluster.Status.VAppMetadataUpdated)
 		}
 		metadataInfraId, err := vdcManager.GetMetadataByKey(vApp, CapvcdInfraId)
-
+		if err != nil {
+			return ctrl.Result{}, errors.Errorf("Error occurred during fetching metadata in vApp")
+		}
 		// checking the metadata value and vcdCluster.Status.InfraId are equal or not
 		if metadataInfraId != vcdCluster.Status.InfraId {
-			if err != nil {
-				log.Error(err, fmt.Sprintf("Error occurred during cluster deletion; vApp [%s] matadata not found", vcdCluster.Name))
-			}
 			return ctrl.Result{}, errors.Wrapf(err,
 				"Error occurred during cluster deletion; failed to delete vApp [%s]", vcdCluster.Name)
 		}

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -839,17 +839,16 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 		}
 	}
 	if vApp != nil {
-		// Delete the vApp if and only if rdeId (matches) present in the vApp
+		// Delete the VM if and only if rdeId (matches) present in the vApp
 		if !vcdCluster.Status.VAppMetadataUpdated {
 			return ctrl.Result{}, errors.Errorf("Error occurred during the machine deletion; Metadata not found in vApp")
 		}
 		metadataInfraId, err := vdcManager.GetMetadataByKey(vApp, CapvcdInfraId)
-
+		if err != nil {
+			return ctrl.Result{}, errors.Errorf("Error occurred during fetching metadata in vApp")
+		}
 		// checking the metadata value and vcdCluster.Status.InfraId are equal or not
 		if metadataInfraId != vcdCluster.Status.InfraId {
-			if err != nil {
-				log.Error(err, fmt.Sprintf("Error occurred during the machine deletion; vApp [%s] matadata not found", vcdCluster.Name))
-			}
 			return ctrl.Result{}, errors.Wrapf(err,
 				"Error occurred during the machine deletion; failed to delete vApp [%s]", vcdCluster.Name)
 		}

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -843,9 +843,10 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 		if !vcdCluster.Status.VAppMetadataUpdated {
 			return ctrl.Result{}, errors.Errorf("Error occurred during the machine deletion; Metadata not found in vApp")
 		}
-		vAppMetadataFound, err := vdcManager.ValidateMetadata(vApp, CapvcdInfraId, vcdCluster.Status.InfraId)
+		metadataInfraId, err := vdcManager.GetMetadataByKey(vApp, CapvcdInfraId)
 
-		if !vAppMetadataFound {
+		// checking the metadata value and vcdCluster.Status.InfraId are equal or not
+		if metadataInfraId != vcdCluster.Status.InfraId {
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Error occurred during the machine deletion; vApp [%s] matadata not found", vcdCluster.Name))
 			}

--- a/pkg/vcdclient/vapp.go
+++ b/pkg/vcdclient/vapp.go
@@ -171,24 +171,20 @@ func (vdc *VdcManager) AddMetadataToVApp(vAppName string, paramMap map[string]st
 	return nil
 }
 
-func (vdc *VdcManager) ValidateMetadata(vApp *govcd.VApp, key string, value string) (bool, error) {
+func (vdc *VdcManager) GetMetadataByKey(vApp *govcd.VApp, key string) (value string, err error) {
 	if vApp == nil || vApp.VApp == nil {
-		return false, fmt.Errorf("found nil value for vApp")
+		return "", fmt.Errorf("found nil value for vApp")
 	}
 	metadata, err := vApp.GetMetadata()
 	if err != nil {
-		return false, fmt.Errorf("unable to get metadata from vApp")
+		return "", fmt.Errorf("unable to get metadata from vApp")
 	}
 	for _, metadataEntity := range metadata.MetadataEntry {
 		if key == metadataEntity.Key {
-			if metadataEntity.TypedValue != nil && value == metadataEntity.TypedValue.Value {
-				return true, nil
-			}
-			return false, fmt.Errorf("key-value pair:{%s, %s} not match", key, value)
+			return metadataEntity.TypedValue.Value, nil
 		}
 	}
-	return false, fmt.Errorf("metadata record not found for {%s, %s}", key, value)
-
+	return "", fmt.Errorf("metadata record not found for {%s, %s}", key, value)
 }
 
 func (vdc *VdcManager) isVappNetworkPresentInVapp(vApp *govcd.VApp, ovdcNetworkName string) bool {

--- a/pkg/vcdclient/vapp.go
+++ b/pkg/vcdclient/vapp.go
@@ -171,6 +171,26 @@ func (vdc *VdcManager) AddMetadataToVApp(vAppName string, paramMap map[string]st
 	return nil
 }
 
+func (vdc *VdcManager) ValidateMetadata(vApp *govcd.VApp, key string, value string) (bool, error) {
+	if vApp == nil || vApp.VApp == nil {
+		return false, fmt.Errorf("found nil value for vApp")
+	}
+	metadata, err := vApp.GetMetadata()
+	if err != nil {
+		return false, fmt.Errorf("unable to get metadata from vApp")
+	}
+	for _, metadataEntity := range metadata.MetadataEntry {
+		if key == metadataEntity.Key {
+			if metadataEntity.TypedValue != nil && value == metadataEntity.TypedValue.Value {
+				return true, nil
+			}
+			return false, fmt.Errorf("key-value pair:{%s, %s} not match", key, value)
+		}
+	}
+	return false, fmt.Errorf("metadata record not found for {%s, %s}", key, value)
+
+}
+
 func (vdc *VdcManager) isVappNetworkPresentInVapp(vApp *govcd.VApp, ovdcNetworkName string) bool {
 	if vApp == nil || vApp.VApp == nil {
 		klog.Error("found nil value for vApp")


### PR DESCRIPTION
* During delete cluster operation, delete the vApp if and only if vApp has the ```InfraId``` as metadata property.
* Created a generic validation function in vApp.go to check whether a key-value pair is matched in vApp's metadata.
* Test Done:
1. If vAppmetadataUpdated is true, deletion process will be in stuck.
2. In current version, vAppmetadataUpdate will not be reset until the deletion process is done.
3. If InfraId is mismatched, deletion process will be in stuck and customers could see error hint in logs.

* To summarize, customers have choice to keep any component they want (vApp, VMs, load balance components).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/110)
<!-- Reviewable:end -->
