### PR TITLE
VCDA-3752, 3753, 3855, 3871 : CRS for TKGm v1.5.4 and v1.4.2

### DIFF
--- a/tanzu/crs/v1.4.2/v1.4.2-antrea.yaml.template
+++ b/tanzu/crs/v1.4.2/v1.4.2-antrea.yaml.template
@@ -1,0 +1,2111 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-antrea
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-antrea-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  name: __CLUSTER_NAME__-antrea-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com
+    spec:
+      group: clusterinformation.antrea.tanzu.vmware.com
+      names:
+        kind: AntreaAgentInfo
+        plural: antreaagentinfos
+        shortNames:
+        - aai
+        singular: antreaagentinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
+    spec:
+      group: clusterinformation.antrea.tanzu.vmware.com
+      names:
+        kind: AntreaControllerInfo
+        plural: antreacontrollerinfos
+        shortNames:
+        - aci
+        singular: antreacontrollerinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clustergroups.core.antrea.tanzu.vmware.com
+    spec:
+      group: core.antrea.tanzu.vmware.com
+      names:
+        kind: ClusterGroup
+        plural: clustergroups
+        shortNames:
+        - cg
+        singular: group
+      scope: Cluster
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  externalEntitySelector:
+                    x-kubernetes-preserve-unknown-fields: true
+                  ipBlock:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                  namespaceSelector:
+                    x-kubernetes-preserve-unknown-fields: true
+                  podSelector:
+                    x-kubernetes-preserve-unknown-fields: true
+                  serviceReference:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: ClusterNetworkPolicy
+        plural: clusternetworkpolicies
+        shortNames:
+        - cnp
+        - acnp
+        singular: clusternetworkpolicy
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this ClusterNetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this ClusterNetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        namespaceSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                        podSelector:
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: externalentities.core.antrea.tanzu.vmware.com
+    spec:
+      group: core.antrea.tanzu.vmware.com
+      names:
+        kind: ExternalEntity
+        plural: externalentities
+        shortNames:
+        - ee
+        singular: externalentity
+      scope: Namespaced
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  endpoints:
+                    items:
+                      properties:
+                        ip:
+                          pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  externalNode:
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            type: object
+        served: false
+        storage: false
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: networkpolicies.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: NetworkPolicy
+        plural: networkpolicies
+        shortNames:
+        - netpol
+        - anp
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this Antrea NetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        podSelector:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                              podSelector:
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tierentitlementbindings.crd.antrea.tanzu.vmware.com
+    spec:
+      group: crd.antrea.tanzu.vmware.com
+      names:
+        kind: TierEntitlementBinding
+        plural: tierentitlementbindings
+        shortNames:
+        - teb
+        singular: tierentitlementbinding
+      scope: Cluster
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  subjects:
+                    items:
+                      properties:
+                        apiGroup:
+                          enum:
+                          - rbac.authorization.k8s.io
+                          type: string
+                        kind:
+                          enum:
+                          - User
+                          - Group
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  tierEntitlement:
+                    type: string
+                required:
+                - tierEntitlement
+                - subjects
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tierentitlements.crd.antrea.tanzu.vmware.com
+    spec:
+      group: crd.antrea.tanzu.vmware.com
+      names:
+        kind: TierEntitlement
+        plural: tierentitlements
+        shortNames:
+        - te
+        singular: tierentitlement
+      scope: Cluster
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  permission:
+                    enum:
+                    - edit
+                    - read
+                    type: string
+                  tiers:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - permission
+                - tiers
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tiers.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: Tier
+        plural: tiers
+        shortNames:
+        - tr
+        singular: tier
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Priority of this Tier relative to other Tiers.
+          jsonPath: .spec.priority
+          name: Priority
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  description:
+                    type: string
+                  priority:
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                required:
+                - priority
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: traceflows.ops.antrea.tanzu.vmware.com
+    spec:
+      group: ops.antrea.tanzu.vmware.com
+      names:
+        kind: Traceflow
+        plural: traceflows
+        shortNames:
+        - tf
+        singular: traceflow
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The phase of the Traceflow.
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: The name of the source Pod.
+          jsonPath: .spec.source.pod
+          name: Source-Pod
+          priority: 10
+          type: string
+        - description: The name of the destination Pod.
+          jsonPath: .spec.destination.pod
+          name: Destination-Pod
+          priority: 10
+          type: string
+        - description: The IP address of the destination.
+          jsonPath: .spec.destination.ip
+          name: Destination-IP
+          priority: 10
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  destination:
+                    oneOf:
+                    - required:
+                      - pod
+                      - namespace
+                    - required:
+                      - service
+                      - namespace
+                    - required:
+                      - ip
+                    properties:
+                      ip:
+                        pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
+                        type: string
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                      service:
+                        type: string
+                    type: object
+                  packet:
+                    properties:
+                      ipHeader:
+                        properties:
+                          flags:
+                            type: integer
+                          protocol:
+                            type: integer
+                          srcIP:
+                            pattern: ^(((([1]?\d)?\d|2[0-4]\d|25[0-5])\.){3}(([1]?\d)?\d|2[0-4]\d|25[0-5]))|([\da-fA-F]{1,4}(\:[\da-fA-F]{1,4}){7})|(([\da-fA-F]{1,4}:){0,5}::([\da-fA-F]{1,4}:){0,5}[\da-fA-F]{1,4})$
+                            type: string
+                          ttl:
+                            type: integer
+                        type: object
+                      ipv6Header:
+                        properties:
+                          hopLimit:
+                            type: integer
+                          nextHeader:
+                            type: integer
+                          srcIP:
+                            format: ipv6
+                            type: string
+                        type: object
+                      transportHeader:
+                        properties:
+                          icmp:
+                            properties:
+                              id:
+                                type: integer
+                              sequence:
+                                type: integer
+                            type: object
+                          tcp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              flags:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                          udp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  source:
+                    properties:
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                    required:
+                    - pod
+                    - namespace
+                    type: object
+                required:
+                - source
+                - destination
+                type: object
+              status:
+                properties:
+                  dataplaneTag:
+                    type: integer
+                  phase:
+                    type: string
+                  reason:
+                    type: string
+                  results:
+                    items:
+                      properties:
+                        node:
+                          type: string
+                        observations:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              component:
+                                type: string
+                              componentInfo:
+                                type: string
+                              dstMAC:
+                                type: string
+                              networkPolicy:
+                                type: string
+                              pod:
+                                type: string
+                              translatedDstIP:
+                                type: string
+                              translatedSrcIP:
+                                type: string
+                              ttl:
+                                type: integer
+                              tunnelDstIP:
+                                type: string
+                            type: object
+                          type: array
+                        role:
+                          type: string
+                        timestamp:
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-antrea-clustergroups-edit
+    rules:
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-antrea-clustergroups-view
+    rules:
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-antrea-policies-edit
+    rules:
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-antrea-policies-view
+    rules:
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-traceflows-edit
+    rules:
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-traceflows-view
+    rules:
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+    rules:
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - networking.antrea.tanzu.vmware.com
+      resources:
+      - networkpolicies
+      - appliedtogroups
+      - addressgroups
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - stats.antrea.tanzu.vmware.com
+      resources:
+      - networkpolicystats
+      - antreaclusternetworkpolicystats
+      - antreanetworkpolicystats
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      resources:
+      - controllerinfos
+      - agentinfos
+      verbs:
+      - get
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      resources:
+      - supportbundles
+      verbs:
+      - get
+      - post
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      resources:
+      - supportbundles/download
+      verbs:
+      - get
+    - nonResourceURLs:
+      - /agentinfo
+      - /addressgroups
+      - /appliedtogroups
+      - /loglevel
+      - /networkpolicies
+      - /ovsflows
+      - /ovstracing
+      - /podinterfaces
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - watch
+      - list
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      resources:
+      - antreaagentinfos
+      verbs:
+      - get
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - networking.antrea.tanzu.vmware.com
+      resources:
+      - networkpolicies
+      - appliedtogroups
+      - addressgroups
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      resources:
+      - nodestatssummaries
+      verbs:
+      - create
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      resources:
+      - networkpolicies/status
+      verbs:
+      - create
+      - get
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resourceNames:
+      - extension-apiserver-authentication
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-ca
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      - traceflows/status
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-cluster-identity-reader
+    rules:
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-cluster-identity
+      resources:
+      - configmaps
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      - pods
+      - namespaces
+      - services
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      resources:
+      - antreacontrollerinfos
+      verbs:
+      - get
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      resources:
+      - antreaagentinfos
+      verbs:
+      - list
+      - delete
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resourceNames:
+      - extension-apiserver-authentication
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-ca
+      - antrea-cluster-identity
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-config-ctb8mftc58
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - apiregistration.k8s.io
+      resourceNames:
+      - v1alpha1.stats.antrea.tanzu.vmware.com
+      - v1beta1.system.antrea.tanzu.vmware.com
+      - v1beta2.controlplane.antrea.tanzu.vmware.com
+      - v1beta1.controlplane.antrea.tanzu.vmware.com
+      - v1beta1.networking.antrea.tanzu.vmware.com
+      resources:
+      - apiservices
+      verbs:
+      - get
+      - update
+      - delete
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resourceNames:
+      - crdmutator.antrea.tanzu.vmware.com
+      - crdvalidator.antrea.tanzu.vmware.com
+      resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies/status
+      - networkpolicies/status
+      verbs:
+      - update
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - tiers
+      verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+    - apiGroups:
+      - crd.antrea.tanzu.vmware.com
+      resources:
+      - tierentitlements
+      - tierentitlementbindings
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      - traceflows/status
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - externalentities
+      - clustergroups
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups/status
+      verbs:
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antctl
+    subjects:
+    - kind: ServiceAccount
+      name: antctl
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antrea-agent
+    subjects:
+    - kind: ServiceAccount
+      name: antrea-agent
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antrea-controller
+    subjects:
+    - kind: ServiceAccount
+      name: antrea-controller
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-ca
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-cluster-identity
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      antrea-agent.conf: |
+        featureGates:
+          AntreaProxy: true
+          EndpointSlice: false
+          Traceflow: true
+          NodePortLocal: false
+          AntreaPolicy: true
+          FlowExporter: false
+          NetworkPolicyStats: false
+        trafficEncapMode: encap
+        noSNAT: false
+        serviceCIDR: 100.64.0.0/13
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+      antrea-cni.conflist: |
+        {
+            "cniVersion":"0.3.0",
+            "name": "antrea",
+            "plugins": [
+                {
+                    "type": "antrea",
+                    "ipam": {
+                        "type": "host-local"
+                    }
+                },
+                {
+                    "type": "portmap",
+                    "capabilities": {"portMappings": true}
+                },
+                {
+                    "type": "bandwidth",
+                    "capabilities": {"bandwidth": true}
+                }
+            ]
+        }
+      antrea-controller.conf: |
+        featureGates:
+          Traceflow: true
+          AntreaPolicy: true
+          NetworkPolicyStats: false
+        selfSignedCert: true
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+    kind: ConfigMap
+    metadata:
+      annotations: {}
+      labels:
+        app: antrea
+      name: antrea-config-ctb8mftc58
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: antrea
+      name: antrea
+      namespace: kube-system
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: api
+      selector:
+        app: antrea
+        component: antrea-controller
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-controller
+      name: antrea-controller
+      namespace: kube-system
+      annotations:
+        kapp.k14s.io/disable-default-label-scoping-rules: ""
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: antrea
+          component: antrea-controller
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: antrea
+            component: antrea-controller
+        spec:
+          containers:
+          - args:
+            - --config
+            - /etc/antrea/antrea-controller.conf
+            - --logtostderr=false
+            - --log_dir=/var/log/antrea
+            - --alsologtostderr
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            - --v=0
+            command:
+            - antrea-controller
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: ANTREA_CONFIG_MAP_NAME
+              value: antrea-config-ctb8mftc58
+            image: projects.registry.vmware.com/tkg/antrea/antrea-debian:v0.13.3_vmware.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                host: 127.0.0.1
+                path: /livez
+                port: api
+                scheme: HTTPS
+              periodSeconds: 10
+              timeoutSeconds: 5
+            name: antrea-controller
+            ports:
+            - containerPort: 10349
+              name: api
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 5
+              httpGet:
+                host: 127.0.0.1
+                path: /readyz
+                port: api
+                scheme: HTTPS
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 200m
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-controller.conf
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-controller.conf
+            - mountPath: /var/run/antrea/antrea-controller-tls
+              name: antrea-controller-tls
+            - mountPath: /var/log/antrea
+              name: host-var-log-antrea
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: antrea-controller
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          volumes:
+          - configMap:
+              name: antrea-config-ctb8mftc58
+            name: antrea-config
+          - name: antrea-controller-tls
+            secret:
+              defaultMode: 256
+              optional: true
+              secretName: antrea-controller-tls
+          - hostPath:
+              path: /var/log/antrea
+              type: DirectoryOrCreate
+            name: host-var-log-antrea
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1alpha1.stats.antrea.tanzu.vmware.com
+    spec:
+      group: stats.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1alpha1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.controlplane.antrea.tanzu.vmware.com
+    spec:
+      group: controlplane.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.networking.antrea.tanzu.vmware.com
+    spec:
+      group: networking.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.system.antrea.tanzu.vmware.com
+    spec:
+      group: system.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta2.controlplane.antrea.tanzu.vmware.com
+    spec:
+      group: controlplane.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta2
+      versionPriority: 100
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-agent
+      name: antrea-agent
+      namespace: kube-system
+      annotations:
+        kapp.k14s.io/disable-default-label-scoping-rules: ""
+    spec:
+      selector:
+        matchLabels:
+          app: antrea
+          component: antrea-agent
+      template:
+        metadata:
+          labels:
+            app: antrea
+            component: antrea-agent
+        spec:
+          containers:
+          - args:
+            - --config
+            - /etc/antrea/antrea-agent.conf
+            - --logtostderr=false
+            - --log_dir=/var/log/antrea
+            - --alsologtostderr
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            - --v=0
+            command:
+            - antrea-agent
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            image: projects.registry.vmware.com/tkg/antrea/antrea-debian:v0.13.3_vmware.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - container_liveness_probe agent
+              failureThreshold: 5
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            name: antrea-agent
+            ports:
+            - containerPort: 10350
+              name: api
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 5
+              httpGet:
+                host: 127.0.0.1
+                path: /readyz
+                port: api
+                scheme: HTTPS
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 200m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-agent.conf
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-agent.conf
+            - mountPath: /var/run/antrea
+              name: host-var-run-antrea
+            - mountPath: /var/run/openvswitch
+              name: host-var-run-antrea
+              subPath: openvswitch
+            - mountPath: /var/lib/cni
+              name: host-var-run-antrea
+              subPath: cni
+            - mountPath: /var/log/antrea
+              name: host-var-log-antrea
+            - mountPath: /host/proc
+              name: host-proc
+              readOnly: true
+            - mountPath: /host/var/run/netns
+              mountPropagation: HostToContainer
+              name: host-var-run-netns
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+          - args:
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            command:
+            - start_ovs
+            image: projects.registry.vmware.com/tkg/antrea/antrea-debian:v0.13.3_vmware.1
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - timeout 10 container_liveness_probe ovs
+              failureThreshold: 5
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: antrea-ovs
+            resources:
+              requests:
+                cpu: 200m
+            securityContext:
+              capabilities:
+                add:
+                - SYS_NICE
+                - NET_ADMIN
+                - SYS_ADMIN
+                - IPC_LOCK
+            volumeMounts:
+            - mountPath: /var/run/openvswitch
+              name: host-var-run-antrea
+              subPath: openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-var-log-antrea
+              subPath: openvswitch
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          initContainers:
+          - command:
+            - install_cni
+            image: projects.registry.vmware.com/tkg/antrea/antrea-debian:v0.13.3_vmware.1
+            imagePullPolicy: IfNotPresent
+            name: install-cni
+            resources:
+              requests:
+                cpu: 100m
+            securityContext:
+              capabilities:
+                add:
+                - SYS_MODULE
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-cni.conflist
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-cni.conflist
+            - mountPath: /host/etc/cni/net.d
+              name: host-cni-conf
+            - mountPath: /host/opt/cni/bin
+              name: host-cni-bin
+            - mountPath: /lib/modules
+              name: host-lib-modules
+              readOnly: true
+            - mountPath: /var/run/antrea
+              name: host-var-run-antrea
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: antrea-agent
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - configMap:
+              name: antrea-config-ctb8mftc58
+            name: antrea-config
+          - hostPath:
+              path: /etc/cni/net.d
+            name: host-cni-conf
+          - hostPath:
+              path: /opt/cni/bin
+            name: host-cni-bin
+          - hostPath:
+              path: /proc
+            name: host-proc
+          - hostPath:
+              path: /var/run/netns
+            name: host-var-run-netns
+          - hostPath:
+              path: /var/run/antrea
+              type: DirectoryOrCreate
+            name: host-var-run-antrea
+          - hostPath:
+              path: /var/log/antrea
+              type: DirectoryOrCreate
+            name: host-var-log-antrea
+          - hostPath:
+              path: /lib/modules
+            name: host-lib-modules
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+      updateStrategy:
+        type: RollingUpdate
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdmutator.antrea.tanzu.vmware.com
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/acnp
+      name: acnpmutator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/anp
+      name: anpmutator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdvalidator.antrea.tanzu.vmware.com
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/tier
+      name: tiervalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - tiers
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/acnp
+      name: acnpvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/anp
+      name: anpvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/clustergroup
+      name: clustergroupvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - core.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha2
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - clustergroups
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: antrea
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-antrea-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    infraProvider: vsphere
+    antrea:
+      config:
+        serviceCIDR: 100.64.0.0/13
+        trafficEncapMode: encap
+        noSNAT: false
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+        featureGates:
+          AntreaProxy: true
+          EndpointSlice: false
+          AntreaPolicy: true
+          NodePortLocal: false
+          AntreaTraceflow: true
+type: tkg.tanzu.vmware.com/addon
+---

