### PR TITLE
VCDA-3661: Move from Update to Patch while updating the field status.infraId.

### DIFF
--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -84,6 +84,7 @@ type VCDClusterStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Ready denotes that the vcd cluster (infrastructure) is ready.
+	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
 	// MetadataUpdated denotes that the metadata of Vapp is updated.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -270,6 +270,7 @@ spec:
               parentUid:
                 type: string
               ready:
+                default: false
                 description: Ready denotes that the vcd cluster (infrastructure) is
                   ready.
                 type: boolean

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -552,12 +552,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// If the vcdClusterObject does not have the InfraId set, we need to set it. If it has one, we can reuse it.
 	if vcdCluster.Status.InfraId == "" {
-		// We need to set the Status.Ready to true and then reset it in order to get a differential for the Patch.
-		// Because if the Ready is not in the differential patch, there is an admission controller that fails.
-		// So we do something idiotic.
-		vcdCluster.Status.Ready = !vcdCluster.Status.Ready
 		oldVCDCluster := vcdCluster.DeepCopy()
-		vcdCluster.Status.Ready = !oldVCDCluster.Status.Ready
 
 		vcdCluster.Status.InfraId = infraID
 		if err := r.Status().Patch(ctx, vcdCluster, client.MergeFrom(oldVCDCluster)); err != nil {

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -550,12 +550,19 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		infraID = noRDEID
 	}
 
+	// If the vcdClusterObject does not have the InfraId set, we need to set it. If it has one, we can reuse it.
 	if vcdCluster.Status.InfraId == "" {
-		// This implies we have to set the infraID into the vcdCluster Object.
+		// We need to set the Status.Ready to true and then reset it in order to get a differential for the Patch.
+		// Because if the Ready is not in the differential patch, there is an admission controller that fails.
+		// So we do something idiotic.
+		vcdCluster.Status.Ready = !vcdCluster.Status.Ready
+		oldVCDCluster := vcdCluster.DeepCopy()
+		vcdCluster.Status.Ready = !oldVCDCluster.Status.Ready
+
 		vcdCluster.Status.InfraId = infraID
-		if err := r.Status().Update(ctx, vcdCluster); err != nil {
+		if err := r.Status().Patch(ctx, vcdCluster, client.MergeFrom(oldVCDCluster)); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
-				"unable to update status of vcdCluster [%s] with InfraID [%s]",
+				"unable to patch status of vcdCluster [%s] with InfraID [%s]",
 				vcdCluster.Name, infraID)
 		}
 		// Also update the client created already so that the CPI etc have the clusterID.


### PR DESCRIPTION
We were using the Update earlier which is fine for the Status() field and nobody else updates it at this point. We did not use Patch since there was an admission controller on Ready that failed.

~In this PR we trick the admission controller and provide the Ready also in the differential, and update what we need with the right `Ready` value.~

Edit: Later trials indicated that there was no use of this hack. I will commit this for now. If someone finds the issue again, we have a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/138)
<!-- Reviewable:end -->
