### PR TITLE
VCDA-3865: Add move annotation to vcd infra objects

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,6 +1,8 @@
 commonLabels:
   cluster.x-k8s.io/v1beta1: v1beta1
   cluster.x-k8s.io/v1alpha4: v1alpha4
+  clusterctl.cluster.x-k8s.io: ""
+  clusterctl.cluster.x-k8s.io/move: ""
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.


### PR DESCRIPTION
This will enable move out of the box for VCD infra objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/173)
<!-- Reviewable:end -->
