### PR TITLE
[Bug Fix] Set VAppMetadataUpdated false if we need to create new vApp

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -642,6 +642,14 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	//Todo duplicate check
 
+	if vdcManager.Vdc == nil {
+		return ctrl.Result{}, errors.Errorf("no Vdc created with vdc manager name [%s]", vdcManager.Client.ClusterOVDCName)
+	}
+	_, err = vdcManager.Vdc.GetVAppByName(vcdCluster.Name, true)
+	if err != nil && err == govcd.ErrorEntityNotFound {
+		vcdCluster.Status.VAppMetadataUpdated = false
+	}
+
 	_, err = vdcManager.GetOrCreateVApp(vcdCluster.Name, vcdCluster.Spec.OvdcNetwork)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Error creating Infra vApp for the cluster [%s]: [%v]", vcdCluster.Name, err)


### PR DESCRIPTION
* Make sure every time an vApp is created, the metadata of vApp would be updated as well.
* Passed the testing: created new cluster -> delete vApp manually -> delete the whole cluster.
Signed-off-by: ymo24 <ymo@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/167)
<!-- Reviewable:end -->
