### PR TITLE
VCDA-3713: keep control-plane IP list without repetitions. This could

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/troubleshoot/pkg/redact"
+	cpiutil "github.com/vmware/cloud-provider-for-cloud-director/pkg/util"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	infrav1 "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/capisdk"
@@ -620,7 +621,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 
 		updatedIPs := append(controlPlaneIPs, machineAddress)
-		err = capvcdGatewayManager.UpdateLoadBalancer(ctx, lbPoolName, updatedIPs, int32(6443))
+		updatedUniqueIPs := cpiutil.NewSet(updatedIPs).GetElements()
+		err = capvcdGatewayManager.UpdateLoadBalancer(ctx, lbPoolName, updatedUniqueIPs, int32(6443))
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
 				"Error updating the load balancer pool [%s] for the "+

--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,13 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.31.4
 	github.com/stretchr/testify v1.7.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220512004601-80e15abccd7d
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220519234318-2fb355a5863c
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6
 	k8s.io/client-go v0.23.6
 	k8s.io/klog v1.0.0
-	k8s.io/klog/v2 v2.60.1
 	sigs.k8s.io/cluster-api v1.1.3
 	sigs.k8s.io/controller-runtime v0.11.2
 )
@@ -90,6 +89,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/cluster-bootstrap v0.23.0 // indirect
 	k8s.io/component-base v0.23.5 // indirect
