### PR TITLE
CAPVCD cluster creation bug because of `vcdCluster.Status.RdeInUse` key

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -272,7 +272,7 @@ spec:
               parentUid:
                 type: string
               rdeVersionInUse:
-                default: 1.0.0
+                default: 1.1.0
                 description: RdeVersionInUse indicates the version of capvcdCluster
                   entity type used by CAPVCD.
                 type: string

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -503,6 +503,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if vcdCluster.Status.InfraId == "" {
 		// This implies we have to set the infraID into the vcdCluster Object.
 		vcdCluster.Status.InfraId = infraID
+		vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
 		if err := r.Status().Update(ctx, vcdCluster); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
 				"unable to update status of vcdCluster [%s] with InfraID [%s]",

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -252,7 +252,7 @@ spec:
               parentUid:
                 type: string
               rdeVersionInUse:
-                default: 1.0.0
+                default: 1.1.0
                 description: RdeVersionInUse indicates the version of capvcdCluster entity type used by CAPVCD.
                 type: string
               ready:

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -383,7 +383,7 @@ func (capvcdRdeManager *CapvcdRdeManager) ConvertToLatestRDEVersionFormat(ctx co
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert RDE [%s] from source version [%s] to destination version [%s]",
-			srcRde.Id, srcRde.EntityType, dstRde.EntityType)
+			srcRde.Id, srcRde.EntityType, rdeType.CapvcdRDETypeVersion)
 	}
 
 	return dstRde, nil


### PR DESCRIPTION
* Status update will overwrite the default value.
* Set `vcdCluster.status.rdeInUse` to `1.1.0` before the status update

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/157)
<!-- Reviewable:end -->
