### PR TITLE
[VCDA-3603] Fix sysadmin cluster creation

### DIFF
--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -72,7 +72,7 @@ type CloudConfig struct {
 	ClusterResources       ClusterResourcesConfig `yaml:"clusterResourceSet"`
 }
 
-func getUserAndOrg(fullUserName string, clusterOrg string) (userOrg string, userName string, err error) {
+func GetUserAndOrg(fullUserName string, clusterOrg string) (userOrg string, userName string, err error) {
 	// If the full username is specified as org/user, the scenario is that the user
 	// may belong to an org different from the cluster, but still has the
 	// necessary rights to view the VMs on this org. Else if the username is
@@ -138,7 +138,7 @@ func SetAuthorization(config *CloudConfig) error {
 	} else {
 		trimmedUserName := strings.TrimSuffix(string(username), "\n")
 		if string(trimmedUserName) != "" {
-			config.VCD.UserOrg, config.VCD.User, err = getUserAndOrg(trimmedUserName, config.VCD.Org)
+			config.VCD.UserOrg, config.VCD.User, err = GetUserAndOrg(trimmedUserName, config.VCD.Org)
 			if err != nil {
 				return fmt.Errorf("unable to get user org and name: [%v]", err)
 			}

--- a/pkg/config/cloudconfig.go
+++ b/pkg/config/cloudconfig.go
@@ -72,7 +72,7 @@ type CloudConfig struct {
 	ClusterResources       ClusterResourcesConfig `yaml:"clusterResourceSet"`
 }
 
-func GetUserAndOrg(fullUserName string, clusterOrg string) (userOrg string, userName string, err error) {
+func GetUserAndOrg(fullUserName string, clusterOrg string, currentUserOrg string) (userOrg string, userName string, err error) {
 	// If the full username is specified as org/user, the scenario is that the user
 	// may belong to an org different from the cluster, but still has the
 	// necessary rights to view the VMs on this org. Else if the username is
@@ -84,8 +84,13 @@ func GetUserAndOrg(fullUserName string, clusterOrg string) (userOrg string, user
 			"invalid username format; expected at most two fields separated by /, obtained [%d]",
 			len(parts))
 	}
+	// userOrg will fallback to clusterOrg if currentUserOrg does not exist, this allows auth to continue successfully
 	if len(parts) == 1 {
-		userOrg = clusterOrg
+		if currentUserOrg == "" {
+			userOrg = clusterOrg
+		} else {
+			userOrg = currentUserOrg
+		}
 		userName = parts[0]
 	} else {
 		userOrg = parts[0]
@@ -138,7 +143,7 @@ func SetAuthorization(config *CloudConfig) error {
 	} else {
 		trimmedUserName := strings.TrimSuffix(string(username), "\n")
 		if string(trimmedUserName) != "" {
-			config.VCD.UserOrg, config.VCD.User, err = GetUserAndOrg(trimmedUserName, config.VCD.Org)
+			config.VCD.UserOrg, config.VCD.User, err = GetUserAndOrg(trimmedUserName, config.VCD.Org, config.VCD.UserOrg)
 			if err != nil {
 				return fmt.Errorf("unable to get user org and name: [%v]", err)
 			}

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -122,7 +122,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, orgName, userOrg)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing username before authenticating to VCD: [%v]", err)
+		return nil, fmt.Errorf("error parsing username before authenticating to VCD: [%v]", err)
 	}
 
 	// We need to get a client every time here rather than reusing the older client, since we can have the same worker

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -116,7 +116,11 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	csiVersion string, cpiVersion string, cniVersion string, capvcdVersion string) (*Client, error) {
 
 	// TODO: validation of parameters
-	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, orgName)
+
+	// We need username, clusterOrg, userOrg for additional fallback as cloudConfig params to client creation in correct format already
+	// ex: username: system/administrator -> user: administrator, userOrg: system, org: org1
+	// By using GetUserAndOrg(username, orgName) this would overwrite userOrg from system to org1
+	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, orgName, userOrg)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing username before authenticating to VCD: [%v]", err)

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -117,7 +117,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	// TODO: validation of parameters
 
 	// When getting the client from main.go, the user, orgName, userOrg would have correct values due to config.SetAuthorization()
-	// when user is sys/admin, userOrg and orgName to have different values, hence we need an additional parameter check to prevent overwrite
+	// when user is sys/admin, userOrg and orgName will have different values, hence we need an additional parameter check to prevent overwrite
 	// as now user='admin' and userOrg='system', we would enter the fallback to clusterOrg which would return userOrg=clusterOrg
 	// so if userOrg is already set, we want the updated fallback to userOrg first which could fall back to clusterOrg if empty
 	// In vcdcluster controller's case, both orgName and userOrg will be the same as we pass in vcdcluster.Spec.Org to both

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -116,9 +116,13 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 
 	// TODO: validation of parameters
 
-	// We need username, clusterOrg, userOrg for additional fallback as cloudConfig params to client creation in correct format already
-	// ex: username: system/administrator -> user: administrator, userOrg: system, org: org1
-	// By using GetUserAndOrg(username, orgName) this would overwrite userOrg from system to org1
+	// When getting the client from main.go, the user, orgName, userOrg would have correct values due to config.SetAuthorization()
+	// when user is sys/admin, userOrg and orgName to have different values, hence we need an additional parameter check to prevent overwrite
+	// as now user='admin' and userOrg='system', we would enter the fallback to clusterOrg which would return userOrg=clusterOrg
+	// so if userOrg is already set, we want the updated fallback to userOrg first which could fall back to clusterOrg if empty
+	// In vcdcluster controller's case, both orgName and userOrg will be the same as we pass in vcdcluster.Spec.Org to both
+	// but since username is still 'sys/admin', we will return correctly
+
 	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, orgName, userOrg)
 
 	if err != nil {

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -108,7 +108,7 @@ func (client *Client) RefreshBearerToken() error {
 	return nil
 }
 
-// NewVCDClientFromSecrets :
+// TODO: Remove userOrg as a param as it's not used
 func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppName string,
 	networkName string, ipamSubnet string, userOrg string, user string, password string,
 	refreshToken string, insecure bool, clusterID string, oneArm *OneArm, httpPort int32,
@@ -116,7 +116,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	csiVersion string, cpiVersion string, cniVersion string, capvcdVersion string) (*Client, error) {
 
 	// TODO: validation of parameters
-	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, userOrg)
+	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, orgName)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing username before authenticating to VCD: [%v]", err)

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -119,7 +119,7 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, userOrg)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing username [%v]", err)
+		return nil, fmt.Errorf("Error parsing username before authenticating to VCD: [%v]", err)
 	}
 
 	// We need to get a client every time here rather than reusing the older client, since we can have the same worker

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -108,7 +108,6 @@ func (client *Client) RefreshBearerToken() error {
 	return nil
 }
 
