### PR TITLE
[Bug fix] ClusterAPI status is array of strings, but should be array of objects

### DIFF
--- a/schema/WIP_schema_1_1_0.json
+++ b/schema/WIP_schema_1_1_0.json
@@ -141,8 +141,7 @@
                     },
                     "port": {
                       "type": "integer"
-                    },
-                    "type": "string"
+                    }
                   }
                 }
               }

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -141,8 +141,7 @@
                     },
                     "port": {
                       "type": "integer"
-                    },
-                    "type": "string"
+                    }
                   }
                 }
               }


### PR DESCRIPTION

1. Pushed the image - [harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:vkp-branch](http://harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:vkp-branch)? NA
2. Are there API changes? - No If yes, please fill in the below
  3. Updated conversions? NA
  4. Updated CRDs? - NA
  5. Updated capiYaml Examples? - NA
  6. Updated infrastructure-components.yaml? - NA
7. Updated VCD-KE with the latest CAPVCD library? - NA

Signed-off-by: sayloo <sahithi.ayloo@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/187)
<!-- Reviewable:end -->