--- a/tanzu/crs/v1.4.2/v1.4.2.yaml.template
+++ b/tanzu/crs/v1.4.2/v1.4.2.yaml.template
@@ -1,0 +1,3037 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-kapp-controller
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-kapp-controller-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+  name: __CLUSTER_NAME__-kapp-controller-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tanzu-package-repo-global
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      name: v1alpha1.data.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: data.packaging.carvel.dev
+      groupPriorityMinimum: 100
+      service:
+        name: packaging-api
+        namespace: tkg-system
+      version: v1alpha1
+      versionPriority: 100
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: packaging-api
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: api
+      selector:
+        app: kapp-controller
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: internalpackagemetadatas.internal.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: internal.packaging.carvel.dev
+      names:
+        kind: InternalPackageMetadata
+        listKind: InternalPackageMetadataList
+        plural: internalpackagemetadatas
+        singular: internalpackagemetadata
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  categories:
+                    items:
+                      type: string
+                    type: array
+                  displayName:
+                    type: string
+                  iconSVGBase64:
+                    type: string
+                  longDescription:
+                    type: string
+                  maintainers:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  providerName:
+                    type: string
+                  shortDescription:
+                    type: string
+                  supportDescription:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: internalpackages.internal.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: internal.packaging.carvel.dev
+      names:
+        kind: InternalPackage
+        listKind: InternalPackageList
+        plural: internalpackages
+        singular: internalpackage
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  capacityRequirementsDescription:
+                    type: string
+                  licenses:
+                    items:
+                      type: string
+                    type: array
+                  refName:
+                    type: string
+                  releaseNotes:
+                    type: string
+                  releasedAt:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  template:
+                    properties:
+                      spec:
+                        properties:
+                          canceled:
+                            description: Canceled when set to true will stop all active changes
+                            type: boolean
+                          cluster:
+                            properties:
+                              kubeconfigSecretRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              namespace:
+                                type: string
+                            type: object
+                          deploy:
+                            items:
+                              properties:
+                                kapp:
+                                  properties:
+                                    delete:
+                                      properties:
+                                        rawOptions:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    inspect:
+                                      properties:
+                                        rawOptions:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    intoNs:
+                                      type: string
+                                    mapNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                    rawOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          fetch:
+                            items:
+                              properties:
+                                git:
+                                  description: TODO implement git
+                                  properties:
+                                    lfsSkipSmudge:
+                                      type: boolean
+                                    ref:
+                                      type: string
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    subPath:
+                                      type: string
+                                    url:
+                                      type: string
+                                  type: object
+                                helmChart:
+                                  properties:
+                                    name:
+                                      description: 'Example: stable/redis'
+                                      type: string
+                                    repository:
+                                      properties:
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              description: Object is expected to be within same namespace
+                                              type: string
+                                          type: object
+                                        url:
+                                          type: string
+                                      type: object
+                                    version:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    sha256:
+                                      type: string
+                                    subPath:
+                                      type: string
+                                    url:
+                                      description: 'URL can point to one of following formats: text, tgz, zip'
+                                      type: string
+                                  type: object
+                                image:
+                                  properties:
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    subPath:
+                                      type: string
+                                    url:
+                                      description: 'Example: username/app1-config:v0.1.0'
+                                      type: string
+                                  type: object
+                                imgpkgBundle:
+                                  properties:
+                                    image:
+                                      type: string
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                  type: object
+                                inline:
+                                  properties:
+                                    paths:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    pathsFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                          secretRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          noopDelete:
+                            description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                            type: boolean
+                          paused:
+                            description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                            type: boolean
+                          serviceAccountName:
+                            type: string
+                          syncPeriod:
+                            description: Controls frequency of app reconciliation
+                            type: string
+                          template:
+                            items:
+                              properties:
+                                helmTemplate:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    path:
+                                      type: string
+                                    valuesFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          path:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                jsonnet:
+                                  description: TODO implement jsonnet
+                                  type: object
+                                kbld:
+                                  properties:
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                kustomize:
+                                  description: TODO implement kustomize
+                                  type: object
+                                sops:
+                                  properties:
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                    pgp:
+                                      properties:
+                                        privateKeysSecretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                ytt:
+                                  properties:
+                                    fileMarks:
+                                      items:
+                                        type: string
+                                      type: array
+                                    ignoreUnknownComments:
+                                      type: boolean
+                                    inline:
+                                      properties:
+                                        paths:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        pathsFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  directoryPath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              secretRef:
+                                                properties:
+                                                  directoryPath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                    strict:
+                                      type: boolean
+                                    valuesFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          path:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                  valuesSchema:
+                    description: valuesSchema can be used to show template values that can be configured by users when a Package is installed in an OpenAPI schema format.
+                    properties:
+                      openAPIv3:
+                        nullable: true
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  version:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: apps.kappctrl.k14s.io
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: kappctrl.k14s.io
+      names:
+        kind: App
+        listKind: AppList
+        plural: apps
+        singular: app
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        - description: Last time app started being deployed. Does not mean anything was changed.
+          jsonPath: .status.deploy.startedAt
+          name: Since-Deploy
+          type: date
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  canceled:
+                    description: Canceled when set to true will stop all active changes
+                    type: boolean
+                  cluster:
+                    properties:
+                      kubeconfigSecretRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      namespace:
+                        type: string
+                    type: object
+                  deploy:
+                    items:
+                      properties:
+                        kapp:
+                          properties:
+                            delete:
+                              properties:
+                                rawOptions:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            inspect:
+                              properties:
+                                rawOptions:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            intoNs:
+                              type: string
+                            mapNs:
+                              items:
+                                type: string
+                              type: array
+                            rawOptions:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  fetch:
+                    items:
+                      properties:
+                        git:
+                          description: TODO implement git
+                          properties:
+                            lfsSkipSmudge:
+                              type: boolean
+                            ref:
+                              type: string
+                            secretRef:
+                              description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            subPath:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                        helmChart:
+                          properties:
+                            name:
+                              description: 'Example: stable/redis'
+                              type: string
+                            repository:
+                              properties:
+                                secretRef:
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            version:
+                              type: string
+                          type: object
+                        http:
+                          properties:
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            sha256:
+                              type: string
+                            subPath:
+                              type: string
+                            url:
+                              description: 'URL can point to one of following formats: text, tgz, zip'
+                              type: string
+                          type: object
+                        image:
+                          properties:
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            subPath:
+                              type: string
+                            url:
+                              description: 'Example: username/app1-config:v0.1.0'
+                              type: string
+                          type: object
+                        imgpkgBundle:
+                          properties:
+                            image:
+                              type: string
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                          type: object
+                        inline:
+                          properties:
+                            paths:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            pathsFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  secretRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  noopDelete:
+                    description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                    type: boolean
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  serviceAccountName:
+                    type: string
+                  syncPeriod:
+                    description: Controls frequency of app reconciliation
+                    type: string
+                  template:
+                    items:
+                      properties:
+                        helmTemplate:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            path:
+                              type: string
+                            valuesFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  path:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        jsonnet:
+                          description: TODO implement jsonnet
+                          type: object
+                        kbld:
+                          properties:
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        kustomize:
+                          description: TODO implement kustomize
+                          type: object
+                        sops:
+                          properties:
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                            pgp:
+                              properties:
+                                privateKeysSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        ytt:
+                          properties:
+                            fileMarks:
+                              items:
+                                type: string
+                              type: array
+                            ignoreUnknownComments:
+                              type: boolean
+                            inline:
+                              properties:
+                                paths:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                pathsFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                      secretRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                            strict:
+                              type: boolean
+                            valuesFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  path:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  consecutiveReconcileFailures:
+                    type: integer
+                  consecutiveReconcileSuccesses:
+                    type: integer
+                  deploy:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      finished:
+                        type: boolean
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  fetch:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  friendlyDescription:
+                    type: string
+                  inspect:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  managedAppName:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  template:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  usefulErrorMessage:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: packageinstalls.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: packaging.carvel.dev
+      names:
+        kind: PackageInstall
+        listKind: PackageInstallList
+        plural: packageinstalls
+        shortNames:
+        - pkgi
+        singular: packageinstall
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: PackageMetadata name
+          jsonPath: .spec.packageRef.refName
+          name: Package name
+          type: string
+        - description: PackageMetadata version
+          jsonPath: .status.version
+          name: Package version
+          type: string
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  canceled:
+                    description: Canceled when set to true will stop all active changes
+                    type: boolean
+                  cluster:
+                    properties:
+                      kubeconfigSecretRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      namespace:
+                        type: string
+                    type: object
+                  noopDelete:
+                    description: When NoopDelete set to true, PackageInstall deletion should delete PackageInstall/App CR but preserve App's associated resources.
+                    type: boolean
+                  packageRef:
+                    properties:
+                      refName:
+                        type: string
+                      versionSelection:
+                        properties:
+                          constraints:
+                            type: string
+                          prereleases:
+                            properties:
+                              identifiers:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  serviceAccountName:
+                    type: string
+                  syncPeriod:
+                    description: Controls frequency of App reconciliation in time + unit format. Always >= 30s. If value below 30s is specified, 30s will be used.
+                    type: string
+                  values:
+                    items:
+                      properties:
+                        secretRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  friendlyDescription:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  usefulErrorMessage:
+                    type: string
+                  version:
+                    description: TODO this is desired resolved version (not actually deployed)
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        packaging.carvel.dev/global-namespace: tanzu-package-repo-global
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+      name: packagerepositories.packaging.carvel.dev
+    spec:
+      group: packaging.carvel.dev
+      names:
+        kind: PackageRepository
+        listKind: PackageRepositoryList
+        plural: packagerepositories
+        shortNames:
+        - pkgr
+        singular: packagerepository
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  fetch:
+                    properties:
+                      git:
+                        description: TODO implement git
+                        properties:
+                          lfsSkipSmudge:
+                            type: boolean
+                          ref:
+                            type: string
+                          secretRef:
+                            description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          subPath:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                      http:
+                        properties:
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          sha256:
+                            type: string
+                          subPath:
+                            type: string
+                          url:
+                            description: 'URL can point to one of following formats: text, tgz, zip'
+                            type: string
+                        type: object
+                      image:
+                        properties:
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          subPath:
+                            type: string
+                          url:
+                            description: 'Example: username/app1-config:v0.1.0'
+                            type: string
+                        type: object
+                      imgpkgBundle:
+                        properties:
+                          image:
+                            type: string
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  syncPeriod:
+                    description: Controls frequency of PackageRepository reconciliation
+                    type: string
+                required:
+                - fetch
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  consecutiveReconcileFailures:
+                    type: integer
+                  consecutiveReconcileSuccesses:
+                    type: integer
+                  deploy:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      finished:
+                        type: boolean
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  fetch:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  friendlyDescription:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  template:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  usefulErrorMessage:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: kapp-controller-config
+      namespace: tkg-system
+      annotations:
+        kapp.k14s.io/change-group: apps.kappctrl.k14s.io/kapp-controller-config
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    data:
+      caCerts: ""
+      httpProxy: ""
+      httpsProxy: ""
+      noProxy: ""
+      dangerousSkipTLSVerify: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kapp-controller.carvel.dev/version: v0.23.0
+        kapp.k14s.io/change-rule: upsert after upserting apps.kappctrl.k14s.io/kapp-controller-config
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+      name: kapp-controller
+      namespace: tkg-system
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 0
+      selector:
+        matchLabels:
+          app: kapp-controller
+      template:
+        metadata:
+          labels:
+            app: kapp-controller
+        spec:
+          containers:
+          - args:
+            - -packaging-global-namespace=tanzu-package-repo-global
+            - -concurrency=4
+            env:
+            - name: KAPPCTRL_MEM_TMP_DIR
+              value: /etc/kappctrl-mem-tmp
+            - name: KAPPCTRL_SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KAPPCTRL_API_PORT
+              value: "10100"
+            image: projects.registry.vmware.com/tkg/kapp-controller:v0.23.0_vmware.1
+            name: kapp-controller
+            ports:
+            - containerPort: 10100
+              name: api
+              protocol: TCP
+            resources:
+              requests:
+                cpu: 120m
+                memory: 100Mi
+            securityContext:
+              runAsGroup: 2000
+              runAsUser: 1000
+            volumeMounts:
+            - mountPath: /etc/kappctrl-mem-tmp
+              name: template-fs
+          securityContext:
+            fsGroup: 3000
+          serviceAccount: kapp-controller-sa
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: template-fs
+          hostNetwork: true
+          priorityClassName: system-cluster-critical
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node.kubernetes.io/not-ready
+          - effect: NoSchedule
+            key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kapp-controller-sa
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kapp-controller-cluster-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts
+      verbs:
+      - get
+    - apiGroups:
+      - kappctrl.k14s.io
+      resources:
+      - apps
+      - apps/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - packaging.carvel.dev
+      resources:
+      - packageinstalls
+      - packageinstalls/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - packaging.carvel.dev
+      resources:
+      - packagerepositories
+      - packagerepositories/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - internal.packaging.carvel.dev
+      resources:
+      - internalpackagemetadatas
+      verbs:
+      - '*'
+    - apiGroups:
+      - data.packaging.carvel.dev
+      resources:
+      - packagemetadatas
+      - packagemetadatas/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - internal.packaging.carvel.dev
+      resources:
+      - internalpackages
+      verbs:
+      - '*'
+    - apiGroups:
+      - data.packaging.carvel.dev
+      resources:
+      - packages
+      - packages/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - '*'
+    - apiGroups:
+      - apiregistration.k8s.io
+      resources:
+      - apiservices
+      verbs:
+      - update
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - namespaces
+      verbs:
+      - list
+      - watch
+      - get
+      - update
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - mutatingwebhookconfigurations
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - validatingwebhookconfigurations
+      verbs:
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kapp-controller-cluster-role-binding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kapp-controller-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: pkg-apiserver:system:auth-delegator
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: pkgserver-auth-reader
+      namespace: kube-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-namespace-role
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: tkg-metadata-reader
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    rules:
+    - apiGroups:
+      - ""
+      resourceNames:
+      - tkg-metadata
+      - tkg-bom
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: tkg-metadata-reader
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: tkg-metadata-reader
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: system:authenticated
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-configmap
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkg-metadata
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    data:
+      metadata.yaml: |
+        cluster:
+          name: __CLUSTER_NAME__
+          type: management
+          plan: dev
+          kubernetesProvider: VMware Tanzu Kubernetes Grid
+          tkgVersion: v1.4.2
+          infrastructure:
+            provider: vsphere
+        bom:
+          configmapRef:
+            name: tkg-bom
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-bom-configmap
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkg-bom
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    data:
+      bom.yaml: |
+        apiVersion: run.tanzu.vmware.com/v1alpha2
+        default:
+          k8sVersion: v1.21.8+vmware.1-tkg.2
+        release:
+          version: v1.4.2
+        components:
+          aad-pod-identity:
+          - version: v1.6.3+vmware.2
+            images:
+              micImage:
+                imagePath: cluster-api/mic
+                tag: v1.6.3_vmware.2
+              nmiImage:
+                imagePath: cluster-api/nmi
+                tag: v1.6.3_vmware.2
+          alertmanager:
+          - version: v0.22.2+vmware.1
+            images:
+              alertmanagerImage:
+                imagePath: prometheus/alertmanager
+                tag: v0.22.2_vmware.1
+          cadvisor:
+          - version: v0.39.1+vmware.1
+            images:
+              cadvisorImage:
+                imagePath: prometheus/cadvisor
+                tag: v0.39.1_vmware.1
+          cloud-provider-azure:
+          - version: v0.7.4+vmware.1
+            images:
+              ccmAzureControllerImage:
+                imagePath: azure-cloud-controller-manager
+                tag: v0.7.4_vmware.1
+              ccmAzureNodeImage:
+                imagePath: azure-cloud-node-manager
+                tag: v0.7.4_vmware.1
+          cluster-api-provider-azure:
+          - version: v0.4.15+vmware.1
+            images:
+              capzControllerImage:
+                imagePath: cluster-api/cluster-api-azure-controller
+                tag: v0.4.15_vmware.1
+          cluster_api:
+          - version: v0.3.23+vmware.1
+            images:
+              cabpkControllerImage:
+                imagePath: cluster-api/kubeadm-bootstrap-controller
+                tag: v0.3.23_vmware.1
+              capdManagerImage:
+                imagePath: cluster-api/capd-manager
+                tag: v0.3.23_vmware.1
+              capiControllerImage:
+                imagePath: cluster-api/cluster-api-controller
+                tag: v0.3.23_vmware.1
+              kcpControllerImage:
+                imagePath: cluster-api/kubeadm-control-plane-controller
+                tag: v0.3.23_vmware.1
+          cluster_api_aws:
+          - version: v0.6.6+vmware.1
+            images:
+              capaControllerImage:
+                imagePath: cluster-api/cluster-api-aws-controller
+                tag: v0.6.6_vmware.1
+          cluster_api_vsphere:
+          - version: v0.7.12+vmware.1
+            images:
+              capvControllerImage:
+                imagePath: cluster-api/cluster-api-vsphere-controller
+                tag: v0.7.12_vmware.1
+          configmap-reload:
+          - version: v0.5.0+vmware.1
+            images:
+              configmapReloadImage:
+                imagePath: prometheus/configmap-reload
+                tag: v0.5.0_vmware.1
+          contour:
+          - version: v1.17.2+vmware.1
+            images:
+              contourImage:
+                imagePath: contour
+                tag: v1.17.2_vmware.1
+          crash-diagnostics:
+          - version: v0.3.7+vmware.3
+          envoy:
+          - version: v1.18.4+vmware.1
+            images:
+              envoyImage:
+                imagePath: envoy
+                tag: v1.18.4_vmware.1
+          external-dns:
+          - version: v0.8.0+vmware.1
+            images:
+              externalDNSImage:
+                imagePath: external-dns
+                tag: v0.8.0_vmware.1
+          fluent-bit:
+          - version: v1.7.5+vmware.1
+            images:
+              fluentBitImage:
+                imagePath: fluent-bit
+                tag: v1.7.5_vmware.1
+          gangway:
+          - version: v3.2.0+vmware.2
+            images:
+              gangwayImage:
+                imagePath: gangway
+                tag: v3.2.0_vmware.2
+          grafana:
+          - version: v7.5.7+vmware.1
+            images:
+              grafanaImage:
+                imagePath: grafana/grafana
+                tag: v7.5.7_vmware.1
+          harbor:
+          - version: v2.2.3+vmware.1
+            images:
+              harborChartMuseumImage:
+                imagePath: harbor/chartmuseum-photon
+                tag: v2.2.3_vmware.1
+              harborCoreImage:
+                imagePath: harbor/harbor-core
+                tag: v2.2.3_vmware.1
+              harborDatabaseImage:
+                imagePath: harbor/harbor-db
+                tag: v2.2.3_vmware.1
+              harborExporterImage:
+                imagePath: harbor/harbor-exporter
+                tag: v2.2.3_vmware.1
+              harborJobServiceImage:
+                imagePath: harbor/harbor-jobservice
+                tag: v2.2.3_vmware.1
+              harborLogImage:
+                imagePath: harbor/harbor-log
+                tag: v2.2.3_vmware.1
+              harborNginxImage:
+                imagePath: harbor/nginx-photon
+                tag: v2.2.3_vmware.1
+              harborNotaryServerImage:
+                imagePath: harbor/notary-server-photon
+                tag: v2.2.3_vmware.1
+              harborNotarySignerImage:
+                imagePath: harbor/notary-signer-photon
+                tag: v2.2.3_vmware.1
+              harborPortalImage:
+                imagePath: harbor/harbor-portal
+                tag: v2.2.3_vmware.1
+              harborPrepareImage:
+                imagePath: harbor/prepare
+                tag: v2.2.3_vmware.1
+              harborRedisImage:
+                imagePath: harbor/redis-photon
+                tag: v2.2.3_vmware.1
+              harborRegistryCtlImage:
+                imagePath: harbor/harbor-registryctl
+                tag: v2.2.3_vmware.1
+              harborRegistryImage:
+                imagePath: harbor/registry-photon
+                tag: v2.2.3_vmware.1
+              harborTrivyAdapterImage:
+                imagePath: harbor/trivy-adapter-photon
+                tag: v2.2.3_vmware.1
+          image-builder:
+          - version: v0.1.11+vmware.3
+            images:
+              imagebuilder-tar:
+                imagePath: image-builder
+                tag: v0.1.11_vmware.3
+          imgpkg:
+          - version: v0.10.0+vmware.1
+          jetstack_cert-manager:
+          - version: v1.1.0+vmware.2
+            images:
+              certMgrControllerImage:
+                imagePath: cert-manager-controller
+                tag: v1.1.0_vmware.2
+              certMgrInjectorImage:
+                imagePath: cert-manager-cainjector
+                tag: v1.1.0_vmware.2
+              certMgrWebhookImage:
+                imagePath: cert-manager-webhook
+                tag: v1.1.0_vmware.2
+          k8s-sidecar:
+          - version: v1.12.1+vmware.1
+            images:
+              k8sSidecarImage:
+                imagePath: grafana/k8s-sidecar
+                tag: v1.12.1_vmware.1
+          k14s_kapp:
+          - version: v0.37.0+vmware.1
+          k14s_ytt:
+          - version: v0.34.0+vmware.1
+          kbld:
+          - version: v0.30.0+vmware.1
+          kube-state-metrics:
+          - version: v1.9.8+vmware.1
+            images:
+              kubeStateMetricsImage:
+                imagePath: prometheus/kube-state-metrics
+                tag: v1.9.8_vmware.1
+          kube-vip:
+          - version: v0.3.3+vmware.1
+            images:
+              kubeVipImage:
+                imagePath: kube-vip
+                tag: v0.3.3_vmware.1
+          kube_rbac_proxy:
+          - version: v0.8.0+vmware.1
+            images:
+              kubeRbacProxyControllerImage:
+                imagePath: kube-rbac-proxy
+                tag: v0.8.0_vmware.1
+              kubeRbacProxyControllerImageCapi:
+                imagePath: cluster-api/kube-rbac-proxy
+                tag: v0.8.0_vmware.1
+          kubernetes-sigs_kind:
+          - version: v1.21.8+vmware.1
+            images:
+              kindNodeImage:
+                imagePath: kind/node
+                tag: v1.21.8_vmware.1
+          kubernetes_autoscaler:
+          - version: v1.21.0+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.21.0_vmware.1
+            metadata:
+              k8sversion: v1.21.1+vmware.1
+          - version: v1.20.0+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.20.0_vmware.1
+            metadata:
+              k8sversion: v1.20.4+vmware.1
+          - version: v1.19.1+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.19.1_vmware.1
+            metadata:
+              k8sversion: v1.19.8+vmware.1
+          multus-cni:
+          - version: v3.7.1+vmware.1
+            images:
+              multusCniImage:
+                imagePath: multus-cni
+                tag: v3.7.1_vmware.1
+          prometheus:
+          - version: v2.27.0+vmware.1
+            images:
+              prometheusImage:
+                imagePath: prometheus/prometheus
+                tag: v2.27.0_vmware.1
+          prometheus_node_exporter:
+          - version: v1.1.2+vmware.1
+            images:
+              prometheusNodeExporterImage:
+                imagePath: prometheus/prometheus_node_exporter
+                tag: v1.1.2_vmware.1
+          pushgateway:
+          - version: v1.4.0+vmware.1
+            images:
+              pushgatewayImage:
+                imagePath: prometheus/pushgateway
+                tag: v1.4.0_vmware.1
+          sonobuoy:
+          - version: v0.20.0+vmware.1
+            images:
+              sonobuoyImage:
+                imagePath: sonobuoy
+                tag: v0.20.0_vmware.1
+          tanzu-framework:
+          - version: v1.4.2
+            images:
+              capabilitiesImage:
+                imagePath: tanzu_core/capabilities/capabilities-controller-manager
+                tag: v1.4.2
+              providerTemplateImage:
+                imagePath: tanzu_core/provider/provider-templates
+                tag: v1.4.2
+              tkrImage:
+                imagePath: tanzu_core/tkr/tkr-controller-manager
+                tag: v1.4.2
+          tkg-bom:
+          - version: v1.4.2
+            images:
+              tkgBomImage:
+                imagePath: tkg-bom
+                tag: v1.4.2
+          tkg-standard-packages:
+          - version: v1.4.2
+            images:
+              cert-manager.tanzu.vmware.com:
+                imagePath: packages/standard/cert-manager
+                tag: v1.1.0_vmware.2-tkg.1
+              contour.tanzu.vmware.com:
+                imagePath: packages/standard/contour
+                tag: v1.17.2_vmware.1-tkg.2
+              external-dns.tanzu.vmware.com:
+                imagePath: packages/standard/external-dns
+                tag: v0.8.0_vmware.1-tkg.1
+              fluent-bit.tanzu.vmware.com:
+                imagePath: packages/standard/fluent-bit
+                tag: v1.7.5_vmware.1-tkg.1
+              grafana.tanzu.vmware.com:
+                imagePath: packages/standard/grafana
+                tag: v7.5.7_vmware.1-tkg.1
+              harbor.tanzu.vmware.com:
+                imagePath: packages/standard/harbor
+                tag: v2.2.3_vmware.1-tkg.2
+              multus-cni.tanzu.vmware.com:
+                imagePath: packages/standard/multus-cni
+                tag: v3.7.1_vmware.2-tkg.1
+              prometheus.tanzu.vmware.com:
+                imagePath: packages/standard/prometheus
+                tag: v2.27.0_vmware.1-tkg.1
+              tanzuStandardPackageRepositoryImage:
+                imagePath: packages/standard/repo
+                tag: v1.4.2
+          tkg_telemetry:
+          - version: v1.4.0+vmware.1
+            images:
+              tkgTelemetryImage:
+                imagePath: tkg-telemetry
+                tag: v1.4.0_vmware.1
+          velero:
+          - version: v1.6.2+vmware.1
+            images:
+              veleroImage:
+                imagePath: velero/velero
+                tag: v1.6.2_vmware.1
+              veleroResticRestoreHelperImage:
+                imagePath: velero/velero-restic-restore-helper
+                tag: v1.6.2_vmware.1
+          velero-plugin-for-aws:
+          - version: v1.2.1+vmware.1
+            images:
+              veleroPluginForAwsImage:
+                imagePath: velero/velero-plugin-for-aws
+                tag: v1.2.1_vmware.1
+          velero-plugin-for-microsoft-azure:
+          - version: v1.2.1+vmware.1
+            images:
+              veleroPluginForMicrosoftAzureImage:
+                imagePath: velero/velero-plugin-for-microsoft-azure
+                tag: v1.2.1_vmware.1
+          velero-plugin-for-vsphere:
+          - version: v1.1.1+vmware.1
+            images:
+              veleroBackupDriverImage:
+                imagePath: velero/backup-driver
+                tag: v1.1.1_vmware.1
+              veleroDataManagerForPluginImage:
+                imagePath: velero/data-manager-for-plugin
+                tag: v1.1.1_vmware.1
+              veleroPluginForVsphereImage:
+                imagePath: velero/velero-plugin-for-vsphere
+                tag: v1.1.1_vmware.1
+          vendir:
+          - version: v0.21.1+vmware.1
+        kindKubeadmConfigSpec:
+        - 'kind: Cluster'
+        - 'apiVersion: kind.x-k8s.io/v1alpha4'
+        - 'kubeadmConfigPatches:'
+        - '- |'
+        - '  apiVersion: kubeadm.k8s.io/v1beta2'
+        - '  kind: ClusterConfiguration'
+        - '  imageRepository: projects.registry.vmware.com/tkg'
+        - '  etcd:'
+        - '    local:'
+        - '      imageRepository: projects.registry.vmware.com/tkg'
+        - '      imageTag: v3.4.13_vmware.25'
+        - '  dns:'
+        - '    type: CoreDNS'
+        - '    imageRepository: projects.registry.vmware.com/tkg'
+        - '    imageTag: v1.8.0_vmware.11'
+        imageConfig:
+          imageRepository: projects.registry.vmware.com/tkg
+        tkr-bom:
+          imagePath: tkr-bom
+        tkr-compatibility:
+          imagePath: tkr-compatibility
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tkg-metadata
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-namespace-role
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-configmap
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-bom-configmap
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metrics/metrics-server
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: metrics-server
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-metrics-server-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    metricsServer:
+      namespace: kube-system
+      config:
+        args: []
+        probe:
+          failureThreshold: 3
+          periodSeconds: 10
+        apiServiceInsecureTLS: true
+type: tkg.tanzu.vmware.com/addon
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-core-package-repository
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-core-package-repository-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+  name: __CLUSTER_NAME__-core-package-repository-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageRepository
+    metadata:
+      name: tanzu-core
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+    spec:
+      fetch:
+        imgpkgBundle:
+          image: projects.registry.vmware.com/tkg/packages/core/repo:v1.21.8_vmware.1-tkg.2
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-standard-package-repository
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-standard-package-repository-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+  name: __CLUSTER_NAME__-standard-package-repository-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageRepository
+    metadata:
+      name: tanzu-standard
+      namespace: tanzu-package-repo-global
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+        tanzu.vmware.com/owner: tkg
+    spec:
+      fetch:
+        imgpkgBundle:
+          image: projects.registry.vmware.com/tkg/packages/standard/repo:v1.4.2
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tanzu-addons-manager-package
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tanzu-addons-manager-package-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  name: __CLUSTER_NAME__-tanzu-addons-manager-package-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: tanzu-addons-package-sa
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-addons-package-cluster-role
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-addons-package-cluster-rolebinding
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-addons-package-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-addons-package-sa
+      namespace: tkg-system
+    ---
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageInstall
+    metadata:
+      name: tanzu-addons-manager
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    spec:
+      serviceAccountName: tanzu-addons-package-sa
+      packageRef:
+        refName: addons-manager.tanzu.vmware.com
+        versionSelection:
+          prereleases: {}
+      values:
+      - secretRef:
+          name: tanzu-addons-manager-data-values
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tanzu-addons-manager-data-values
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    type: Opaque
+    stringData:
+      values.yaml: |
+        #@data/values
+        #@overlay/match-child-defaults missing_ok=True
+        ---
+        tanzuAddonsManager:
+          namespace: tkg-system
+          createNamespace: false
+          deployment:
+            hostNetwork: true
+            priorityClassName: system-cluster-critical
+            tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: tanzu-addons-manager
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tanzu-addons-manager-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    tanzuAddonsManager:
+      namespace: tkg-system
+      createNamespace: false
+      deployment:
+        hostNetwork: true
+        priorityClassName: system-cluster-critical
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+type: tkg.tanzu.vmware.com/addon
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tkr
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkr
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+  name: __CLUSTER_NAME__-tkr
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        control-plane: controller-manager
+      name: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkr-controller-config
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    data:
+      caCerts: ""
+      imageRepository: ""
+    ---
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.2.5
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+      creationTimestamp: null
+      name: tanzukubernetesreleases.run.tanzu.vmware.com
+    spec:
+      additionalPrinterColumns:
+      - JSONPath: .spec.version
+        name: Version
+        type: string
+      - JSONPath: .status.conditions[?(@.type=='Compatible')].status
+        name: Compatible
+        type: string
+      - JSONPath: .metadata.creationTimestamp
+        name: Created
+        type: date
+      group: run.tanzu.vmware.com
+      names:
+        kind: TanzuKubernetesRelease
+        listKind: TanzuKubernetesReleaseList
+        plural: tanzukubernetesreleases
+        shortNames:
+        - tkr
+        singular: tanzukubernetesrelease
+      scope: Cluster
+      subresources:
+        status: {}
+      validation:
+        openAPIV3Schema:
+          description: TanzuKubernetesRelease is the schema for the tanzukubernetesreleases API. TanzuKubernetesRelease objects represent Kubernetes releases available via TKG, which can be used to create TanzuKubernetesCluster instances. TKRs are immutable to end-users. They are created and managed by TKG to provide discovery of Kubernetes releases to TKG users.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TanzuKubernetesReleaseSpec defines the desired state of TanzuKubernetesRelease
+              properties:
+                images:
+                  description: Images is the list of (other than Kubernetes core) essential container images shipped by this TKR (e.g. coredns, etcd).
+                  items:
+                    description: ContainerImage is a struct representing a single fully qualified container image name, constructed as `{Repository}/{Name}:{Tag}`.
+                    properties:
+                      name:
+                        description: Name is the container image name without the repository prefix. It MUST be a valid URI path, MAY contain zero or more '/', and SHOULD NOT start or end with '/'.
+                        type: string
+                      repository:
+                        description: Repository is the container image repository used by this image. It MUST be a DNS-compatible name.
+                        type: string
+                      tag:
+                        description: Tag is the container image version tag. It is the suffix coming after ':' in a fully qualified image name.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                kubernetesVersion:
+                  description: KubernetesVersion is the fully qualified Semantic Versioning conformant version of Kubernetes shipped by this TKR. The same KubernetesVersion MAY be shipped by different TKRs.
+                  type: string
+                nodeImageRef:
+                  description: NodeImageRef refers to an object representing the image used to create TKC nodes (e.g. VirtualMachineImage).
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                repository:
+                  description: Repository is the container image repository for Kubernetes core images, such as kube-apiserver, kube-proxy, etc. It MUST be a DNS-compatible name.
+                  type: string
+                version:
+                  description: Version is the fully qualified Semantic Versioning conformant version of the TanzuKubernetesRelease. Version MUST be unique across all TanzuKubernetesRelease objects.
+                  type: string
+              required:
+              - version
+              type: object
+            status:
+              description: TanzuKubernetesReleaseStatus defines the observed state of TanzuKubernetesRelease
+              properties:
+                conditions:
+                  items:
+                    description: Condition defines an observation of a Cluster API resource operational state.
+                    properties:
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition. This field may be empty.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                        type: string
+                      severity:
+                        description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      version: v1alpha1
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: tkr-leader-election-role
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps/status
+      verbs:
+      - get
+      - update
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: tkr-manager-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    rules:
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: tkr-leader-election-rolebinding
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: tkr-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: tkr-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tkr-manager-rolebinding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tkr-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: tkr-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        control-plane: controller-manager
+      name: tkr-controller-manager
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --enable-leader-election
+            - --bom-image-path=projects.registry.vmware.com/tkg/tkr-bom
+            - --bom-metadata-image-path=projects.registry.vmware.com/tkg/tkr-compatibility
+            - --skip-verify-registry-cert=False
+            - --continuous-discover-frequency=600
+            command:
+            - /manager
+            image: projects.registry.vmware.com/tkg/tanzu_core/tkr/tkr-controller-manager:v1.4.2
+            imagePullPolicy: Always
+            name: manager
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+          terminationGracePeriodSeconds: 10
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-capabilities
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-capabilities
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: __CLUSTER_NAME__-capabilities
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.2.5
+      creationTimestamp: null
+      name: capabilities.run.tanzu.vmware.com
+    spec:
+      group: run.tanzu.vmware.com
+      names:
+        kind: Capability
+        listKind: CapabilityList
+        plural: capabilities
+        singular: capability
+      scope: Namespaced
+      subresources:
+        status: {}
+      validation:
+        openAPIV3Schema:
+          description: Capability is the Schema for the capabilities API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec is the capability spec that has cluster queries.
+              properties:
+                queries:
+                  description: Queries specifies set of queries that are evaluated.
+                  items:
+                    description: Query is a logical grouping of GVR, Object and PartialSchema queries.
+                    properties:
+                      groupVersionResources:
+                        description: GroupVersionResources evaluates a slice of GVR queries.
+                        items:
+                          description: QueryGVR queries for an API group with the optional ability to check for API versions and resource.
+                          properties:
+                            group:
+                              description: Group is the API group to check for in the cluster.
+                              minLength: 1
+                              type: string
+                            name:
+                              description: Name is the unique name of the query.
+                              minLength: 1
+                              type: string
+                            resource:
+                              description: Resource is the API resource to check for given an API group and a slice of versions. Specifying a Resource requires at least one version to be specified in Versions.
+                              type: string
+                            versions:
+                              description: Versions is the slice of versions to check for in the specified API group.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - group
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      name:
+                        description: Name is the unique name of the query.
+                        minLength: 1
+                        type: string
+                      objects:
+                        description: Objects evaluates a slice of Object queries.
+                        items:
+                          description: QueryObject represents any runtime.Object that could exist in a cluster with the ability to check for annotations.
+                          properties:
+                            name:
+                              description: Name is the unique name of the query.
+                              minLength: 1
+                              type: string
+                            objectReference:
+                              description: ObjectReference is the ObjectReference to check for in the cluster.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                            withAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: WithAnnotations are the annotations whose presence is checked in the object. The query succeeds only if all the annotations specified exists.
+                              type: object
+                            withoutAnnotations:
+                              additionalProperties:
+                                type: string
+                              description: WithAnnotations are the annotations whose absence is checked in the object. The query succeeds only if all the annotations specified do not exist.
+                              type: object
+                          required:
+                          - name
+                          - objectReference
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      partialSchemas:
+                        description: PartialSchemas evaluates a slice of PartialSchema queries.
+                        items:
+                          description: QueryPartialSchema queries for any OpenAPI schema that may exist on a cluster.
+                          properties:
+                            name:
+                              description: Name is the unique name of the query.
+                              minLength: 1
+                              type: string
+                            partialSchema:
+                              description: PartialSchema is the partial OpenAPI schema that will be matched in a cluster.
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          - partialSchema
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+              required:
+              - queries
+              type: object
+            status:
+              description: Status is the capability status that has results of cluster queries.
+              properties:
+                results:
+                  description: Results represents the results of all the queries specified in the spec.
+                  items:
+                    description: Result represents the results of queries in Query.
+                    properties:
+                      groupVersionResources:
+                        description: GroupVersionResources represents results of GVR queries in spec.
+                        items:
+                          description: QueryResult represents the result of a single query.
+                          properties:
+                            error:
+                              description: Error indicates if an error occurred while processing the query.
+                              type: boolean
+                            errorDetail:
+                              description: ErrorDetail represents the error detail, if an error occurred.
+                              type: string
+                            found:
+                              description: Found is a boolean which indicates if the query condition succeeded.
+                              type: boolean
+                            name:
+                              description: Name is the name of the query in spec whose result this struct represents.
+                              minLength: 1
+                              type: string
+                            notFoundReason:
+                              description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      name:
+                        description: Name is the unique name of the query.
+                        minLength: 1
+                        type: string
+                      objects:
+                        description: Objects represents results of Object queries in spec.
+                        items:
+                          description: QueryResult represents the result of a single query.
+                          properties:
+                            error:
+                              description: Error indicates if an error occurred while processing the query.
+                              type: boolean
+                            errorDetail:
+                              description: ErrorDetail represents the error detail, if an error occurred.
+                              type: string
+                            found:
+                              description: Found is a boolean which indicates if the query condition succeeded.
+                              type: boolean
+                            name:
+                              description: Name is the name of the query in spec whose result this struct represents.
+                              minLength: 1
+                              type: string
+                            notFoundReason:
+                              description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      partialSchemas:
+                        description: PartialSchemas represents results of PartialSchema queries in spec.
+                        items:
+                          description: QueryResult represents the result of a single query.
+                          properties:
+                            error:
+                              description: Error indicates if an error occurred while processing the query.
+                              type: boolean
+                            errorDetail:
+                              description: ErrorDetail represents the error detail, if an error occurred.
+                              type: string
+                            found:
+                              description: Found is a boolean which indicates if the query condition succeeded.
+                              type: boolean
+                            name:
+                              description: Name is the name of the query in spec whose result this struct represents.
+                              minLength: 1
+                              type: string
+                            notFoundReason:
+                              description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                  - name
+                  x-kubernetes-list-type: map
+              required:
+              - results
+              type: object
+          type: object
+      version: v1alpha1
+      versions:
+      - name: v1alpha1
+        served: true
+        storage: true
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: tanzu-capabilities-manager
+      name: tanzu-capabilities-manager-sa
+      namespace: tkg-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-capabilities-manager-clusterrole
+    rules:
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - capabilities
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - capabilities/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases
+      - tanzukubernetesreleases/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesclusters
+      - tanzukubernetesclusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - clusterctl.cluster.x-k8s.io
+      resources:
+      - providers
+      - providers/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - namespaces
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-capabilities-manager-clusterrolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-capabilities-manager-clusterrole
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-capabilities-manager-sa
+      namespace: tkg-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: tanzu-capabilities-manager
+      name: tanzu-capabilities-controller-manager
+      namespace: tkg-system
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: tanzu-capabilities-manager
+      template:
+        metadata:
+          labels:
+            app: tanzu-capabilities-manager
+        spec:
+          containers:
+          - image: projects.registry.vmware.com/tkg/tanzu_core/capabilities/capabilities-controller-manager:v1.4.2
+            imagePullPolicy: IfNotPresent
+            name: manager
+            resources:
+              limits:
+                cpu: 100m
+                memory: 30Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+          serviceAccount: tanzu-capabilities-manager-sa
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+type: addons.cluster.x-k8s.io/resource-set
+---

