### PR TITLE
[VCDA-3475] Fix refresh token issue with system admin when username is not provided

### DIFF
--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 type authorizationDetails struct {
-	Username string `yaml:"username"`
-	Password string `yaml:"password"`
-	RefreshToken string `yaml:"refreshToken"`
-	UserOrg string `yaml:"userOrg"`
-	SystemUser string `yaml:"systemUser"`
-	SystemUserPassword string `yaml:"systemUserPassword"`
+	Username               string `yaml:"username"`
+	Password               string `yaml:"password"`
+	RefreshToken           string `yaml:"refreshToken"`
+	UserOrg                string `yaml:"userOrg"`
+	SystemUser             string `yaml:"systemUser"`
+	SystemUserPassword     string `yaml:"systemUserPassword"`
 	SystemUserRefreshToken string `yaml:"systemUserRefreshToken"`
 }
 
@@ -59,11 +59,10 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.RefreshToken,
-		"userOrg": authDetails.UserOrg,
+		"userOrg":      authDetails.UserOrg,
 	})
 	assert.NoError(t, err, "Unable to get VCD Client")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
-
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"host":         "https://some-random-address",
@@ -112,7 +111,7 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"refreshToken": authDetails.SystemUserRefreshToken,
-		"userOrg": "system",
+		"userOrg":      "system",
 	})
 	assert.NoError(t, err, "Unable to get VCD client for system administrator")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")

--- a/pkg/vcdclient/auth_system_test.go
+++ b/pkg/vcdclient/auth_system_test.go
@@ -40,18 +40,20 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 	assert.NoError(t, err, "There should be no error parsing auth file content.")
 
 	vcdClient, err := getTestVCDClient(map[string]interface{}{
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
+		"refreshToken": "",
 	})
 	assert.NoError(t, err, "Unable to get VCD client")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
 		"getVdcClient": true,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
+		"refreshToken": "",
 	})
 	assert.NoError(t, err, "Unable to get Client with VDC details.")
 
@@ -64,42 +66,47 @@ func TestNewVCDAuthConfigFromSecrets(t *testing.T) {
 
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"host": "https://some-random-address",
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"host":         "https://some-random-address",
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
+		"refreshToken": "",
 	})
 	assert.Error(t, err, "Error should be obtained for url [https://some-random-address]")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"network": "",
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"network":      "",
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
+		"refreshToken": "",
 	})
 	assert.Error(t, err, "Error should be obtained for missing network")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"oneArm": nil,
-		"user": authDetails.Username,
-		"secret": authDetails.Password,
-		"userOrg": authDetails.UserOrg,
+		"oneArm":       nil,
+		"user":         authDetails.Username,
+		"secret":       authDetails.Password,
+		"userOrg":      authDetails.UserOrg,
+		"refreshToken": "",
 	})
 	assert.NoError(t, err, "There should be no error for missing OneArm")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
-		"userOrg": "system",
+		"user":         authDetails.SystemUser,
+		"secret":       authDetails.SystemUserPassword,
+		"userOrg":      "system",
+		"refreshToken": "",
 	})
 	assert.NoError(t, err, "Unable to get VCD client for system administrator")
 	assert.NotNil(t, vcdClient, "VCD Client should not be nil")
 
 	vcdClient, err = getTestVCDClient(map[string]interface{}{
-		"user": authDetails.SystemUser,
-		"secret": authDetails.SystemUserPassword,
-		"userOrg": "system",
-		"network": "",
+		"user":         authDetails.SystemUser,
+		"secret":       authDetails.SystemUserPassword,
+		"userOrg":      "system",
+		"network":      "",
+		"refreshToken": "",
 	})
 	assert.Error(t, err, "Error should be obtained for missing network")
 

