### PR TITLE
[VCDA-3860] correctly pull credentials from client auth config struct instead of cluster object

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -5,10 +5,10 @@ write_files: {{- if .ControlPlane }}
   content: |
     ---
     apiVersion: v1
-    data:
+    data: {{- if not .B64RefreshToken }}
       username: "{{ .B64OrgUser }}"
-      password: "{{ .B64Password }}"
-      refreshToken: "{{ .B64RefreshToken }}"
+      password: "{{ .B64Password }}" {{- else }}
+      refreshToken: "{{ .B64RefreshToken }}" {{- end }}
     kind: Secret
     metadata:
       name: vcloud-basic-auth

--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -5,9 +5,9 @@ write_files: {{- if .ControlPlane }}
   content: |
     ---
     apiVersion: v1
-    data: {{- if not .B64RefreshToken }}
+    data: {{- if and .B64OrgUser .B64Password }}
       username: "{{ .B64OrgUser }}"
-      password: "{{ .B64Password }}" {{- else }}
+      password: "{{ .B64Password }}" {{- end }}{{- if .B64RefreshToken }}
       refreshToken: "{{ .B64RefreshToken }}" {{- end }}
     kind: Secret
     metadata:

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -508,8 +508,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			cloudInitInput = CloudInitScriptInput{
 				ControlPlane:              true,
 				B64OrgUser:                b64.StdEncoding.EncodeToString([]byte(orgUserStr)),
-				B64Password:               b64.StdEncoding.EncodeToString([]byte(vcdCluster.Spec.UserCredentialsContext.Password)),
-				B64RefreshToken:           b64.StdEncoding.EncodeToString([]byte(vcdCluster.Spec.UserCredentialsContext.RefreshToken)),
+				B64Password:               b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.Password)),
+				B64RefreshToken:           b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.RefreshToken)),
 				K8sStorageClassName:       k8sStorageClassName,
 				ReclaimPolicy:             reclaimPolicy,
 				VcdStorageProfileName:     vcdStorageProfileName,


### PR DESCRIPTION
resolves https://github.com/vmware/cluster-api-provider-cloud-director/issues/171

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/172)
<!-- Reviewable:end -->