--- a/tanzu/crs/v1.5.4/v1.5.4-antrea.yaml.template
+++ b/tanzu/crs/v1.5.4/v1.5.4-antrea.yaml.template
@@ -1,0 +1,4726 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-antrea
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-antrea-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  name: __CLUSTER_NAME__-antrea-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreaagentinfos.clusterinformation.antrea.tanzu.vmware.com
+    spec:
+      group: clusterinformation.antrea.tanzu.vmware.com
+      names:
+        kind: AntreaAgentInfo
+        plural: antreaagentinfos
+        shortNames:
+        - laai
+        singular: antreaagentinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreaagentinfos.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: AntreaAgentInfo
+        plural: antreaagentinfos
+        shortNames:
+        - aai
+        singular: antreaagentinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreacontrollerinfos.clusterinformation.antrea.tanzu.vmware.com
+    spec:
+      group: clusterinformation.antrea.tanzu.vmware.com
+      names:
+        kind: AntreaControllerInfo
+        plural: antreacontrollerinfos
+        shortNames:
+        - laci
+        singular: antreacontrollerinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: antreacontrollerinfos.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: AntreaControllerInfo
+        plural: antreacontrollerinfos
+        shortNames:
+        - aci
+        singular: antreacontrollerinfo
+      scope: Cluster
+      versions:
+      - name: v1beta1
+        schema:
+          openAPIV3Schema:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clustergroups.core.antrea.tanzu.vmware.com
+    spec:
+      group: core.antrea.tanzu.vmware.com
+      names:
+        kind: ClusterGroup
+        plural: clustergroups
+        shortNames:
+        - lcg
+        singular: group
+      scope: Cluster
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  childGroups:
+                    items:
+                      type: string
+                    type: array
+                  externalEntitySelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  ipBlock:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                  ipBlocks:
+                    items:
+                      properties:
+                        cidr:
+                          format: cidr
+                          type: string
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  podSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  serviceReference:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clustergroups.crd.antrea.io
+    spec:
+      conversion:
+        strategy: Webhook
+        webhook:
+          clientConfig:
+            service:
+              name: antrea
+              namespace: kube-system
+              path: /convert/clustergroup
+          conversionReviewVersions:
+          - v1
+          - v1beta1
+      group: crd.antrea.io
+      names:
+        kind: ClusterGroup
+        plural: clustergroups
+        shortNames:
+        - cg
+        singular: group
+      scope: Cluster
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  childGroups:
+                    items:
+                      type: string
+                    type: array
+                  externalEntitySelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  ipBlock:
+                    properties:
+                      cidr:
+                        format: cidr
+                        type: string
+                    type: object
+                  ipBlocks:
+                    items:
+                      properties:
+                        cidr:
+                          format: cidr
+                          type: string
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  podSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  serviceReference:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: false
+      - name: v1alpha3
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  childGroups:
+                    items:
+                      type: string
+                    type: array
+                  externalEntitySelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  ipBlocks:
+                    items:
+                      properties:
+                        cidr:
+                          format: cidr
+                          type: string
+                      type: object
+                    type: array
+                  namespaceSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  podSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  serviceReference:
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clusternetworkpolicies.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: ClusterNetworkPolicy
+        plural: clusternetworkpolicies
+        shortNames:
+        - acnp
+        singular: clusternetworkpolicy
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this ClusterNetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this ClusterNetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              fqdn:
+                                type: string
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              namespaces:
+                                properties:
+                                  match:
+                                    type: string
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              namespaces:
+                                properties:
+                                  match:
+                                    type: string
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: clusternetworkpolicies.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: ClusterNetworkPolicy
+        plural: clusternetworkpolicies
+        shortNames:
+        - lacnp
+        singular: clusternetworkpolicy
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this ClusterNetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this ClusterNetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        group:
+                          type: string
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              namespaces:
+                                properties:
+                                  match:
+                                    type: string
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              group:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              namespaces:
+                                properties:
+                                  match:
+                                    type: string
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: egresses.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: Egress
+        plural: egresses
+        shortNames:
+        - eg
+        singular: egress
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: Specifies the SNAT IP address for the selected workloads.
+          jsonPath: .spec.egressIP
+          name: EgressIP
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: The Owner Node of egress IP
+          jsonPath: .status.egressNode
+          name: Node
+          type: string
+        name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                anyOf:
+                - required:
+                  - egressIP
+                - required:
+                  - externalIPPool
+                properties:
+                  appliedTo:
+                    properties:
+                      namespaceSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      podSelector:
+                        properties:
+                          matchExpressions:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            type: array
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                    type: object
+                  egressIP:
+                    oneOf:
+                    - format: ipv4
+                    - format: ipv6
+                    type: string
+                  externalIPPool:
+                    type: string
+                required:
+                - appliedTo
+                type: object
+              status:
+                properties:
+                  egressNode:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: externalentities.core.antrea.tanzu.vmware.com
+    spec:
+      group: core.antrea.tanzu.vmware.com
+      names:
+        kind: ExternalEntity
+        plural: externalentities
+        shortNames:
+        - lee
+        singular: externalentity
+      scope: Namespaced
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  endpoints:
+                    items:
+                      properties:
+                        ip:
+                          oneOf:
+                          - format: ipv4
+                          - format: ipv6
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  externalNode:
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            type: object
+        served: false
+        storage: false
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: externalentities.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: ExternalEntity
+        plural: externalentities
+        shortNames:
+        - ee
+        singular: externalentity
+      scope: Namespaced
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  endpoints:
+                    items:
+                      properties:
+                        ip:
+                          oneOf:
+                          - format: ipv4
+                          - format: ipv6
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  externalNode:
+                    type: string
+                  ports:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        port:
+                          x-kubernetes-int-or-string: true
+                        protocol:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            type: object
+        served: false
+        storage: false
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: externalippools.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: ExternalIPPool
+        plural: externalippools
+        shortNames:
+        - eip
+        singular: externalippool
+      scope: Cluster
+      versions:
+      - name: v1alpha2
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  ipRanges:
+                    items:
+                      oneOf:
+                      - required:
+                        - cidr
+                      - required:
+                        - start
+                        - end
+                      properties:
+                        cidr:
+                          format: cidr
+                          type: string
+                        end:
+                          oneOf:
+                          - format: ipv4
+                          - format: ipv6
+                          type: string
+                        start:
+                          oneOf:
+                          - format: ipv4
+                          - format: ipv6
+                          type: string
+                      type: object
+                    type: array
+                  nodeSelector:
+                    properties:
+                      matchExpressions:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              enum:
+                              - In
+                              - NotIn
+                              - Exists
+                              - DoesNotExist
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      matchLabels:
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                required:
+                - ipRanges
+                - nodeSelector
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: networkpolicies.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: NetworkPolicy
+        plural: networkpolicies
+        shortNames:
+        - anp
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this Antrea NetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              fqdn:
+                                type: string
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: networkpolicies.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: NetworkPolicy
+        plural: networkpolicies
+        shortNames:
+        - lanp
+        singular: networkpolicy
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: The Tier to which this Antrea NetworkPolicy belongs to.
+          jsonPath: .spec.tier
+          name: Tier
+          type: string
+        - description: The Priority of this Antrea NetworkPolicy relative to other policies.
+          format: float
+          jsonPath: .spec.priority
+          name: Priority
+          type: number
+        - description: The total number of Nodes that should realize the NetworkPolicy.
+          format: int32
+          jsonPath: .status.desiredNodesRealized
+          name: Desired Nodes
+          type: number
+        - description: The number of Nodes that have realized the NetworkPolicy.
+          format: int32
+          jsonPath: .status.currentNodesRealized
+          name: Current Nodes
+          type: number
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  appliedTo:
+                    items:
+                      properties:
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            matchLabels:
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                        to:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    items:
+                      properties:
+                        action:
+                          enum:
+                          - Allow
+                          - Drop
+                          - Reject
+                          type: string
+                        appliedTo:
+                          items:
+                            properties:
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          type: boolean
+                        from:
+                          items:
+                            properties:
+                              externalEntitySelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              ipBlock:
+                                properties:
+                                  cidr:
+                                    format: cidr
+                                    type: string
+                                type: object
+                              namespaceSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              podSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          enum:
+                                          - In
+                                          - NotIn
+                                          - Exists
+                                          - DoesNotExist
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          type: array
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              endPort:
+                                type: integer
+                              port:
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    format: float
+                    maximum: 10000
+                    minimum: 1
+                    type: number
+                  tier:
+                    type: string
+                required:
+                - priority
+                type: object
+              status:
+                properties:
+                  currentNodesRealized:
+                    type: integer
+                  desiredNodesRealized:
+                    type: integer
+                  observedGeneration:
+                    type: integer
+                  phase:
+                    type: string
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tierentitlementbindings.crd.antrea.tanzu.vmware.com
+    spec:
+      group: crd.antrea.tanzu.vmware.com
+      names:
+        kind: TierEntitlementBinding
+        plural: tierentitlementbindings
+        shortNames:
+        - teb
+        singular: tierentitlementbinding
+      scope: Cluster
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  subjects:
+                    items:
+                      properties:
+                        apiGroup:
+                          enum:
+                          - rbac.authorization.k8s.io
+                          type: string
+                        kind:
+                          enum:
+                          - User
+                          - Group
+                          - ServiceAccount
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                    type: array
+                  tierEntitlement:
+                    type: string
+                required:
+                - tierEntitlement
+                - subjects
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tierentitlements.crd.antrea.tanzu.vmware.com
+    spec:
+      group: crd.antrea.tanzu.vmware.com
+      names:
+        kind: TierEntitlement
+        plural: tierentitlements
+        shortNames:
+        - te
+        singular: tierentitlement
+      scope: Cluster
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  permission:
+                    enum:
+                    - edit
+                    - read
+                    type: string
+                  tiers:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - permission
+                - tiers
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tiers.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: Tier
+        plural: tiers
+        shortNames:
+        - tr
+        singular: tier
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Priority of this Tier relative to other Tiers.
+          jsonPath: .spec.priority
+          name: Priority
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  description:
+                    type: string
+                  priority:
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                required:
+                - priority
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: tiers.security.antrea.tanzu.vmware.com
+    spec:
+      group: security.antrea.tanzu.vmware.com
+      names:
+        kind: Tier
+        plural: tiers
+        shortNames:
+        - ltr
+        singular: tier
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The Priority of this Tier relative to other Tiers.
+          jsonPath: .spec.priority
+          name: Priority
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  description:
+                    type: string
+                  priority:
+                    maximum: 255
+                    minimum: 0
+                    type: integer
+                required:
+                - priority
+                type: object
+            type: object
+        served: true
+        storage: true
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: traceflows.crd.antrea.io
+    spec:
+      group: crd.antrea.io
+      names:
+        kind: Traceflow
+        plural: traceflows
+        shortNames:
+        - tf
+        singular: traceflow
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The phase of the Traceflow.
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: The name of the source Pod.
+          jsonPath: .spec.source.pod
+          name: Source-Pod
+          priority: 10
+          type: string
+        - description: The name of the destination Pod.
+          jsonPath: .spec.destination.pod
+          name: Destination-Pod
+          priority: 10
+          type: string
+        - description: The IP address of the destination.
+          jsonPath: .spec.destination.ip
+          name: Destination-IP
+          priority: 10
+          type: string
+        - description: Trace live traffic.
+          jsonPath: .spec.liveTraffic
+          name: Live-Traffic
+          priority: 10
+          type: boolean
+        - description: Capture only the dropped packet.
+          jsonPath: .spec.droppedOnly
+          name: Dropped-Only
+          priority: 10
+          type: boolean
+        - description: Timeout in seconds.
+          jsonPath: .spec.timeout
+          name: Timeout
+          priority: 10
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  destination:
+                    properties:
+                      ip:
+                        oneOf:
+                        - format: ipv4
+                        - format: ipv6
+                        type: string
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                      service:
+                        type: string
+                    type: object
+                  droppedOnly:
+                    type: boolean
+                  liveTraffic:
+                    type: boolean
+                  packet:
+                    properties:
+                      ipHeader:
+                        properties:
+                          flags:
+                            type: integer
+                          protocol:
+                            type: integer
+                          srcIP:
+                            oneOf:
+                            - format: ipv4
+                            - format: ipv6
+                            type: string
+                          ttl:
+                            type: integer
+                        type: object
+                      ipv6Header:
+                        properties:
+                          hopLimit:
+                            type: integer
+                          nextHeader:
+                            type: integer
+                          srcIP:
+                            format: ipv6
+                            type: string
+                        type: object
+                      transportHeader:
+                        properties:
+                          icmp:
+                            properties:
+                              id:
+                                type: integer
+                              sequence:
+                                type: integer
+                            type: object
+                          tcp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              flags:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                          udp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  source:
+                    properties:
+                      ip:
+                        oneOf:
+                        - format: ipv4
+                        - format: ipv6
+                        type: string
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                    type: object
+                  timeout:
+                    type: integer
+                type: object
+              status:
+                properties:
+                  capturedPacket:
+                    properties:
+                      dstIP:
+                        type: string
+                      ipHeader:
+                        properties:
+                          flags:
+                            type: integer
+                          protocol:
+                            type: integer
+                          ttl:
+                            type: integer
+                        type: object
+                      ipv6Header:
+                        properties:
+                          hopLimit:
+                            type: integer
+                          nextHeader:
+                            type: integer
+                        type: object
+                      length:
+                        type: integer
+                      srcIP:
+                        type: string
+                      transportHeader:
+                        properties:
+                          icmp:
+                            properties:
+                              id:
+                                type: integer
+                              sequence:
+                                type: integer
+                            type: object
+                          tcp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              flags:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                          udp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  dataplaneTag:
+                    type: integer
+                  phase:
+                    type: string
+                  reason:
+                    type: string
+                  results:
+                    items:
+                      properties:
+                        node:
+                          type: string
+                        observations:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              component:
+                                type: string
+                              componentInfo:
+                                type: string
+                              dstMAC:
+                                type: string
+                              networkPolicy:
+                                type: string
+                              pod:
+                                type: string
+                              translatedDstIP:
+                                type: string
+                              translatedSrcIP:
+                                type: string
+                              ttl:
+                                type: integer
+                              tunnelDstIP:
+                                type: string
+                            type: object
+                          type: array
+                        role:
+                          type: string
+                        timestamp:
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      labels:
+        app: antrea
+      name: traceflows.ops.antrea.tanzu.vmware.com
+    spec:
+      group: ops.antrea.tanzu.vmware.com
+      names:
+        kind: Traceflow
+        plural: traceflows
+        shortNames:
+        - ltf
+        singular: traceflow
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - description: The phase of the Traceflow.
+          jsonPath: .status.phase
+          name: Phase
+          type: string
+        - description: The name of the source Pod.
+          jsonPath: .spec.source.pod
+          name: Source-Pod
+          priority: 10
+          type: string
+        - description: The name of the destination Pod.
+          jsonPath: .spec.destination.pod
+          name: Destination-Pod
+          priority: 10
+          type: string
+        - description: The IP address of the destination.
+          jsonPath: .spec.destination.ip
+          name: Destination-IP
+          priority: 10
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  destination:
+                    properties:
+                      ip:
+                        oneOf:
+                        - format: ipv4
+                        - format: ipv6
+                        type: string
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                      service:
+                        type: string
+                    type: object
+                  packet:
+                    properties:
+                      ipHeader:
+                        properties:
+                          flags:
+                            type: integer
+                          protocol:
+                            type: integer
+                          srcIP:
+                            oneOf:
+                            - format: ipv4
+                            - format: ipv6
+                            type: string
+                          ttl:
+                            type: integer
+                        type: object
+                      ipv6Header:
+                        properties:
+                          hopLimit:
+                            type: integer
+                          nextHeader:
+                            type: integer
+                          srcIP:
+                            format: ipv6
+                            type: string
+                        type: object
+                      transportHeader:
+                        properties:
+                          icmp:
+                            properties:
+                              id:
+                                type: integer
+                              sequence:
+                                type: integer
+                            type: object
+                          tcp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              flags:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                          udp:
+                            properties:
+                              dstPort:
+                                type: integer
+                              srcPort:
+                                type: integer
+                            type: object
+                        type: object
+                    type: object
+                  source:
+                    properties:
+                      namespace:
+                        type: string
+                      pod:
+                        type: string
+                    required:
+                    - pod
+                    - namespace
+                    type: object
+                required:
+                - source
+                type: object
+              status:
+                properties:
+                  dataplaneTag:
+                    type: integer
+                  phase:
+                    type: string
+                  reason:
+                    type: string
+                  results:
+                    items:
+                      properties:
+                        node:
+                          type: string
+                        observations:
+                          items:
+                            properties:
+                              action:
+                                type: string
+                              component:
+                                type: string
+                              componentInfo:
+                                type: string
+                              dstMAC:
+                                type: string
+                              networkPolicy:
+                                type: string
+                              pod:
+                                type: string
+                              translatedDstIP:
+                                type: string
+                              translatedSrcIP:
+                                type: string
+                              ttl:
+                                type: integer
+                              tunnelDstIP:
+                                type: string
+                            type: object
+                          type: array
+                        role:
+                          type: string
+                        timestamp:
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-antrea-clustergroups-edit
+    rules:
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-antrea-clustergroups-view
+    rules:
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clustergroups
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-antrea-policies-edit
+    rules:
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-antrea-policies-view
+    rules:
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-admin: "true"
+        rbac.authorization.k8s.io/aggregate-to-edit: "true"
+      name: aggregate-traceflows-edit
+    rules:
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+      name: aggregate-traceflows-view
+    rules:
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - traceflows
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+    rules:
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - controlplane.antrea.io
+      resources:
+      - networkpolicies
+      - appliedtogroups
+      - addressgroups
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - stats.antrea.tanzu.vmware.com
+      - stats.antrea.io
+      resources:
+      - networkpolicystats
+      - antreaclusternetworkpolicystats
+      - antreanetworkpolicystats
+      verbs:
+      - get
+      - list
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      - system.antrea.io
+      resources:
+      - controllerinfos
+      - agentinfos
+      verbs:
+      - get
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      - system.antrea.io
+      resources:
+      - supportbundles
+      verbs:
+      - get
+      - post
+    - apiGroups:
+      - system.antrea.tanzu.vmware.com
+      - system.antrea.io
+      resources:
+      - supportbundles/download
+      verbs:
+      - get
+    - nonResourceURLs:
+      - /agentinfo
+      - /addressgroups
+      - /appliedtogroups
+      - /loglevel
+      - /networkpolicies
+      - /ovsflows
+      - /ovstracing
+      - /podinterfaces
+      - /featuregates
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - watch
+      - list
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - watch
+      - list
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - endpoints
+      - services
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - discovery.k8s.io
+      resources:
+      - endpointslices
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      - crd.antrea.io
+      resources:
+      - antreaagentinfos
+      verbs:
+      - get
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - controlplane.antrea.io
+      resources:
+      - networkpolicies
+      - appliedtogroups
+      - addressgroups
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - controlplane.antrea.io
+      resources:
+      - egressgroups
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - controlplane.antrea.io
+      resources:
+      - nodestatssummaries
+      verbs:
+      - create
+    - apiGroups:
+      - controlplane.antrea.tanzu.vmware.com
+      - controlplane.antrea.io
+      resources:
+      - networkpolicies/status
+      verbs:
+      - create
+      - get
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resourceNames:
+      - extension-apiserver-authentication
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-ca
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      - crd.antrea.io
+      resources:
+      - traceflows
+      - traceflows/status
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - egresses
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - egresses/status
+      verbs:
+      - update
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - externalippools
+      verbs:
+      - get
+      - watch
+      - list
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-cluster-identity-reader
+    rules:
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-cluster-identity
+      resources:
+      - configmaps
+      verbs:
+      - get
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - namespaces
+      - services
+      - configmaps
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - watch
+      - list
+      - patch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - networkpolicies
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - authentication.k8s.io
+      resources:
+      - tokenreviews
+      verbs:
+      - create
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - ""
+      resourceNames:
+      - extension-apiserver-authentication
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-ca
+      - antrea-cluster-identity
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resourceNames:
+      - antrea-config-822fk25299
+      resources:
+      - configmaps
+      verbs:
+      - get
+    - apiGroups:
+      - apiregistration.k8s.io
+      resourceNames:
+      - v1alpha1.stats.antrea.tanzu.vmware.com
+      - v1beta1.system.antrea.tanzu.vmware.com
+      - v1beta2.controlplane.antrea.tanzu.vmware.com
+      - v1beta1.controlplane.antrea.tanzu.vmware.com
+      - v1alpha1.stats.antrea.io
+      - v1beta1.system.antrea.io
+      - v1beta2.controlplane.antrea.io
+      resources:
+      - apiservices
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - apiregistration.k8s.io
+      resourceNames:
+      - v1beta1.networking.antrea.tanzu.vmware.com
+      resources:
+      - apiservices
+      verbs:
+      - delete
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resourceNames:
+      - crdmutator.antrea.tanzu.vmware.com
+      - crdvalidator.antrea.tanzu.vmware.com
+      - labelsmutator.antrea.io
+      - crdmutator.antrea.io
+      - crdvalidator.antrea.io
+      resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - antreacontrollerinfos
+      verbs:
+      - get
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - antreaagentinfos
+      verbs:
+      - list
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clusternetworkpolicies/status
+      - networkpolicies/status
+      verbs:
+      - update
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - tiers
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - traceflows
+      - traceflows/status
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - externalentities
+      - clustergroups
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - clustergroups/status
+      verbs:
+      - update
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - egresses
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+    - apiGroups:
+      - crd.antrea.io
+      resources:
+      - externalippools
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      resources:
+      - antreacontrollerinfos
+      verbs:
+      - get
+      - create
+      - update
+      - delete
+    - apiGroups:
+      - clusterinformation.antrea.tanzu.vmware.com
+      resources:
+      - antreaagentinfos
+      verbs:
+      - list
+      - delete
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies
+      - networkpolicies
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - clusternetworkpolicies/status
+      - networkpolicies/status
+      verbs:
+      - update
+    - apiGroups:
+      - security.antrea.tanzu.vmware.com
+      resources:
+      - tiers
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - crd.antrea.tanzu.vmware.com
+      resources:
+      - tierentitlements
+      - tierentitlementbindings
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ops.antrea.tanzu.vmware.com
+      resources:
+      - traceflows
+      - traceflows/status
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - externalentities
+      - clustergroups
+      verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch
+      - create
+      - delete
+    - apiGroups:
+      - core.antrea.tanzu.vmware.com
+      resources:
+      - clustergroups/status
+      verbs:
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antctl
+      namespace: kube-system
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antctl
+    subjects:
+    - kind: ServiceAccount
+      name: antctl
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antrea-agent
+    subjects:
+    - kind: ServiceAccount
+      name: antrea-agent
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: antrea-controller
+    subjects:
+    - kind: ServiceAccount
+      name: antrea-controller
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      antrea-agent-tweaker.conf: |
+        disableUdpTunnelOffload: false
+    kind: ConfigMap
+    metadata:
+      labels:
+        app: antrea
+      name: antrea-agent-tweaker-g56hc6fh8t
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    data:
+      antrea-agent.conf: |
+        featureGates:
+          AntreaProxy: true
+          EndpointSlice: false
+          Traceflow: true
+          NodePortLocal: false
+          AntreaPolicy: true
+          FlowExporter: false
+          NetworkPolicyStats: false
+          Egress: false
+        trafficEncapMode: encap
+        noSNAT: false
+        serviceCIDR: 100.64.0.0/13
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+      antrea-cni.conflist: |
+        {
+            "cniVersion":"0.3.0",
+            "name": "antrea",
+            "plugins": [
+                {
+                    "type": "antrea",
+                    "ipam": {
+                        "type": "host-local"
+                    }
+                },
+                {
+                    "type": "portmap",
+                    "capabilities": {"portMappings": true}
+                },
+                {
+                    "type": "bandwidth",
+                    "capabilities": {"bandwidth": true}
+                }
+            ]
+        }
+      antrea-controller.conf: |
+        featureGates:
+          Traceflow: true
+          AntreaPolicy: true
+          NetworkPolicyStats: false
+          Egress: false
+        selfSignedCert: true
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+    kind: ConfigMap
+    metadata:
+      annotations: {}
+      labels:
+        app: antrea
+      name: antrea-config-822fk25299
+      namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app: antrea
+      name: antrea
+      namespace: kube-system
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: api
+      selector:
+        app: antrea
+        component: antrea-controller
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-controller
+      name: antrea-controller
+      namespace: kube-system
+      annotations:
+        kapp.k14s.io/disable-default-label-scoping-rules: ""
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: antrea
+          component: antrea-controller
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: antrea
+            component: antrea-controller
+        spec:
+          containers:
+          - args:
+            - --config
+            - /etc/antrea/antrea-controller.conf
+            - --logtostderr=false
+            - --log_dir=/var/log/antrea
+            - --alsologtostderr
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            - --v=0
+            command:
+            - antrea-controller
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: SERVICEACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: ANTREA_CONFIG_MAP_NAME
+              value: antrea-config-822fk25299
+            image: projects.registry.vmware.com/tkg/antrea-advanced-debian:v1.2.3_vmware.4
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                host: localhost
+                path: /livez
+                port: api
+                scheme: HTTPS
+              periodSeconds: 10
+              timeoutSeconds: 5
+            name: antrea-controller
+            ports:
+            - containerPort: 10349
+              name: api
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 5
+              httpGet:
+                host: localhost
+                path: /readyz
+                port: api
+                scheme: HTTPS
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 200m
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-controller.conf
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-controller.conf
+            - mountPath: /var/run/antrea/antrea-controller-tls
+              name: antrea-controller-tls
+            - mountPath: /var/log/antrea
+              name: host-var-log-antrea
+          hostNetwork: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-cluster-critical
+          serviceAccountName: antrea-controller
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          volumes:
+          - configMap:
+              name: antrea-config-822fk25299
+            name: antrea-config
+          - name: antrea-controller-tls
+            secret:
+              defaultMode: 256
+              optional: true
+              secretName: antrea-controller-tls
+          - hostPath:
+              path: /var/log/antrea
+              type: DirectoryOrCreate
+            name: host-var-log-antrea
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1alpha1.stats.antrea.io
+    spec:
+      group: stats.antrea.io
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1alpha1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1alpha1.stats.antrea.tanzu.vmware.com
+    spec:
+      group: stats.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1alpha1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.controlplane.antrea.tanzu.vmware.com
+    spec:
+      group: controlplane.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.system.antrea.io
+    spec:
+      group: system.antrea.io
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta1.system.antrea.tanzu.vmware.com
+    spec:
+      group: system.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta1
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta2.controlplane.antrea.io
+    spec:
+      group: controlplane.antrea.io
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta2
+      versionPriority: 100
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      labels:
+        app: antrea
+      name: v1beta2.controlplane.antrea.tanzu.vmware.com
+    spec:
+      group: controlplane.antrea.tanzu.vmware.com
+      groupPriorityMinimum: 100
+      service:
+        name: antrea
+        namespace: kube-system
+      version: v1beta2
+      versionPriority: 100
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-agent
+      name: antrea-agent
+      namespace: kube-system
+      annotations:
+        kapp.k14s.io/disable-default-label-scoping-rules: ""
+    spec:
+      selector:
+        matchLabels:
+          app: antrea
+          component: antrea-agent
+      template:
+        metadata:
+          annotations:
+            kubectl.kubernetes.io/default-container: antrea-agent
+          labels:
+            app: antrea
+            component: antrea-agent
+        spec:
+          containers:
+          - args:
+            - --config
+            - /etc/antrea/antrea-agent.conf
+            - --logtostderr=false
+            - --log_dir=/var/log/antrea
+            - --alsologtostderr
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            - --v=0
+            command:
+            - antrea-agent
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            image: projects.registry.vmware.com/tkg/antrea-advanced-debian:v1.2.3_vmware.4
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - container_liveness_probe agent
+              failureThreshold: 5
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            name: antrea-agent
+            ports:
+            - containerPort: 10350
+              name: api
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 8
+              httpGet:
+                host: localhost
+                path: /readyz
+                port: api
+                scheme: HTTPS
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 200m
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-agent.conf
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-agent.conf
+            - mountPath: /var/run/antrea
+              name: host-var-run-antrea
+            - mountPath: /var/run/openvswitch
+              name: host-var-run-antrea
+              subPath: openvswitch
+            - mountPath: /var/lib/cni
+              name: host-var-run-antrea
+              subPath: cni
+            - mountPath: /var/log/antrea
+              name: host-var-log-antrea
+            - mountPath: /host/proc
+              name: host-proc
+              readOnly: true
+            - mountPath: /host/var/run/netns
+              mountPropagation: HostToContainer
+              name: host-var-run-netns
+              readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+          - args:
+            - --log_file_max_size=100
+            - --log_file_max_num=4
+            command:
+            - start_ovs
+            image: projects.registry.vmware.com/tkg/antrea-advanced-debian:v1.2.3_vmware.4
+            imagePullPolicy: IfNotPresent
+            livenessProbe:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - timeout 10 container_liveness_probe ovs
+              failureThreshold: 5
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              timeoutSeconds: 10
+            name: antrea-ovs
+            resources:
+              requests:
+                cpu: 200m
+            securityContext:
+              capabilities:
+                add:
+                - SYS_NICE
+                - NET_ADMIN
+                - SYS_ADMIN
+                - IPC_LOCK
+            volumeMounts:
+            - mountPath: /var/run/openvswitch
+              name: host-var-run-antrea
+              subPath: openvswitch
+            - mountPath: /var/log/openvswitch
+              name: host-var-log-antrea
+              subPath: openvswitch
+          dnsPolicy: ClusterFirstWithHostNet
+          hostNetwork: true
+          initContainers:
+          - command:
+            - install_cni
+            image: projects.registry.vmware.com/tkg/antrea-advanced-debian:v1.2.3_vmware.4
+            imagePullPolicy: IfNotPresent
+            name: install-cni
+            resources:
+              requests:
+                cpu: 100m
+            securityContext:
+              capabilities:
+                add:
+                - SYS_MODULE
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-cni.conflist
+              name: antrea-config
+              readOnly: true
+              subPath: antrea-cni.conflist
+            - mountPath: /host/etc/cni/net.d
+              name: host-cni-conf
+            - mountPath: /host/opt/cni/bin
+              name: host-cni-bin
+            - mountPath: /lib/modules
+              name: host-lib-modules
+              readOnly: true
+            - mountPath: /var/run/antrea
+              name: host-var-run-antrea
+          - args:
+            - --config
+            - /etc/antrea/antrea-agent-tweaker.conf
+            command:
+            - antrea-agent-tweaker
+            env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            image: projects.registry.vmware.com/tkg/antrea-advanced-debian:v1.2.3_vmware.4
+            name: antrea-agent-tweaker
+            resources:
+              requests:
+                cpu: 100m
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+            volumeMounts:
+            - mountPath: /etc/antrea/antrea-agent-tweaker.conf
+              name: antrea-agent-tweaker-config
+              subPath: antrea-agent-tweaker.conf
+          nodeSelector:
+            kubernetes.io/os: linux
+          priorityClassName: system-node-critical
+          serviceAccountName: antrea-agent
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            operator: Exists
+          - effect: NoExecute
+            operator: Exists
+          volumes:
+          - configMap:
+              name: antrea-config-822fk25299
+            name: antrea-config
+          - configMap:
+              name: antrea-agent-tweaker-g56hc6fh8t
+            name: antrea-agent-tweaker-config
+          - hostPath:
+              path: /etc/cni/net.d
+            name: host-cni-conf
+          - hostPath:
+              path: /opt/cni/bin
+            name: host-cni-bin
+          - hostPath:
+              path: /proc
+            name: host-proc
+          - hostPath:
+              path: /var/run/netns
+            name: host-var-run-netns
+          - hostPath:
+              path: /var/run/antrea
+              type: DirectoryOrCreate
+            name: host-var-run-antrea
+          - hostPath:
+              path: /var/log/antrea
+              type: DirectoryOrCreate
+            name: host-var-log-antrea
+          - hostPath:
+              path: /lib/modules
+            name: host-lib-modules
+          - hostPath:
+              path: /run/xtables.lock
+              type: FileOrCreate
+            name: xtables-lock
+      updateStrategy:
+        type: RollingUpdate
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdmutator.antrea.io
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/acnp
+      name: acnpmutator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/anp
+      name: anpmutator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdmutator.antrea.tanzu.vmware.com
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/acnp
+      name: acnpmutator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /mutate/anp
+      name: anpmutator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdvalidator.antrea.io
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/tier
+      name: tiervalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - tiers
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/acnp
+      name: acnpvalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/anp
+      name: anpvalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/clustergroup
+      name: clustergroupvalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha3
+        - v1alpha2
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - clustergroups
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/externalippool
+      name: externalippoolvalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha2
+        operations:
+        - UPDATE
+        resources:
+        - externalippools
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/egress
+      name: egressvalidator.antrea.io
+      rules:
+      - apiGroups:
+        - crd.antrea.io
+        apiVersions:
+        - v1alpha2
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - egresses
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    ---
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        app: antrea
+      name: crdvalidator.antrea.tanzu.vmware.com
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/tier
+      name: tiervalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - tiers
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/acnp
+      name: acnpvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - clusternetworkpolicies
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/anp
+      name: anpvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - security.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - networkpolicies
+        scope: Namespaced
+      sideEffects: None
+      timeoutSeconds: 5
+    - admissionReviewVersions:
+      - v1
+      - v1beta1
+      clientConfig:
+        service:
+          name: antrea
+          namespace: kube-system
+          path: /validate/clustergroup
+      name: clustergroupvalidator.antrea.tanzu.vmware.com
+      rules:
+      - apiGroups:
+        - core.antrea.tanzu.vmware.com
+        apiVersions:
+        - v1alpha2
+        operations:
+        - CREATE
+        - UPDATE
+        - DELETE
+        resources:
+        - clustergroups
+        scope: Cluster
+      sideEffects: None
+      timeoutSeconds: 5
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: cni/antrea
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: antrea
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-antrea-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    infraProvider: vsphere
+    antrea:
+      config:
+        serviceCIDR: 100.64.0.0/13
+        trafficEncapMode: encap
+        noSNAT: false
+        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+        disableUdpTunnelOffload: false
+        featureGates:
+          AntreaProxy: true
+          EndpointSlice: false
+          AntreaPolicy: true
+          NodePortLocal: false
+          AntreaTraceflow: true
+type: tkg.tanzu.vmware.com/addon
+---