--- a/pkg/vcdclient/client.go
+++ b/pkg/vcdclient/client.go
@@ -58,11 +58,15 @@ func (client *Client) RefreshBearerToken() error {
 
 	klog.V(3).Infof("Is user sysadmin: [%v]", client.VcdClient.Client.IsSysAdmin)
 	if client.VcdAuthConfig.RefreshToken != "" {
-		// Refresh vcd client using refresh token
-		err := client.VcdClient.SetToken(client.VcdAuthConfig.UserOrg,
+		userOrg := client.VcdAuthConfig.UserOrg
+		if client.VcdAuthConfig.IsSysAdmin {
+			userOrg = "system"
+		}
+		// Refresh vcd client using refresh token as system org user
+		err := client.VcdClient.SetToken(userOrg,
 			govcd.ApiTokenHeader, client.VcdAuthConfig.RefreshToken)
 		if err != nil {
-			return fmt.Errorf("failed to set authorization header: [%v]", err)
+			return fmt.Errorf("failed to refresh VCD client with the refresh token: [%v]", err)
 		}
 	} else if client.VcdAuthConfig.User != "" && client.VcdAuthConfig.Password != "" {
 		// Refresh vcd client using username and password
@@ -87,7 +91,7 @@ func (client *Client) RefreshBearerToken() error {
 
 	vdc, err := org.GetVDCByName(client.ClusterOVDCName, true)
 	if err != nil {
-		return fmt.Errorf("unable to get vdc from org [%s], vdc [%s]: [%v]",
+		return fmt.Errorf("unable to get VDC from org [%s], VDC [%s]: [%v]",
 			client.ClusterOrgName, client.VcdAuthConfig.VDC, err)
 	}
 	client.Vdc = vdc

--- a/pkg/vcdclient/common_system_test.go
+++ b/pkg/vcdclient/common_system_test.go
@@ -13,14 +13,27 @@ package vcdclient
 import (
 	"fmt"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/config"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
 	gitRoot string = ""
 )
+
+type VcdInfo struct {
+	Host         string `yaml:"host"`
+	TenantOrg    string `yaml:"tenantOrg"`
+	TenantVdc    string `yaml:"tenantVdc"`
+	OvdcNetwork  string `yaml:"ovdcNetwork"`
+	User         string `yaml:"user"`
+	UserOrg      string `yaml:"userOrg"`
+	Password     string `yaml:"password"`
+	RefreshToken string `yaml:"refreshToken"`
+}
 
 func init() {
 	gitRoot = os.Getenv("GITROOT")
@@ -64,6 +77,20 @@ func getInt32ValStrict(val interface{}, defaultVal int32) int32 {
 
 func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 
+	// "testdata/vcd_info.yaml" contains VCD details
+	testVcdInfoFilePath := filepath.Join(gitRoot, "testdata/vcd_info.yaml")
+	vcdInfoContent, err := ioutil.ReadFile(testVcdInfoFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading the vcd_info.yaml file contents: [%v]", err)
+	}
+
+	var vcdInfo VcdInfo
+	err = yaml.Unmarshal(vcdInfoContent, &vcdInfo)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing vcd_info.yaml file content: [%v]", err)
+	}
+
+	// "testdata/config_test.yaml" contains all the information that can be passed in as the config map
 	testConfigFilePath := filepath.Join(gitRoot, "testdata/config_test.yaml")
 	capvcdVersionFile := filepath.Join(gitRoot, "release/version")
 	capvcdVersion, err := ioutil.ReadFile(capvcdVersionFile)
@@ -72,7 +99,7 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 	}
 	configReader, err := os.Open(testConfigFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to open file [%s]: [%v]", testConfigFilePath, err)
+		return nil, fmt.Errorf("unable to open file [%s]: [%v]", testConfigFilePath, err)
 	}
 	defer configReader.Close()
 
@@ -91,20 +118,21 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 		for key, val := range inputMap {
 			switch key {
 			case "host":
-				cloudConfig.VCD.Host = getStrValStrict(val, cloudConfig.VCD.Host)
+				vcdInfo.Host = getStrValStrict(val, vcdInfo.Host)
+				vcdInfo.Host = strings.TrimRight(vcdInfo.Host, "/")
 			case "org":
-				cloudConfig.VCD.Org = getStrValStrict(val, cloudConfig.VCD.Org)
+				vcdInfo.TenantOrg = getStrValStrict(val, vcdInfo.TenantOrg)
 			case "network":
-				cloudConfig.VCD.VDCNetwork = getStrValStrict(val, cloudConfig.VCD.VDCNetwork)
+				vcdInfo.OvdcNetwork = getStrValStrict(val, vcdInfo.OvdcNetwork)
 			case "subnet":
 				cloudConfig.VCD.VIPSubnet = getStrValStrict(val, cloudConfig.VCD.VIPSubnet)
 			case "user":
-				cloudConfig.VCD.User = getStrValStrict(val, cloudConfig.VCD.User)
+				vcdInfo.User = getStrValStrict(val, vcdInfo.User)
 			case "secret":
-				cloudConfig.VCD.Secret = getStrValStrict(val, cloudConfig.VCD.Secret)
+				vcdInfo.Password = getStrValStrict(val, vcdInfo.Password)
 			case "userOrg":
-				// default to cloudConfig.VCD.Org if val is empty
-				cloudConfig.VCD.UserOrg = getStrValStrict(val, cloudConfig.VCD.UserOrg)
+				// default to userOrg if val is empty
+				vcdInfo.UserOrg = getStrValStrict(val, vcdInfo.UserOrg)
 			case "insecure":
 				insecure = getBoolValStrict(val, true)
 			case "clusterID":
@@ -119,21 +147,23 @@ func getTestVCDClient(inputMap map[string]interface{}) (*Client, error) {
 				cloudConfig.LB.Ports.TCP = getInt32ValStrict(val, cloudConfig.LB.Ports.TCP)
 			case "getVdcClient":
 				getVdcClient = getBoolValStrict(val, false)
+			case "refreshToken":
+				vcdInfo.RefreshToken = getStrValStrict(val, cloudConfig.VCD.RefreshToken)
 			}
 		}
 	}
 
 	return NewVCDClientFromSecrets(
-		cloudConfig.VCD.Host,
-		cloudConfig.VCD.Org,
-		cloudConfig.VCD.VDC,
+		vcdInfo.Host,
+		vcdInfo.TenantOrg,
+		vcdInfo.TenantVdc,
 		"",
-		cloudConfig.VCD.VDCNetwork,
+		vcdInfo.OvdcNetwork,
 		cloudConfig.VCD.VIPSubnet,
-		cloudConfig.VCD.UserOrg,
-		cloudConfig.VCD.User,
-		cloudConfig.VCD.Secret,
-		cloudConfig.VCD.RefreshToken,
+		vcdInfo.UserOrg,
+		vcdInfo.User,
+		vcdInfo.Password,
+		vcdInfo.RefreshToken,
 		insecure,
 		cloudConfig.ClusterID,
 		oneArm,

--- a/testdata/auth_test.yaml
+++ b/testdata/auth_test.yaml
@@ -1,3 +1,4 @@
+# This file contains test data override information for tests in auth_system_test.go
 username: "tenant-user-name"
 password: "tenant-password"
 userOrg: "tenant-org"

--- a/testdata/config_test.yaml
+++ b/testdata/config_test.yaml
@@ -1,3 +1,4 @@
+# This file contains information that can be passed as input to CAPVCD via controller_manager_config config map.
 vcd:
   host: VCD_HOST
   org: ORG

--- a/testdata/vcd_info.yaml
+++ b/testdata/vcd_info.yaml
@@ -1,0 +1,9 @@
+# This file contains the information that needs to be passed to create the client for the tests
+host: "vcd-host-url"
+tenantOrg: "tenant-org"
+tenantVdc: "tenant-ovdc"
+ovdcNetwork: "tenant-ovdc-network"
+user: "username"
+userOrg: "user-org"
+password: "secret"
+refreshToken: "refreshToken"


### PR DESCRIPTION
* when authenticating using refresh token, follow the following steps
* authenticate as a system org user
* if the above step fails, authenticate as a tenant user
* this PR also fixes authentication based tests which were broken

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/119)
<!-- Reviewable:end -->