+	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -520,6 +520,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220512004601-80e15abccd7d h1:xjjs+/vQboXBAxUEh1c6pZRxuwENm1g3MjI0awGwM5s=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220512004601-80e15abccd7d/go.mod h1:rnauVYaw45r+LZVU3D2vwrcsl2QjpYfGkox83zFY144=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220519234318-2fb355a5863c h1:ULe2GbOyX/1wTfzelWUFa/i6YzGOdqmcSBIENYKCkw4=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220519234318-2fb355a5863c/go.mod h1:rnauVYaw45r+LZVU3D2vwrcsl2QjpYfGkox83zFY144=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/defined_entity_util.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/defined_entity_util.go
@@ -1,0 +1,90 @@
+package util
+
+import (
+	"fmt"
+	swaggerClient "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
+	"strings"
+)
+
+const (
+	CAPVCDEntityTypeVendor = "vmware"
+	CAPVCDEntityTypeNss    = "capvcdCluster"
+
+	NativeClusterEntityTypeVendor = "cse"
+	NativeClusterEntityTypeNss    = "nativeCluster"
+)
+
+func isCAPVCDEntityType(entityTypeID string) bool {
+	entityTypeIDSplit := strings.Split(entityTypeID, ":")
+	// format is urn:vcloud:type:<vendor>:<nss>:<version>
+	if len(entityTypeIDSplit) != 6 {
+		return false
+	}
+	return entityTypeIDSplit[3] == CAPVCDEntityTypeVendor && entityTypeIDSplit[4] == CAPVCDEntityTypeNss
+}
+
+func isNativeClusterEntityType(entityTypeID string) bool {
+	entityTypeIDSplit := strings.Split(entityTypeID, ":")
+	// format is urn:vcloud:type:<vendor>:<nss>:<version>
+	if len(entityTypeIDSplit) != 6 {
+		return false
+	}
+	return entityTypeIDSplit[3] == NativeClusterEntityTypeVendor && entityTypeIDSplit[4] == NativeClusterEntityTypeNss
+}
+
+func GetVirtualIPsFromRDE(rde *swaggerClient.DefinedEntity) ([]string, error) {
+	statusEntry, ok := rde.Entity["status"]
+	if !ok {
+		return nil, fmt.Errorf("could not find 'status' entry in defined entity")
+	}
+	statusMap, ok := statusEntry.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert [%T] to map", statusEntry)
+	}
+
+	var virtualIpInterfaces interface{}
+	if isCAPVCDEntityType(rde.EntityType) {
+		virtualIpInterfaces = statusMap["virtualIPs"]
+	} else if isNativeClusterEntityType(rde.EntityType) {
+		virtualIpInterfaces = statusMap["virtual_IPs"]
+	} else {
+		return nil, fmt.Errorf("entity type %s not supported by CPI", rde.EntityType)
+	}
+
+	if virtualIpInterfaces == nil {
+		return make([]string, 0), nil
+	}
+
+	virtualIpInterfacesSlice, ok := virtualIpInterfaces.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert [%T] to slice of interface", virtualIpInterfaces)
+	}
+	virtualIpStrs := make([]string, len(virtualIpInterfacesSlice))
+	for ind, ipInterface := range virtualIpInterfacesSlice {
+		currIp, ok := ipInterface.(string)
+		if !ok {
+			return nil, fmt.Errorf("unable to convert [%T] to string", ipInterface)
+		}
+		virtualIpStrs[ind] = currIp
+	}
+	return virtualIpStrs, nil
+}
+
+// ReplaceVirtualIPsInRDE replaces the virtual IPs array in the inputted rde. It does not make an API call to update
+// the RDE.
+func ReplaceVirtualIPsInRDE(rde *swaggerClient.DefinedEntity, updatedIps []string) (*swaggerClient.DefinedEntity, error) {
+	statusEntry, ok := rde.Entity["status"]
+	if !ok {
+		return nil, fmt.Errorf("could not find 'status' entry in defined entity")
+	}
+	statusMap, ok := statusEntry.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert [%T] to map", statusEntry)
+	}
+	if isCAPVCDEntityType(rde.EntityType) {
+		statusMap["virtualIPs"] = updatedIps
+	} else if isNativeClusterEntityType(rde.EntityType) {
+		statusMap["virtual_IPs"] = updatedIps
+	}
+	return rde, nil
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/set.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/set.go
@@ -1,0 +1,72 @@
+/*
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import "sync"
+
+type Set struct {
+	lock sync.RWMutex
+	elements map[string]bool
+}
+
+func NewSet(elementList []string) Set {
+	s := Set{
+		elements: make(map[string]bool),
+	}
+
+	// No need for synchronization here since nobody else knows about `s` yet.
+	for _, element := range elementList {
+		s.elements[element] = true
+	}
+
+	return s
+}
+
+func (s Set) GetElements() []string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	elementList := make([]string, len(s.elements))
+	idx := 0
+	for key, _ := range s.elements {
+		elementList[idx] = key
+		idx ++
+	}
+
+	return elementList
+}
+
+func (s Set) Add(element string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, exists := s.elements[element]; exists {
+		return
+	}
+
+	s.elements[element] = true
+	return
+}
+
+func (s Set) Delete(element string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if _, exists := s.elements[element]; !exists {
+		return
+	}
+
+	delete(s.elements, element)
+	return
+}
+
+func (s Set) Contains(element string) bool {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	_, exists := s.elements[element]
+	return exists
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/util.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/util/util.go
@@ -1,0 +1,65 @@
+/*
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"github.com/vmware/go-vcloud-director/v2/util"
+	"io/ioutil"
+	"net/http"
+)
+
+// indentJsonBody indents raw JSON body for easier readability
+func indentJsonBody(body []byte) ([]byte, error) {
+	var prettyJSON bytes.Buffer
+	err := json.Indent(&prettyJSON, body, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error indenting response JSON: %s", err)
+	}
+	body = prettyJSON.Bytes()
+	return body, nil
+}
+
+// DecodeXMLBody is used to decode a response body of types.BodyType
+func DecodeXMLBody(bodyType types.BodyType, resp *http.Response, out interface{}) error {
+	body, err := ioutil.ReadAll(resp.Body)
+
+	// In case of JSON, body does not have indents in response therefore it must be indented
+	if bodyType == types.BodyTypeJSON {
+		body, err = indentJsonBody(body)
+		if err != nil {
+			return err
+		}
+	}
+
+	util.ProcessResponseOutput(util.FuncNameCallStack(), resp, fmt.Sprintf("%s", body))
+	if err != nil {
+		return err
+	}
+
+	// only attempt to unmarshal if body is not empty
+	if len(body) > 0 {
+		switch bodyType {
+		case types.BodyTypeXML:
+			if err = xml.Unmarshal(body, &out); err != nil {
+				return err
+			}
+		case types.BodyTypeJSON:
+			if err = json.Unmarshal(body, &out); err != nil {
+				return err
+			}
+
+		default:
+			panic(fmt.Sprintf("unknown body type: %d", bodyType))
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,8 +228,9 @@ github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.1
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220512004601-80e15abccd7d
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220519234318-2fb355a5863c
 ## explicit; go 1.17
+github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient
 # github.com/vmware/go-vcloud-director/v2 v2.15.0


### PR DESCRIPTION
occur if there is a failure in VM creation. The lbpool needs to be
created before the vm is powered on because the network route needs
to be ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/148)
<!-- Reviewable:end -->