--- a/tanzu/crs/v1.5.4/v1.5.4.yaml.template
+++ b/tanzu/crs/v1.5.4/v1.5.4.yaml.template
@@ -1,0 +1,3674 @@
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-kapp-controller
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-kapp-controller-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+  name: __CLUSTER_NAME__-kapp-controller-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tanzu-package-repo-global
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: apiregistration.k8s.io/v1
+    kind: APIService
+    metadata:
+      name: v1alpha1.data.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: data.packaging.carvel.dev
+      groupPriorityMinimum: 100
+      service:
+        name: packaging-api
+        namespace: tkg-system
+      version: v1alpha1
+      versionPriority: 100
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: packaging-api
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      ports:
+      - port: 443
+        protocol: TCP
+        targetPort: api
+      selector:
+        app: kapp-controller
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: internalpackagemetadatas.internal.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: internal.packaging.carvel.dev
+      names:
+        kind: InternalPackageMetadata
+        listKind: InternalPackageMetadataList
+        plural: internalpackagemetadatas
+        singular: internalpackagemetadata
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  categories:
+                    items:
+                      type: string
+                    type: array
+                  displayName:
+                    type: string
+                  iconSVGBase64:
+                    type: string
+                  longDescription:
+                    type: string
+                  maintainers:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  providerName:
+                    type: string
+                  shortDescription:
+                    type: string
+                  supportDescription:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: internalpackages.internal.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: internal.packaging.carvel.dev
+      names:
+        kind: InternalPackage
+        listKind: InternalPackageList
+        plural: internalpackages
+        singular: internalpackage
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  capacityRequirementsDescription:
+                    type: string
+                  licenses:
+                    items:
+                      type: string
+                    type: array
+                  refName:
+                    type: string
+                  releaseNotes:
+                    type: string
+                  releasedAt:
+                    format: date-time
+                    nullable: true
+                    type: string
+                  template:
+                    properties:
+                      spec:
+                        properties:
+                          canceled:
+                            description: Canceled when set to true will stop all active changes
+                            type: boolean
+                          cluster:
+                            properties:
+                              kubeconfigSecretRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              namespace:
+                                type: string
+                            type: object
+                          deploy:
+                            items:
+                              properties:
+                                kapp:
+                                  properties:
+                                    delete:
+                                      properties:
+                                        rawOptions:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    inspect:
+                                      properties:
+                                        rawOptions:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    intoNs:
+                                      type: string
+                                    mapNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                    rawOptions:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          fetch:
+                            items:
+                              properties:
+                                git:
+                                  description: TODO implement git
+                                  properties:
+                                    lfsSkipSmudge:
+                                      type: boolean
+                                    ref:
+                                      type: string
+                                    refSelection:
+                                      properties:
+                                        semver:
+                                          properties:
+                                            constraints:
+                                              type: string
+                                            prereleases:
+                                              properties:
+                                                identifiers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                          type: object
+                                      type: object
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    subPath:
+                                      type: string
+                                    url:
+                                      type: string
+                                  type: object
+                                helmChart:
+                                  properties:
+                                    name:
+                                      description: 'Example: stable/redis'
+                                      type: string
+                                    repository:
+                                      properties:
+                                        secretRef:
+                                          properties:
+                                            name:
+                                              description: Object is expected to be within same namespace
+                                              type: string
+                                          type: object
+                                        url:
+                                          type: string
+                                      type: object
+                                    version:
+                                      type: string
+                                  type: object
+                                http:
+                                  properties:
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    sha256:
+                                      type: string
+                                    subPath:
+                                      type: string
+                                    url:
+                                      description: 'URL can point to one of following formats: text, tgz, zip'
+                                      type: string
+                                  type: object
+                                image:
+                                  properties:
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    subPath:
+                                      type: string
+                                    tagSelection:
+                                      properties:
+                                        semver:
+                                          properties:
+                                            constraints:
+                                              type: string
+                                            prereleases:
+                                              properties:
+                                                identifiers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                          type: object
+                                      type: object
+                                    url:
+                                      description: 'Example: username/app1-config:v0.1.0'
+                                      type: string
+                                  type: object
+                                imgpkgBundle:
+                                  properties:
+                                    image:
+                                      type: string
+                                    secretRef:
+                                      description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                                      properties:
+                                        name:
+                                          description: Object is expected to be within same namespace
+                                          type: string
+                                      type: object
+                                    tagSelection:
+                                      properties:
+                                        semver:
+                                          properties:
+                                            constraints:
+                                              type: string
+                                            prereleases:
+                                              properties:
+                                                identifiers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                          type: object
+                                      type: object
+                                  type: object
+                                inline:
+                                  properties:
+                                    paths:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    pathsFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                          secretRef:
+                                            properties:
+                                              directoryPath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                          noopDelete:
+                            description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                            type: boolean
+                          paused:
+                            description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                            type: boolean
+                          serviceAccountName:
+                            type: string
+                          syncPeriod:
+                            description: Controls frequency of app reconciliation
+                            type: string
+                          template:
+                            items:
+                              properties:
+                                helmTemplate:
+                                  properties:
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    path:
+                                      type: string
+                                    valuesFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          path:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                jsonnet:
+                                  description: TODO implement jsonnet
+                                  type: object
+                                kbld:
+                                  properties:
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                kustomize:
+                                  description: TODO implement kustomize
+                                  type: object
+                                sops:
+                                  properties:
+                                    age:
+                                      properties:
+                                        privateKeysSecretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                    pgp:
+                                      properties:
+                                        privateKeysSecretRef:
+                                          properties:
+                                            name:
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                ytt:
+                                  properties:
+                                    fileMarks:
+                                      items:
+                                        type: string
+                                      type: array
+                                    ignoreUnknownComments:
+                                      type: boolean
+                                    inline:
+                                      properties:
+                                        paths:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        pathsFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  directoryPath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                              secretRef:
+                                                properties:
+                                                  directoryPath:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          type: array
+                                      type: object
+                                    paths:
+                                      items:
+                                        type: string
+                                      type: array
+                                    strict:
+                                      type: boolean
+                                    valuesFrom:
+                                      items:
+                                        properties:
+                                          configMapRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                          path:
+                                            type: string
+                                          secretRef:
+                                            properties:
+                                              name:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    required:
+                    - spec
+                    type: object
+                  valuesSchema:
+                    description: valuesSchema can be used to show template values that can be configured by users when a Package is installed in an OpenAPI schema format.
+                    properties:
+                      openAPIv3:
+                        nullable: true
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    type: object
+                  version:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: apps.kappctrl.k14s.io
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: kappctrl.k14s.io
+      names:
+        kind: App
+        listKind: AppList
+        plural: apps
+        singular: app
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        - description: Last time app started being deployed. Does not mean anything was changed.
+          jsonPath: .status.deploy.startedAt
+          name: Since-Deploy
+          type: date
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  canceled:
+                    description: Canceled when set to true will stop all active changes
+                    type: boolean
+                  cluster:
+                    properties:
+                      kubeconfigSecretRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      namespace:
+                        type: string
+                    type: object
+                  deploy:
+                    items:
+                      properties:
+                        kapp:
+                          properties:
+                            delete:
+                              properties:
+                                rawOptions:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            inspect:
+                              properties:
+                                rawOptions:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            intoNs:
+                              type: string
+                            mapNs:
+                              items:
+                                type: string
+                              type: array
+                            rawOptions:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  fetch:
+                    items:
+                      properties:
+                        git:
+                          description: TODO implement git
+                          properties:
+                            lfsSkipSmudge:
+                              type: boolean
+                            ref:
+                              type: string
+                            refSelection:
+                              properties:
+                                semver:
+                                  properties:
+                                    constraints:
+                                      type: string
+                                    prereleases:
+                                      properties:
+                                        identifiers:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            subPath:
+                              type: string
+                            url:
+                              type: string
+                          type: object
+                        helmChart:
+                          properties:
+                            name:
+                              description: 'Example: stable/redis'
+                              type: string
+                            repository:
+                              properties:
+                                secretRef:
+                                  properties:
+                                    name:
+                                      description: Object is expected to be within same namespace
+                                      type: string
+                                  type: object
+                                url:
+                                  type: string
+                              type: object
+                            version:
+                              type: string
+                          type: object
+                        http:
+                          properties:
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            sha256:
+                              type: string
+                            subPath:
+                              type: string
+                            url:
+                              description: 'URL can point to one of following formats: text, tgz, zip'
+                              type: string
+                          type: object
+                        image:
+                          properties:
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            subPath:
+                              type: string
+                            tagSelection:
+                              properties:
+                                semver:
+                                  properties:
+                                    constraints:
+                                      type: string
+                                    prereleases:
+                                      properties:
+                                        identifiers:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                  type: object
+                              type: object
+                            url:
+                              description: 'Example: username/app1-config:v0.1.0'
+                              type: string
+                          type: object
+                        imgpkgBundle:
+                          properties:
+                            image:
+                              type: string
+                            secretRef:
+                              description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                              properties:
+                                name:
+                                  description: Object is expected to be within same namespace
+                                  type: string
+                              type: object
+                            tagSelection:
+                              properties:
+                                semver:
+                                  properties:
+                                    constraints:
+                                      type: string
+                                    prereleases:
+                                      properties:
+                                        identifiers:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                  type: object
+                              type: object
+                          type: object
+                        inline:
+                          properties:
+                            paths:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            pathsFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  secretRef:
+                                    properties:
+                                      directoryPath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  noopDelete:
+                    description: When NoopDeletion set to true, App deletion should delete App CR but preserve App's associated resources
+                    type: boolean
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  serviceAccountName:
+                    type: string
+                  syncPeriod:
+                    description: Controls frequency of app reconciliation
+                    type: string
+                  template:
+                    items:
+                      properties:
+                        helmTemplate:
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            path:
+                              type: string
+                            valuesFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  path:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        jsonnet:
+                          description: TODO implement jsonnet
+                          type: object
+                        kbld:
+                          properties:
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        kustomize:
+                          description: TODO implement kustomize
+                          type: object
+                        sops:
+                          properties:
+                            age:
+                              properties:
+                                privateKeysSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                            pgp:
+                              properties:
+                                privateKeysSecretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        ytt:
+                          properties:
+                            fileMarks:
+                              items:
+                                type: string
+                              type: array
+                            ignoreUnknownComments:
+                              type: boolean
+                            inline:
+                              properties:
+                                paths:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                pathsFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                      secretRef:
+                                        properties:
+                                          directoryPath:
+                                            type: string
+                                          name:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            paths:
+                              items:
+                                type: string
+                              type: array
+                            strict:
+                              type: boolean
+                            valuesFrom:
+                              items:
+                                properties:
+                                  configMapRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  path:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  consecutiveReconcileFailures:
+                    type: integer
+                  consecutiveReconcileSuccesses:
+                    type: integer
+                  deploy:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      finished:
+                        type: boolean
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  fetch:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  friendlyDescription:
+                    type: string
+                  inspect:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  managedAppName:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  template:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  usefulErrorMessage:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      name: packageinstalls.packaging.carvel.dev
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    spec:
+      group: packaging.carvel.dev
+      names:
+        kind: PackageInstall
+        listKind: PackageInstallList
+        plural: packageinstalls
+        shortNames:
+        - pkgi
+        singular: packageinstall
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: PackageMetadata name
+          jsonPath: .spec.packageRef.refName
+          name: Package name
+          type: string
+        - description: PackageMetadata version
+          jsonPath: .status.version
+          name: Package version
+          type: string
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  canceled:
+                    description: Canceled when set to true will stop all active changes
+                    type: boolean
+                  cluster:
+                    properties:
+                      kubeconfigSecretRef:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      namespace:
+                        type: string
+                    type: object
+                  noopDelete:
+                    description: When NoopDelete set to true, PackageInstall deletion should delete PackageInstall/App CR but preserve App's associated resources.
+                    type: boolean
+                  packageRef:
+                    properties:
+                      refName:
+                        type: string
+                      versionSelection:
+                        properties:
+                          constraints:
+                            type: string
+                          prereleases:
+                            properties:
+                              identifiers:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  serviceAccountName:
+                    type: string
+                  syncPeriod:
+                    description: Controls frequency of App reconciliation in time + unit format. Always >= 30s. If value below 30s is specified, 30s will be used.
+                    type: string
+                  values:
+                    items:
+                      properties:
+                        secretRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  friendlyDescription:
+                    type: string
+                  lastAttemptedVersion:
+                    description: LastAttemptedVersion specifies what version was last attempted to be installed. It does _not_ indicate it was successfully installed.
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  usefulErrorMessage:
+                    type: string
+                  version:
+                    description: TODO this is desired resolved version (not actually deployed)
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        packaging.carvel.dev/global-namespace: tanzu-package-repo-global
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+      name: packagerepositories.packaging.carvel.dev
+    spec:
+      group: packaging.carvel.dev
+      names:
+        kind: PackageRepository
+        listKind: PackageRepositoryList
+        plural: packagerepositories
+        shortNames:
+        - pkgr
+        singular: packagerepository
+      scope: Namespaced
+      versions:
+      - additionalPrinterColumns:
+        - description: Time since creation
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Friendly description
+          jsonPath: .status.friendlyDescription
+          name: Description
+          type: string
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  fetch:
+                    properties:
+                      git:
+                        description: TODO implement git
+                        properties:
+                          lfsSkipSmudge:
+                            type: boolean
+                          ref:
+                            type: string
+                          refSelection:
+                            properties:
+                              semver:
+                                properties:
+                                  constraints:
+                                    type: string
+                                  prereleases:
+                                    properties:
+                                      identifiers:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            type: object
+                          secretRef:
+                            description: 'Secret may include one or more keys: ssh-privatekey, ssh-knownhosts'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          subPath:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                      http:
+                        properties:
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          sha256:
+                            type: string
+                          subPath:
+                            type: string
+                          url:
+                            description: 'URL can point to one of following formats: text, tgz, zip'
+                            type: string
+                        type: object
+                      image:
+                        properties:
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          subPath:
+                            type: string
+                          tagSelection:
+                            properties:
+                              semver:
+                                properties:
+                                  constraints:
+                                    type: string
+                                  prereleases:
+                                    properties:
+                                      identifiers:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            type: object
+                          url:
+                            description: 'Example: username/app1-config:v0.1.0'
+                            type: string
+                        type: object
+                      imgpkgBundle:
+                        properties:
+                          image:
+                            type: string
+                          secretRef:
+                            description: 'Secret may include one or more keys: username, password, token. By default anonymous access is used for authentication. TODO support docker config formated secret'
+                            properties:
+                              name:
+                                description: Object is expected to be within same namespace
+                                type: string
+                            type: object
+                          tagSelection:
+                            properties:
+                              semver:
+                                properties:
+                                  constraints:
+                                    type: string
+                                  prereleases:
+                                    properties:
+                                      identifiers:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  paused:
+                    description: Paused when set to true will ignore all pending changes, once it set back to false, pending changes will be applied
+                    type: boolean
+                  syncPeriod:
+                    description: Controls frequency of PackageRepository reconciliation
+                    type: string
+                required:
+                - fetch
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: TODO rename to Condition
+                      properties:
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  consecutiveReconcileFailures:
+                    type: integer
+                  consecutiveReconcileSuccesses:
+                    type: integer
+                  deploy:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      finished:
+                        type: boolean
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  fetch:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      startedAt:
+                        format: date-time
+                        type: string
+                      stderr:
+                        type: string
+                      stdout:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  friendlyDescription:
+                    type: string
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                  template:
+                    properties:
+                      error:
+                        type: string
+                      exitCode:
+                        type: integer
+                      stderr:
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                    type: object
+                  usefulErrorMessage:
+                    type: string
+                type: object
+            required:
+            - spec
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: kapp-controller-config
+      namespace: tkg-system
+      annotations:
+        kapp.k14s.io/change-group: apps.kappctrl.k14s.io/kapp-controller-config
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    data:
+      caCerts: ""
+      httpProxy: ""
+      httpsProxy: ""
+      noProxy: ""
+      dangerousSkipTLSVerify: ""
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        kapp-controller.carvel.dev/version: v0.30.1
+        kapp.k14s.io/change-rule: upsert after upserting apps.kappctrl.k14s.io/kapp-controller-config
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+      name: kapp-controller
+      namespace: tkg-system
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 0
+      selector:
+        matchLabels:
+          app: kapp-controller
+      template:
+        metadata:
+          labels:
+            app: kapp-controller
+        spec:
+          containers:
+          - args:
+            - -packaging-global-namespace=tanzu-package-repo-global
+            - -concurrency=4
+            - -metrics-bind-address=0
+            env:
+            - name: KAPPCTRL_MEM_TMP_DIR
+              value: /etc/kappctrl-mem-tmp
+            - name: KAPPCTRL_SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KAPPCTRL_API_PORT
+              value: "10100"
+            image: projects.registry.vmware.com/tkg/kapp-controller:v0.30.1_vmware.1
+            name: kapp-controller
+            ports:
+            - containerPort: 10100
+              name: api
+              protocol: TCP
+            resources:
+              requests:
+                cpu: 120m
+                memory: 100Mi
+            securityContext:
+              runAsGroup: 2000
+              runAsUser: 1000
+            volumeMounts:
+            - mountPath: /etc/kappctrl-mem-tmp
+              name: template-fs
+            - mountPath: /etc
+              name: etc
+          securityContext:
+            fsGroup: 3000
+          serviceAccount: kapp-controller-sa
+          volumes:
+          - emptyDir:
+              medium: Memory
+            name: template-fs
+          - emptyDir:
+              medium: Memory
+            name: etc
+          initContainers:
+          - args:
+            - -c
+            - cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver 100.64.0.10' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc; chmod g+w /kapp-etc/pki/tls/certs/ca-bundle.crt && chgrp 2000 /kapp-etc/pki/tls/certs/ca-bundle.crt
+            command:
+            - /bin/sh
+            image: projects.registry.vmware.com/tkg/kapp-controller:v0.30.1_vmware.1
+            name: init-kapp-controller
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsUser: 0
+            volumeMounts:
+            - mountPath: /kapp-etc
+              name: etc
+          hostNetwork: true
+          priorityClassName: system-cluster-critical
+          tolerations:
+          - key: CriticalAddonsOnly
+            operator: Exists
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+          - effect: NoSchedule
+            key: node.kubernetes.io/not-ready
+          - effect: NoSchedule
+            key: node.cloudprovider.kubernetes.io/uninitialized
+            value: "true"
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kapp-controller-sa
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: kapp-controller-cluster-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - create
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - serviceaccounts
+      verbs:
+      - get
+    - apiGroups:
+      - kappctrl.k14s.io
+      resources:
+      - apps
+      - apps/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - packaging.carvel.dev
+      resources:
+      - packageinstalls
+      - packageinstalls/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - packaging.carvel.dev
+      resources:
+      - packagerepositories
+      - packagerepositories/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - internal.packaging.carvel.dev
+      resources:
+      - internalpackagemetadatas
+      verbs:
+      - '*'
+    - apiGroups:
+      - data.packaging.carvel.dev
+      resources:
+      - packagemetadatas
+      - packagemetadatas/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - internal.packaging.carvel.dev
+      resources:
+      - internalpackages
+      verbs:
+      - '*'
+    - apiGroups:
+      - data.packaging.carvel.dev
+      resources:
+      - packages
+      - packages/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - '*'
+    - apiGroups:
+      - apiregistration.k8s.io
+      resources:
+      - apiservices
+      verbs:
+      - update
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - namespaces
+      verbs:
+      - list
+      - watch
+      - get
+      - update
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - mutatingwebhookconfigurations
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - validatingwebhookconfigurations
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - subjectaccessreviews
+      verbs:
+      - create
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kapp-controller-cluster-role-binding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kapp-controller-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: pkg-apiserver:system:auth-delegator
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: pkgserver-auth-reader
+      namespace: kube-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/kapp-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: extension-apiserver-authentication-reader
+    subjects:
+    - kind: ServiceAccount
+      name: kapp-controller-sa
+      namespace: tkg-system
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package-repo
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-management-package-repository
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-management-package-repository-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package-repo
+  name: __CLUSTER_NAME__-management-package-repository-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageRepository
+    metadata:
+      name: tanzu-management
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package-repo
+    spec:
+      fetch:
+        imgpkgBundle:
+          image: projects.registry.vmware.com/tkg/packages/management/repo:v0.11.6-1-g90440e2b
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-core-management-plugins-package
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-core-management-plugins-package-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  name: __CLUSTER_NAME__-core-management-plugins-package-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: tanzu-core-management-plugins-package-sa
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-core-management-plugins-package-cluster-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - cli.tanzu.vmware.com
+      resources:
+      - cliplugins
+      verbs:
+      - create
+      - get
+      - patch
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-core-management-plugins-package-cluster-rolebinding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-core-management-plugins-package-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-core-management-plugins-package-sa
+      namespace: tkg-system
+    ---
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageInstall
+    metadata:
+      name: tanzu-core-management-plugins
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    spec:
+      serviceAccountName: tanzu-core-management-plugins-package-sa
+      packageRef:
+        refName: core-management-plugins.tanzu.vmware.com
+        versionSelection:
+          prereleases: {}
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-featuregates-default-resource
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-featuregates-default-resource-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  name: __CLUSTER_NAME__-featuregates-default-resource-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: config.tanzu.vmware.com/v1alpha1
+    kind: FeatureGate
+    metadata:
+      name: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    spec:
+      namespaceSelector: {}
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-featuregates-package
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-featuregates-package-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: packages/management-package
+  name: __CLUSTER_NAME__-featuregates-package-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: tanzu-featuregates-package-sa
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-featuregates-package-cluster-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - serviceaccounts
+      - services
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - cert-manager.io
+      resources:
+      - issuers
+      - certificates
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - validatingwebhookconfigurations
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - clusterroles
+      - clusterrolebindings
+      verbs:
+      - create
+      - update
+      - get
+    - apiGroups:
+      - config.tanzu.vmware.com
+      resources:
+      - featuregates
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - config.tanzu.vmware.com
+      resources:
+      - featuregates/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - config.tanzu.vmware.com
+      resources:
+      - features
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - config.tanzu.vmware.com
+      resources:
+      - features/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - namespaces
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-featuregates-package-cluster-rolebinding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-featuregates-package-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-featuregates-package-sa
+      namespace: tkg-system
+    ---
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageInstall
+    metadata:
+      name: tanzu-featuregates
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: packages/management-package
+    spec:
+      serviceAccountName: tanzu-featuregates-package-sa
+      packageRef:
+        refName: featuregates.tanzu.vmware.com
+        versionSelection:
+          prereleases: {}
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-namespace-role
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: tkg-metadata-reader
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    rules:
+    - apiGroups:
+      - ""
+      resourceNames:
+      - tkg-metadata
+      - tkg-bom
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: tkg-metadata-reader
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: tkg-metadata-reader
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: system:authenticated
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-configmap
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkg-metadata
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    data:
+      metadata.yaml: |
+        cluster:
+          name: __CLUSTER_NAME__
+          type: management
+          plan: dev
+          kubernetesProvider: VMware Tanzu Kubernetes Grid
+          tkgVersion: v1.5.4
+          edition: tkg
+          infrastructure:
+            provider: vsphere
+        bom:
+          configmapRef:
+            name: tkg-bom
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  name: __CLUSTER_NAME__-tkg-metadata-bom-configmap
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkg-bom
+      namespace: tkg-system-public
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: metadata/tkg
+    data:
+      bom.yaml: |
+        apiVersion: run.tanzu.vmware.com/v1alpha2
+        default:
+          k8sVersion: v1.22.9+vmware.1-tkg.1
+        release:
+          version: v1.5.4
+        components:
+          aad-pod-identity:
+          - version: v1.8.0+vmware.1
+            images:
+              micImage:
+                imagePath: cluster-api/mic
+                tag: v1.8.0_vmware.1
+              nmiImage:
+                imagePath: cluster-api/nmi
+                tag: v1.8.0_vmware.1
+          alertmanager:
+          - version: v0.22.2+vmware.1
+            images:
+              alertmanagerImage:
+                imagePath: prometheus/alertmanager
+                tag: v0.22.2_vmware.1
+          cadvisor:
+          - version: v0.39.1+vmware.1
+            images:
+              cadvisorImage:
+                imagePath: prometheus/cadvisor
+                tag: v0.39.1_vmware.1
+          cloud-provider-azure:
+          - version: v0.7.4+vmware.1
+            images:
+              ccmAzureControllerImage:
+                imagePath: azure-cloud-controller-manager
+                tag: v0.7.4_vmware.1
+              ccmAzureNodeImage:
+                imagePath: azure-cloud-node-manager
+                tag: v0.7.4_vmware.1
+          cluster-api-provider-azure:
+          - version: v1.0.2+vmware.1
+            images:
+              capzControllerImage:
+                imagePath: cluster-api/cluster-api-azure-controller
+                tag: v1.0.2_vmware.1
+          cluster-api-provider-bringyourownhost:
+          - version: v0.1.0+vmware.7
+            images:
+              byohControllerImage:
+                imagePath: cluster-api/cluster-api-byoh-controller
+                tag: v0.1.0_vmware.7
+              byohImgpkgBundle:
+                imagePath: cluster-api/byoh-bundle-ubuntu_20.04.1_x86-64_k8s_v1.22.3
+                tag: v0.1.0_vmware.7
+          cluster_api:
+          - version: v1.0.1+vmware.1
+            images:
+              cabpkControllerImage:
+                imagePath: cluster-api/kubeadm-bootstrap-controller
+                tag: v1.0.1_vmware.1
+              capdManagerImage:
+                imagePath: cluster-api/capd-manager
+                tag: v1.0.1_vmware.1
+              capiControllerImage:
+                imagePath: cluster-api/cluster-api-controller
+                tag: v1.0.1_vmware.1
+              kcpControllerImage:
+                imagePath: cluster-api/kubeadm-control-plane-controller
+                tag: v1.0.1_vmware.1
+          cluster_api_aws:
+          - version: v1.2.0+vmware.1
+            images:
+              capaControllerImage:
+                imagePath: cluster-api/cluster-api-aws-controller
+                tag: v1.2.0_vmware.1
+          cluster_api_vsphere:
+          - version: v1.0.3+vmware.1
+            images:
+              capvControllerImage:
+                imagePath: cluster-api/cluster-api-vsphere-controller
+                tag: v1.0.3_vmware.1
+          configmap-reload:
+          - version: v0.5.0+vmware.2
+            images:
+              configmapReloadImage:
+                imagePath: prometheus/configmap-reload
+                tag: v0.5.0_vmware.2
+          contour:
+          - version: v1.17.2+vmware.1
+            images:
+              contourImage:
+                imagePath: contour
+                tag: v1.17.2_vmware.1
+          - version: v1.18.2+vmware.1
+            images:
+              contourImage:
+                imagePath: contour
+                tag: v1.18.2_vmware.1
+          crash-diagnostics:
+          - version: v0.3.7+vmware.5
+          envoy:
+          - version: v1.18.4+vmware.1
+            images:
+              envoyImage:
+                imagePath: envoy
+                tag: v1.18.4_vmware.1
+          - version: v1.19.1+vmware.1
+            images:
+              envoyImage:
+                imagePath: envoy
+                tag: v1.19.1_vmware.1
+          external-dns:
+          - version: v0.10.0+vmware.1
+            images:
+              externalDNSImage:
+                imagePath: external-dns
+                tag: v0.10.0_vmware.1
+          fluent-bit:
+          - version: v1.7.5+vmware.2
+            images:
+              fluentBitImage:
+                imagePath: fluent-bit
+                tag: v1.7.5_vmware.2
+          gangway:
+          - version: v3.2.0+vmware.2
+            images:
+              gangwayImage:
+                imagePath: gangway
+                tag: v3.2.0_vmware.2
+          grafana:
+          - version: v7.5.7+vmware.2
+            images:
+              grafanaImage:
+                imagePath: grafana/grafana
+                tag: v7.5.7_vmware.2
+          harbor:
+          - version: v2.3.3+vmware.1
+            images:
+              harborChartMuseumImage:
+                imagePath: harbor/chartmuseum-photon
+                tag: v2.3.3_vmware.1
+              harborCoreImage:
+                imagePath: harbor/harbor-core
+                tag: v2.3.3_vmware.1
+              harborDatabaseImage:
+                imagePath: harbor/harbor-db
+                tag: v2.3.3_vmware.1
+              harborExporterImage:
+                imagePath: harbor/harbor-exporter
+                tag: v2.3.3_vmware.1
+              harborJobServiceImage:
+                imagePath: harbor/harbor-jobservice
+                tag: v2.3.3_vmware.1
+              harborLogImage:
+                imagePath: harbor/harbor-log
+                tag: v2.3.3_vmware.1
+              harborNginxImage:
+                imagePath: harbor/nginx-photon
+                tag: v2.3.3_vmware.1
+              harborNotaryServerImage:
+                imagePath: harbor/notary-server-photon
+                tag: v2.3.3_vmware.1
+              harborNotarySignerImage:
+                imagePath: harbor/notary-signer-photon
+                tag: v2.3.3_vmware.1
+              harborPortalImage:
+                imagePath: harbor/harbor-portal
+                tag: v2.3.3_vmware.1
+              harborPrepareImage:
+                imagePath: harbor/prepare
+                tag: v2.3.3_vmware.1
+              harborRedisImage:
+                imagePath: harbor/redis-photon
+                tag: v2.3.3_vmware.1
+              harborRegistryCtlImage:
+                imagePath: harbor/harbor-registryctl
+                tag: v2.3.3_vmware.1
+              harborRegistryImage:
+                imagePath: harbor/registry-photon
+                tag: v2.3.3_vmware.1
+              harborTrivyAdapterImage:
+                imagePath: harbor/trivy-adapter-photon
+                tag: v2.3.3_vmware.1
+          image-builder:
+          - version: v0.1.11+vmware.3
+            images:
+              imagebuilder-tar:
+                imagePath: image-builder
+                tag: v0.1.11_vmware.3
+          imgpkg:
+          - version: v0.22.0+vmware.1
+          jetstack_cert-manager:
+          - version: v1.5.3+vmware.2
+            images:
+              certMgrControllerImage:
+                imagePath: cert-manager-controller
+                tag: v1.5.3_vmware.2
+              certMgrInjectorImage:
+                imagePath: cert-manager-cainjector
+                tag: v1.5.3_vmware.2
+              certMgrWebhookImage:
+                imagePath: cert-manager-webhook
+                tag: v1.5.3_vmware.2
+          k8s-sidecar:
+          - version: v1.12.1+vmware.2
+            images:
+              k8sSidecarImage:
+                imagePath: grafana/k8s-sidecar
+                tag: v1.12.1_vmware.2
+          k14s_kapp:
+          - version: v0.42.0+vmware.2
+          k14s_ytt:
+          - version: v0.37.0+vmware.1
+          kbld:
+          - version: v0.31.0+vmware.1
+          kube-state-metrics:
+          - version: v1.9.8+vmware.1
+            images:
+              kubeStateMetricsImage:
+                imagePath: prometheus/kube-state-metrics
+                tag: v1.9.8_vmware.1
+          kube-vip:
+          - version: v0.3.3+vmware.1
+            images:
+              kubeVipImage:
+                imagePath: kube-vip
+                tag: v0.3.3_vmware.1
+          kube_rbac_proxy:
+          - version: v0.8.0+vmware.1
+            images:
+              kubeRbacProxyControllerImage:
+                imagePath: kube-rbac-proxy
+                tag: v0.8.0_vmware.1
+              kubeRbacProxyControllerImageCapi:
+                imagePath: cluster-api/kube-rbac-proxy
+                tag: v0.8.0_vmware.1
+          kubernetes-sigs_kind:
+          - version: v1.22.9+vmware.1_v0.11.1
+            images:
+              kindNodeImage:
+                imagePath: kind/node
+                tag: v1.22.9_vmware.1_v0.11.1
+          kubernetes_autoscaler:
+          - version: v1.22.0+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.22.0_vmware.1
+            metadata:
+              k8sversion: v1.22.3+vmware.1
+          - version: v1.21.0+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.21.0_vmware.1
+            metadata:
+              k8sversion: v1.21.1+vmware.1
+          - version: v1.20.0+vmware.1
+            images:
+              kubernetesAutoscalerImage:
+                imagePath: cluster-autoscaler
+                tag: v1.20.0_vmware.1
+            metadata:
+              k8sversion: v1.20.4+vmware.1
+          multus-cni:
+          - version: v3.7.1+vmware.2
+            images:
+              multusCniImage:
+                imagePath: multus-cni
+                tag: v3.7.1_vmware.2
+          prometheus:
+          - version: v2.27.0+vmware.1
+            images:
+              prometheusImage:
+                imagePath: prometheus/prometheus
+                tag: v2.27.0_vmware.1
+          prometheus_node_exporter:
+          - version: v1.1.2+vmware.1
+            images:
+              prometheusNodeExporterImage:
+                imagePath: prometheus/prometheus_node_exporter
+                tag: v1.1.2_vmware.1
+          pushgateway:
+          - version: v1.4.0+vmware.1
+            images:
+              pushgatewayImage:
+                imagePath: prometheus/pushgateway
+                tag: v1.4.0_vmware.1
+          sonobuoy:
+          - version: v0.54.0+vmware.1
+            images:
+              sonobuoyImage:
+                imagePath: sonobuoy
+                tag: v0.54.0_vmware.1
+          standalone-plugins-package:
+          - version: v0.11.6-1-g90440e2b-standalone-plugins
+            images:
+              standalone-plugins.tanzu.vmware.com:
+                imagePath: packages/standalone/standalone-plugins
+                tag: v0.11.6-1-g90440e2b_vmware.1
+          tanzu-framework:
+          - version: v0.11.6-1-g90440e2b
+            images:
+              capabilitiesImage:
+                imagePath: tanzu_core/capabilities/capabilities-controller-manager
+                tag: v0.11.6-1-g90440e2b
+              clipluginsClusterDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/cluster-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsClusterLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/cluster-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsClusterWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/cluster-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsKubernetesReleaseDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsKubernetesReleaseLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsKubernetesReleaseWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsLoginDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/login-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsLoginLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/login-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsLoginWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/login-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsManagementClusterDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsManagementClusterLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsManagementClusterWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPackageDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/package-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPackageLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/package-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPackageWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/package-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPinnipedAuthDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPinnipedAuthLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsPinnipedAuthWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsSecretDarwinAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/secret-darwin-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsSecretLinuxAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/secret-linux-amd64
+                tag: v0.11.6-1-g90440e2b
+              clipluginsSecretWindowsAmd64Image:
+                imagePath: tanzu_core/tanzu-cli-plugins/secret-windows-amd64
+                tag: v0.11.6-1-g90440e2b
+              featuregatesImage:
+                imagePath: tanzu_core/featuregates/featuregates-controller-manager
+                tag: v0.11.6-1-g90440e2b
+              providerTemplateImage:
+                imagePath: tanzu_core/provider/provider-templates
+                tag: v0.11.6-1-g90440e2b
+              tkrImage:
+                imagePath: tanzu_core/tkr/tkr-controller-manager
+                tag: v0.11.6-1-g90440e2b
+          tanzu-framework-management-packages:
+          - version: v0.11.6-1-g90440e2b
+            images:
+              tanzuFrameworkManagementPackageRepositoryImage:
+                imagePath: packages/management/repo
+                tag: v0.11.6-1-g90440e2b
+          tkg-bom:
+          - version: v1.5.4
+            images:
+              tkgBomImage:
+                imagePath: tkg-bom
+                tag: v1.5.4
+          tkg-standard-packages:
+          - version: v1.5.4
+            images:
+              tanzuStandardPackageRepositoryImage:
+                imagePath: packages/standard/repo
+                tag: v1.5.4
+          tkg_telemetry:
+          - version: v1.5.0+vmware.1
+            images:
+              tkgTelemetryImage:
+                imagePath: tkg-telemetry
+                tag: v1.5.0_vmware.1
+          velero:
+          - version: v1.8.1+vmware.1
+            images:
+              veleroImage:
+                imagePath: velero/velero
+                tag: v1.8.1_vmware.1
+              veleroResticRestoreHelperImage:
+                imagePath: velero/velero-restic-restore-helper
+                tag: v1.8.1_vmware.1
+          velero-plugin-for-aws:
+          - version: v1.4.1+vmware.1
+            images:
+              veleroPluginForAwsImage:
+                imagePath: velero/velero-plugin-for-aws
+                tag: v1.4.1_vmware.1
+          velero-plugin-for-microsoft-azure:
+          - version: v1.4.1+vmware.1
+            images:
+              veleroPluginForMicrosoftAzureImage:
+                imagePath: velero/velero-plugin-for-microsoft-azure
+                tag: v1.4.1_vmware.1
+          velero-plugin-for-vsphere:
+          - version: v1.3.1+vmware.1
+            images:
+              veleroBackupDriverImage:
+                imagePath: velero/backup-driver
+                tag: v1.3.1_vmware.1
+              veleroDataManagerForPluginImage:
+                imagePath: velero/data-manager-for-plugin
+                tag: v1.3.1_vmware.1
+              veleroPluginForVsphereImage:
+                imagePath: velero/velero-plugin-for-vsphere
+                tag: v1.3.1_vmware.1
+          vendir:
+          - version: v0.23.1+vmware.1
+        kindKubeadmConfigSpec:
+        - 'kind: Cluster'
+        - 'apiVersion: kind.x-k8s.io/v1alpha4'
+        - 'kubeadmConfigPatches:'
+        - '- |'
+        - '  apiVersion: kubeadm.k8s.io/v1beta2'
+        - '  kind: ClusterConfiguration'
+        - '  imageRepository: projects.registry.vmware.com/tkg'
+        - '  etcd:'
+        - '    local:'
+        - '      imageRepository: projects.registry.vmware.com/tkg'
+        - '      imageTag: v3.5.4_vmware.2'
+        - '  dns:'
+        - '    type: CoreDNS'
+        - '    imageRepository: projects.registry.vmware.com/tkg'
+        - '    imageTag: v1.8.4_vmware.9'
+        imageConfig:
+          imageRepository: projects.registry.vmware.com/tkg
+        tkr-bom:
+          imagePath: tkr-bom
+        tkr-compatibility:
+          imagePath: tkr-compatibility
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metadata/tkg
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tkg-metadata
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-namespace-role
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-configmap
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkg-metadata-bom-configmap
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: metrics/metrics-server
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: metrics-server
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-metrics-server-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    metricsServer:
+      namespace: kube-system
+      config:
+        args: []
+        probe:
+          failureThreshold: 3
+          periodSeconds: 10
+        apiServiceInsecureTLS: true
+type: tkg.tanzu.vmware.com/addon
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-core-package-repository
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-core-package-repository-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+  name: __CLUSTER_NAME__-core-package-repository-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageRepository
+    metadata:
+      name: tanzu-core
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/core-package-repo
+    spec:
+      fetch:
+        imgpkgBundle:
+          image: projects.registry.vmware.com/tkg/packages/core/repo:v1.22.9_vmware.1-tkg.1
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/secretgen-controller
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: secretgen-controller
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-secretgen-controller-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    secretgenController:
+      namespace: tanzu-system
+      createNamespace: true
+type: tkg.tanzu.vmware.com/addon
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-standard-package-repository
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-standard-package-repository-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+  name: __CLUSTER_NAME__-standard-package-repository-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageRepository
+    metadata:
+      name: tanzu-standard
+      namespace: tanzu-package-repo-global
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: addons-management/standard-package-repo
+        tanzu.vmware.com/owner: tkg
+    spec:
+      fetch:
+        imgpkgBundle:
+          image: projects.registry.vmware.com/tkg/packages/standard/repo:v1.5.4
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tanzu-addons-manager-package
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tanzu-addons-manager-package-crs
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  name: __CLUSTER_NAME__-tanzu-addons-manager-package-crs
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: tanzu-addons-package-sa
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-addons-package-cluster-role
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    rules:
+    - apiGroups:
+      - '*'
+      resources:
+      - '*'
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-addons-package-cluster-rolebinding
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-addons-package-cluster-role
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-addons-package-sa
+      namespace: tkg-system
+    ---
+    apiVersion: packaging.carvel.dev/v1alpha1
+    kind: PackageInstall
+    metadata:
+      name: tanzu-addons-manager
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    spec:
+      serviceAccountName: tanzu-addons-package-sa
+      packageRef:
+        refName: addons-manager.tanzu.vmware.com
+        versionSelection:
+          prereleases: {}
+      values:
+      - secretRef:
+          name: tanzu-addons-manager-data-values
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: tanzu-addons-manager-data-values
+      namespace: tkg-system
+      annotations:
+        ext.packaging.carvel.dev/ytt-data-values-overlays: tanzu-addons-manager-data-values
+        tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+    type: Opaque
+    stringData:
+      values.yaml: |
+        #@data/values
+        #@overlay/match-child-defaults missing_ok=True
+        ---
+        tanzuAddonsManager:
+          namespace: tkg-system
+          createNamespace: false
+          deployment:
+            hostNetwork: true
+            priorityClassName: system-cluster-critical
+            tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: addons-management/tanzu-addons-manager
+  labels:
+    clusterctl.cluster.x-k8s.io/move: ""
+    tkg.tanzu.vmware.com/addon-name: tanzu-addons-manager
+    tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tanzu-addons-manager-addon
+  namespace: __NAMESPACE_NAME__
+stringData:
+  values.yaml: |
+    #@data/values
+    #@overlay/match-child-defaults missing_ok=True
+    ---
+    tanzuAddonsManager:
+      namespace: tkg-system
+      createNamespace: false
+      deployment:
+        hostNetwork: true
+        priorityClassName: system-cluster-critical
+        tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+type: tkg.tanzu.vmware.com/addon
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-tkr
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-tkr
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+  name: __CLUSTER_NAME__-tkr
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      labels:
+        control-plane: controller-manager
+      name: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: tkr-controller-config
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    data:
+      caCerts: ""
+      imageRepository: ""
+    ---
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.7.0
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+      creationTimestamp: null
+      name: tanzukubernetesreleases.run.tanzu.vmware.com
+    spec:
+      group: run.tanzu.vmware.com
+      names:
+        kind: TanzuKubernetesRelease
+        listKind: TanzuKubernetesReleaseList
+        plural: tanzukubernetesreleases
+        shortNames:
+        - tkr
+        singular: tanzukubernetesrelease
+      scope: Cluster
+      versions:
+      - additionalPrinterColumns:
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Compatible')].status
+          name: Compatible
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Created
+          type: date
+        name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            description: TanzuKubernetesRelease is the schema for the tanzukubernetesreleases API. TanzuKubernetesRelease objects represent Kubernetes releases available via TKG, which can be used to create TanzuKubernetesCluster instances. TKRs are immutable to end-users. They are created and managed by TKG to provide discovery of Kubernetes releases to TKG users.
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: TanzuKubernetesReleaseSpec defines the desired state of TanzuKubernetesRelease
+                properties:
+                  images:
+                    description: Images is the list of (other than Kubernetes core) essential container images shipped by this TKR (e.g. coredns, etcd).
+                    items:
+                      description: ContainerImage is a struct representing a single fully qualified container image name, constructed as `{Repository}/{Name}:{Tag}`.
+                      properties:
+                        name:
+                          description: Name is the container image name without the repository prefix. It MUST be a valid URI path, MAY contain zero or more '/', and SHOULD NOT start or end with '/'.
+                          type: string
+                        repository:
+                          description: Repository is the container image repository used by this image. It MUST be a DNS-compatible name.
+                          type: string
+                        tag:
+                          description: Tag is the container image version tag. It is the suffix coming after ':' in a fully qualified image name.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  kubernetesVersion:
+                    description: KubernetesVersion is the fully qualified Semantic Versioning conformant version of Kubernetes shipped by this TKR. The same KubernetesVersion MAY be shipped by different TKRs.
+                    type: string
+                  nodeImageRef:
+                    description: NodeImageRef refers to an object representing the image used to create TKC nodes (e.g. VirtualMachineImage).
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  repository:
+                    description: Repository is the container image repository for Kubernetes core images, such as kube-apiserver, kube-proxy, etc. It MUST be a DNS-compatible name.
+                    type: string
+                  version:
+                    description: Version is the fully qualified Semantic Versioning conformant version of the TanzuKubernetesRelease. Version MUST be unique across all TanzuKubernetesRelease objects.
+                    type: string
+                required:
+                - version
+                type: object
+              status:
+                description: TanzuKubernetesReleaseStatus defines the observed state of TanzuKubernetesRelease
+                properties:
+                  conditions:
+                    items:
+                      description: Condition defines an observation of a Cluster API resource operational state.
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: A human readable message indicating details about the transition. This field may be empty.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                          type: string
+                        severity:
+                          description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False, Unknown.
+                          type: string
+                        type:
+                          description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - status
+                      - type
+                      type: object
+                    type: array
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: []
+      storedVersions: []
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: tkr-leader-election-role
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps/status
+      verbs:
+      - get
+      - update
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: tkr-manager-role
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    rules:
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - cluster.x-k8s.io
+      resources:
+      - clusters
+      - clusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - create
+      - get
+      - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: tkr-leader-election-rolebinding
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: tkr-leader-election-role
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: tkr-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tkr-manager-rolebinding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tkr-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: tkr-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        control-plane: controller-manager
+      name: tkr-controller-manager
+      namespace: tkr-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: tkr/tkr-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          control-plane: controller-manager
+      template:
+        metadata:
+          labels:
+            control-plane: controller-manager
+        spec:
+          containers:
+          - args:
+            - --enable-leader-election
+            - --bom-image-path=projects.registry.vmware.com/tkg/tkr-bom
+            - --bom-metadata-image-path=projects.registry.vmware.com/tkg/tkr-compatibility
+            - --skip-verify-registry-cert=False
+            - --continuous-discover-frequency=600
+            command:
+            - /manager
+            image: projects.registry.vmware.com/tkg/tanzu_core/tkr/tkr-controller-manager:v0.11.6-1-g90440e2b
+            imagePullPolicy: Always
+            name: manager
+            resources:
+              limits:
+                cpu: 100m
+                memory: 100Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+          terminationGracePeriodSeconds: 10
+type: addons.cluster.x-k8s.io/resource-set
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+  labels:
+    cluster.x-k8s.io/cluster-name: __CLUSTER_NAME__
+  name: __CLUSTER_NAME__-capabilities
+  namespace: __NAMESPACE_NAME__
+spec:
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: __CLUSTER_NAME__
+  resources:
+  - kind: Secret
+    name: __CLUSTER_NAME__-capabilities
+  strategy: ApplyOnce
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+  name: __CLUSTER_NAME__-capabilities
+  namespace: __NAMESPACE_NAME__
+stringData:
+  value: |
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.7.0
+        tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+      creationTimestamp: null
+      name: capabilities.run.tanzu.vmware.com
+    spec:
+      group: run.tanzu.vmware.com
+      names:
+        kind: Capability
+        listKind: CapabilityList
+        plural: capabilities
+        singular: capability
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            description: Capability is the Schema for the capabilities API
+            properties:
+              apiVersion:
+                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                type: string
+              kind:
+                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                type: string
+              metadata:
+                type: object
+              spec:
+                description: Spec is the capability spec that has cluster queries.
+                properties:
+                  queries:
+                    description: Queries specifies set of queries that are evaluated.
+                    items:
+                      description: Query is a logical grouping of GVR, Object and PartialSchema queries.
+                      properties:
+                        groupVersionResources:
+                          description: GroupVersionResources evaluates a slice of GVR queries.
+                          items:
+                            description: QueryGVR queries for an API group with the optional ability to check for API versions and resource.
+                            properties:
+                              group:
+                                description: Group is the API group to check for in the cluster.
+                                minLength: 1
+                                type: string
+                              name:
+                                description: Name is the unique name of the query.
+                                minLength: 1
+                                type: string
+                              resource:
+                                description: Resource is the API resource to check for given an API group and a slice of versions. Specifying a Resource requires at least one version to be specified in Versions.
+                                type: string
+                              versions:
+                                description: Versions is the slice of versions to check for in the specified API group.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - group
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        name:
+                          description: Name is the unique name of the query.
+                          minLength: 1
+                          type: string
+                        objects:
+                          description: Objects evaluates a slice of Object queries.
+                          items:
+                            description: QueryObject represents any runtime.Object that could exist in a cluster with the ability to check for annotations.
+                            properties:
+                              name:
+                                description: Name is the unique name of the query.
+                                minLength: 1
+                                type: string
+                              objectReference:
+                                description: ObjectReference is the ObjectReference to check for in the cluster.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                              withAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: WithAnnotations are the annotations whose presence is checked in the object. The query succeeds only if all the annotations specified exists.
+                                type: object
+                              withoutAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: WithAnnotations are the annotations whose absence is checked in the object. The query succeeds only if all the annotations specified do not exist.
+                                type: object
+                            required:
+                            - name
+                            - objectReference
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        partialSchemas:
+                          description: PartialSchemas evaluates a slice of PartialSchema queries.
+                          items:
+                            description: QueryPartialSchema queries for any OpenAPI schema that may exist on a cluster.
+                            properties:
+                              name:
+                                description: Name is the unique name of the query.
+                                minLength: 1
+                                type: string
+                              partialSchema:
+                                description: PartialSchema is the partial OpenAPI schema that will be matched in a cluster.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - partialSchema
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - queries
+                type: object
+              status:
+                description: Status is the capability status that has results of cluster queries.
+                properties:
+                  results:
+                    description: Results represents the results of all the queries specified in the spec.
+                    items:
+                      description: Result represents the results of queries in Query.
+                      properties:
+                        groupVersionResources:
+                          description: GroupVersionResources represents results of GVR queries in spec.
+                          items:
+                            description: QueryResult represents the result of a single query.
+                            properties:
+                              error:
+                                description: Error indicates if an error occurred while processing the query.
+                                type: boolean
+                              errorDetail:
+                                description: ErrorDetail represents the error detail, if an error occurred.
+                                type: string
+                              found:
+                                description: Found is a boolean which indicates if the query condition succeeded.
+                                type: boolean
+                              name:
+                                description: Name is the name of the query in spec whose result this struct represents.
+                                minLength: 1
+                                type: string
+                              notFoundReason:
+                                description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        name:
+                          description: Name is the unique name of the query.
+                          minLength: 1
+                          type: string
+                        objects:
+                          description: Objects represents results of Object queries in spec.
+                          items:
+                            description: QueryResult represents the result of a single query.
+                            properties:
+                              error:
+                                description: Error indicates if an error occurred while processing the query.
+                                type: boolean
+                              errorDetail:
+                                description: ErrorDetail represents the error detail, if an error occurred.
+                                type: string
+                              found:
+                                description: Found is a boolean which indicates if the query condition succeeded.
+                                type: boolean
+                              name:
+                                description: Name is the name of the query in spec whose result this struct represents.
+                                minLength: 1
+                                type: string
+                              notFoundReason:
+                                description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        partialSchemas:
+                          description: PartialSchemas represents results of PartialSchema queries in spec.
+                          items:
+                            description: QueryResult represents the result of a single query.
+                            properties:
+                              error:
+                                description: Error indicates if an error occurred while processing the query.
+                                type: boolean
+                              errorDetail:
+                                description: ErrorDetail represents the error detail, if an error occurred.
+                                type: string
+                              found:
+                                description: Found is a boolean which indicates if the query condition succeeded.
+                                type: boolean
+                              name:
+                                description: Name is the name of the query in spec whose result this struct represents.
+                                minLength: 1
+                                type: string
+                              notFoundReason:
+                                description: NotFoundReason provides the reason if the query condition fails. This is non-empty when Found is false.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - results
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: tanzu-capabilities-manager
+      name: tanzu-capabilities-manager-sa
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: tanzu-capabilities-manager-clusterrole
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+    rules:
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - capabilities
+      verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - capabilities/status
+      verbs:
+      - get
+      - patch
+      - update
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesreleases
+      - tanzukubernetesreleases/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - run.tanzu.vmware.com
+      resources:
+      - tanzukubernetesclusters
+      - tanzukubernetesclusters/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - clusterctl.cluster.x-k8s.io
+      resources:
+      - providers
+      - providers/status
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - namespaces
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: tanzu-capabilities-manager-clusterrolebinding
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: tanzu-capabilities-manager-clusterrole
+    subjects:
+    - kind: ServiceAccount
+      name: tanzu-capabilities-manager-sa
+      namespace: tkg-system
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app: tanzu-capabilities-manager
+      name: tanzu-capabilities-controller-manager
+      namespace: tkg-system
+      annotations:
+        tkg.tanzu.vmware.com/addon-type: capabilities/capabilities-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: tanzu-capabilities-manager
+      template:
+        metadata:
+          labels:
+            app: tanzu-capabilities-manager
+        spec:
+          containers:
+          - image: projects.registry.vmware.com/tkg/tanzu_core/capabilities/capabilities-controller-manager:v0.11.6-1-g90440e2b
+            imagePullPolicy: IfNotPresent
+            name: manager
+            resources:
+              limits:
+                cpu: 100m
+                memory: 30Mi
+              requests:
+                cpu: 100m
+                memory: 20Mi
+          serviceAccount: tanzu-capabilities-manager-sa
+          terminationGracePeriodSeconds: 10
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+type: addons.cluster.x-k8s.io/resource-set
+---


### PR DESCRIPTION
This brings in CRS templates for 1.5.4 and 1.4.2. The antrea yaml needs to be installed on the parent cluster (KinD) and the other yaml is to be installed on the child cluster itself. After some time, a `tanzu package installed list -A` will show the packages installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/182)
<!-- Reviewable:end -->
