### PR TITLE
[Bug fix] for empty clusterID in capvcdrdeManager

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -247,7 +247,7 @@ func (r *VCDClusterReconciler) constructAndCreateRDEFromCluster(ctx context.Cont
 func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *clusterv1.Cluster, vcdCluster *infrav1.VCDCluster, workloadVCDClient *vcdsdk.Client) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
 	_, capvcdSpec, capvcdMetadata, capvcdStatus, err := capvcdRdeManager.GetCAPVCDEntity(ctx, vcdCluster.Status.InfraId)
 	if err != nil {
 		return fmt.Errorf("failed to get RDE with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.InfraId, vcdCluster.Name, err)
@@ -439,7 +439,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// General note on RDE operations, always ensure CAPVCD cluster reconciliation progress
 	//is not affected by any RDE operation failures.
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
 
 	// Use the pre-created RDEId specified in the CAPI yaml specification.
 	// TODO validate if the RDE ID format is correct.
@@ -491,7 +491,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.V(3).Info("Reusing already available InfraID", "infraID", infraID)
 		if !strings.Contains(infraID, NoRdePrefix) && vcdCluster.Status.RdeVersionInUse != "" &&
 			vcdCluster.Status.RdeVersionInUse != rdeType.CapvcdRDETypeVersion {
-			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
 			log.Info("Upgrading RDE", "rdeID", infraID,
 				"targetRDEVersion", rdeType.CapvcdRDETypeVersion)
 			_, err = capvcdRdeManager.ConvertToLatestRDEVersionFormat(ctx, infraID)
@@ -650,7 +650,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	vcdCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
 		Host: controlPlaneNodeIP,
-		Port: int(r.Config.LB.Ports.TCP),
+		Port: 6443,
 	}
 	log.Info(fmt.Sprintf("Control plane endpoint for the cluster is [%s]", controlPlaneNodeIP))
 
@@ -691,8 +691,9 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		return ctrl.Result{}, errors.Wrapf(err,
 			"Error creating vdc manager to to reconcile vcd infrastructure for cluster [%s]", vcdCluster.Name)
 	}
-	//Todo duplicate check
-
+	metadataMap := map[string]string{
+		CapvcdInfraId: vcdCluster.Status.InfraId,
+	}
 	if vdcManager.Vdc == nil {
 		return ctrl.Result{}, errors.Errorf("no Vdc created with vdc manager name [%s]", vdcManager.Client.ClusterOVDCName)
 	}
@@ -711,6 +712,12 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	if clusterVApp == nil || clusterVApp.VApp == nil {
 		return ctrl.Result{}, errors.Wrapf(err, "found nil value for VApp [%s]", vcdCluster.Name)
+	}
+	if metadataMap != nil && len(metadataMap) > 0 && !vcdCluster.Status.VAppMetadataUpdated {
+		if err := vdcManager.AddMetadataToVApp(vcdCluster.Name, metadataMap); err != nil {
+			return ctrl.Result{}, fmt.Errorf("unable to add metadata [%s] to vApp [%s]: [%v]", metadataMap, vcdCluster.Name, err)
+		}
+		vcdCluster.Status.VAppMetadataUpdated = true
 	}
 	// Add VApp to VCDResourceSet
 	err = rdeManager.AddToVCDResourceSet(ctx, vcdsdk.ComponentCAPVCD, VCDResourceVApp,
@@ -769,7 +776,7 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 			"Error occurred during cluster deletion; unable to create client for the workload cluster [%s]",
 			vcdCluster.Name)
 	}
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
 
 	gateway, err := vcdsdk.NewGatewayManager(ctx, workloadVCDClient, vcdCluster.Spec.OvdcNetwork, r.Config.VCD.VIPSubnet)
 	if err != nil {
@@ -786,15 +793,16 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 			EndIP:   r.Config.LB.OneArm.EndIP,
 		}
 	}
+	resourcesAllocated := &vcdsdkutil.AllocatedResourcesMap{}
 	_, err = gateway.DeleteLoadBalancer(ctx, virtualServiceNamePrefix, lbPoolNamePrefix,
 		[]vcdsdk.PortDetails{
 			{
 				Protocol:     "TCP",
 				PortSuffix:   "tcp",
-				ExternalPort: r.Config.LB.Ports.TCP,
-				InternalPort: r.Config.LB.Ports.TCP,
+				ExternalPort: 6443,
+				InternalPort: 6443,
 			},
-		}, oneArm, nil)
+		}, oneArm, resourcesAllocated)
 	if err != nil {
 		err1 := capvcdRdeManager.AddToErrorSet(ctx, capisdk.LoadBalancerDeleteError, "", virtualServiceNamePrefix, fmt.Sprintf("%v", err))
 		if err1 != nil {

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -650,7 +650,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	vcdCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
 		Host: controlPlaneNodeIP,
-		Port: 6443,
+		Port: int(r.Config.LB.Ports.TCP),
 	}
 	log.Info(fmt.Sprintf("Control plane endpoint for the cluster is [%s]", controlPlaneNodeIP))
 
@@ -799,8 +799,8 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 			{
 				Protocol:     "TCP",
 				PortSuffix:   "tcp",
-				ExternalPort: 6443,
-				InternalPort: 6443,
+				ExternalPort: r.Config.LB.Ports.TCP,
+				InternalPort: r.Config.LB.Ports.TCP,
 			},
 		}, oneArm, resourcesAllocated)
 	if err != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -1068,8 +1068,8 @@ func (r *VCDMachineReconciler) VCDClusterToVCDMachines(o client.Object) []ctrl.R
 
 	return result
 }
