### PR TITLE
Update default csi version to 1.2.0

### DIFF
--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -17,6 +17,6 @@ loadbalancer:
 # Retrieve that RDEId using the API - https://VCD_IP/cloudapi/1.0.0/entities/types/vmware/capvcdCluster/1.0.0
 managementClusterRDEId: ""
 clusterResourceSet:
-  csi: 1.1.0 # CSI version to be used in the workload cluster
+  csi: 1.2.0 # CSI version to be used in the workload cluster
   cpi: 1.1.0 # CPI version to be used in the workload cluster
   cni: 0.11.3 # Antrea version to be used in the workload cluster


### PR DESCRIPTION
CSI in version 1.1.0 is buggy and fails to attach volumes to pods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/159)
<!-- Reviewable:end -->