-// TODO: Remove userOrg as a param as it's not used
 func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppName string,
 	networkName string, ipamSubnet string, userOrg string, user string, password string,
 	refreshToken string, insecure bool, clusterID string, oneArm *OneArm, httpPort int32,

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/vmware/cluster-api-provider-cloud-director/pkg/config"
 	"k8s.io/klog"
 	"net/http"
 	"sync"
@@ -115,10 +116,15 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, vAppNa
 	csiVersion string, cpiVersion string, cniVersion string, capvcdVersion string) (*Client, error) {
 
 	// TODO: validation of parameters
+	updatedUserOrg, updatedUserName, err := config.GetUserAndOrg(user, userOrg)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing username [%v]", err)
+	}
 
 	// We need to get a client every time here rather than reusing the older client, since we can have the same worker
 	// working on different userContexts
-	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, user, password, refreshToken, userOrg, insecure)
+	vcdAuthConfig := NewVCDAuthConfigFromSecrets(host, updatedUserName, password, refreshToken, updatedUserOrg, insecure)
 
 	vcdClient, apiClient, err := vcdAuthConfig.GetSwaggerClientFromSecrets()
 	if err != nil {


### PR DESCRIPTION
* Publicized config helper function to re-use in client
* Pass in `system/administrator` as `userOrg: system`, `username: administrator` to AuthConfig instead of passing entire string
* Testing done:
    - Successfully created and deleted cluster with SysAdmin CAPVCD credentials, and `system/administrator` in capi.yaml
    - Successfully created and deleted cluster with SysAdmin CAPVCD credentials, and tenant user in capi.yaml
    - Successfully created and deleted cluster with tenant admin CAPVCD credentials, and tenant user in capi.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/117)
<!-- Reviewable:end -->