-
-func (r *VCDMachineReconciler) hasCloudInitExecutionFailedBefore(ctx context.Context, workloadVCDClient *vcdsdk.Client, vm *govcd.VM) (bool, error) {
+func (r *VCDMachineReconciler) hasCloudInitExecutionFailedBefore(ctx context.Context,
+	workloadVCDClient *vcdsdk.Client, vm *govcd.VM) (bool, error) {
 	vdcManager, err := vcdsdk.NewVDCManager(workloadVCDClient, workloadVCDClient.ClusterOrgName,
 		workloadVCDClient.ClusterOVDCName)
 	if err != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -354,7 +354,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Unable to create VCD client to reconcile infrastructure for the Machine [%s]", machine.Name)
 	}
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
 	if vcdMachine.Spec.ProviderID != nil {
 		vcdMachine.Status.Ready = true
 		conditions.MarkTrue(vcdMachine, ContainerProvisionedCondition)
@@ -601,6 +601,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 		updatedIPs := append(controlPlaneIPs, machineAddress)
 		updatedUniqueIPs := cpiutil.NewSet(updatedIPs).GetElements()
+		resourcesAllocated := &cpiutil.AllocatedResourcesMap{}
 		var oneArm *vcdsdk.OneArm = nil
 		if vcdCluster.Spec.LoadBalancer.UseOneArm {
 			oneArm = &vcdsdk.OneArm{
@@ -611,7 +612,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
 		_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedUniqueIPs,
 			int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
-			oneArm, !vcdCluster.Spec.LoadBalancer.UseOneArm, nil)
+			oneArm, !vcdCluster.Spec.LoadBalancer.UseOneArm, resourcesAllocated)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
 				"Error updating the load balancer pool [%s] for the "+
@@ -828,7 +829,7 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 	}
 	workloadVCDClient, err := vcdsdk.NewVCDClientFromSecrets(vcdCluster.Spec.Site, vcdCluster.Spec.Org,
 		vcdCluster.Spec.Ovdc, vcdCluster.Spec.Org, userCreds.Username, userCreds.Password, userCreds.RefreshToken, true, true)
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient)
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Unable to create VCD client to reconcile infrastructure for the Machine [%s]", machine.Name)
 	}
@@ -870,7 +871,7 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 					updatedIPs = append(controlPlaneIPs[:i], controlPlaneIPs[i+1:]...)
 				}
 			}
-
+			resourcesAllocated := &cpiutil.AllocatedResourcesMap{}
 			var oneArm *vcdsdk.OneArm = nil
 			if vcdCluster.Spec.LoadBalancer.UseOneArm {
 				oneArm = &vcdsdk.OneArm{
@@ -881,7 +882,7 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
 			_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedIPs,
 				int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
-				oneArm, !vcdCluster.Spec.LoadBalancer.UseOneArm, nil)
+				oneArm, !vcdCluster.Spec.LoadBalancer.UseOneArm, resourcesAllocated)
 			if err != nil {
 				return ctrl.Result{}, errors.Wrapf(err,
 					"Error while deleting the infra resources of the machine [%s/%s]; error deleting the control plane from the load balancer pool [%s]",
@@ -1068,8 +1069,7 @@ func (r *VCDMachineReconciler) VCDClusterToVCDMachines(o client.Object) []ctrl.R
 	return result
 }
 
-func (r *VCDMachineReconciler) hasCloudInitExecutionFailedBefore(ctx context.Context,
-	workloadVCDClient *vcdsdk.Client, vm *govcd.VM) (bool, error) {
+func (r *VCDMachineReconciler) hasCloudInitExecutionFailedBefore(ctx context.Context, workloadVCDClient *vcdsdk.Client, vm *govcd.VM) (bool, error) {
 	vdcManager, err := vcdsdk.NewVDCManager(workloadVCDClient, workloadVCDClient.ClusterOrgName,
 		workloadVCDClient.ClusterOVDCName)
 	if err != nil {

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -81,14 +81,14 @@ type CapvcdRdeManager struct {
 	RdeManager *vcdsdk.RDEManager
 }
 
-func NewCapvcdRdeManager(client *vcdsdk.Client) *CapvcdRdeManager {
+func NewCapvcdRdeManager(client *vcdsdk.Client, clusterID string) *CapvcdRdeManager {
 	return &CapvcdRdeManager{
 		Client: client,
 		RdeManager: &vcdsdk.RDEManager{
 			Client:                 client,
 			StatusComponentName:    StatusComponentNameCAPVCD,
 			StatusComponentVersion: release.CAPVCDVersion,
-			ClusterID:              "",
+			ClusterID:              clusterID,
 		},
 	}
 }


### PR DESCRIPTION
* Bug fix for empty clusterID in capvcdrdeManager
* Add metadata (InfraId) into the vApp
Signed-off-by: ymo24 <ymo@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/176)
<!-- Reviewable:end -->
