### PR TITLE
[VCDA-3811] Create node pool with details from kubernetes objects

### DIFF
--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -88,12 +88,22 @@ type VCDResource struct {
 	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
 }
 
+type NodePool struct {
+	Name            string            `json:"name,omitempty"`
+	SizingPolicy    string            `json:"sizingPolicy,omitempty"`
+	PlacementPolicy string            `json:"placementPolicy,omitempty"`
+	DiskSizeMb      int32             `json:"diskSizeMb,omitempty"`
+	NvidiaGpu       string            `json:"nvidiaGpu,omitempty"`
+	Replicas        int32             `json:"replicas,omitempty"`
+	NodeStatus      map[string]string `json:"nodeStatus,omitempty"`
+}
+
 type CAPVCDStatus struct {
 	Phase                  string            `json:"phase,omitempty"`
 	Kubernetes             string            `json:"kubernetes,omitempty"`
 	Uid                    string            `json:"uid,omitempty"`
 	ClusterAPIStatus       ClusterApiStatus  `json:"clusterApiStatus,omitempty"`
-	NodeStatus             map[string]string `json:"nodeStatus,omitempty"`
+	NodePool               []NodePool        `json:"nodePool,omitempty"`
 	CapvcdVersion          string            `json:"capvcdVersion,omitempty"`
 	UseAsManagementCluster bool              `json:"useAsManagementCluster,omitempty"`
 	Errors                 []string          `json:"errors,omitempty"`

--- a/schema/WIP_schema_1_1_0.json
+++ b/schema/WIP_schema_1_1_0.json
@@ -137,7 +137,7 @@
                 }
               }
             },
-            "nodeStatus": {
+            "nodePool": {
               "additionalProperties": {
                 "type": "string",
                 "properties": {}


### PR DESCRIPTION
* Add node pool with the following details - sizingPolicy, placementPolicy, nvidiaGpu (not populated), replicas, DiskSizeMb, and node status
* Approach -
* 1. get all machine deployments using the cluster label and namespace
* 2. use the machine deployments to fetch vcdmachine template
* 3. use the machine deployment label, cluster label and namespace to query all machines
* 4. populate all node pools info for all machine deployment (uses info from vcdmachine template and machines)

for control plane machines
1. get all kcp objects using the cluster label and namespace
2. use the kcp object to get vcdmachine template object
3. use cluster label and kcp namespace to retrieve all the machines associated with the kcp
4. populate node pools for control plane objects - (uses information from vcdmachine template and machines)

Testing done:
* Create a cluster and see if the values for nodepool is getting reconciled.
* Delete the machine deployment to see if the nodepools get removed.

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/162)
<!-- Reviewable:end -->
