### PR TITLE
[VCDA-3974] Add missing rbac kubebuilder codes in vcdclustercontroller.go

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,24 +18,6 @@ rules:
   - update
   - watch
 - apiGroups:
-    - cluster.x-k8s.io
-  resources:
-    - clusters
-    - clusters/status
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
-    - cluster.x-k8s.io
-  resources:
-    - machines
-    - machines/status
-  verbs:
-    - get
-    - list
-    - watch
-- apiGroups:
   - ""
   resources:
   - namespaces
@@ -58,6 +40,60 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - kubeadmconfigtemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
@@ -112,50 +148,14 @@ rules:
   - patch
   - update
 - apiGroups:
-    - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
   resources:
-    - kubeadmcontrolplanes
+  - vcdmachinetemplates
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - infrastructure.cluster.x-k8s.io
-  resources:
-    - vcdmachinetemplates
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - cluster.x-k8s.io
-  resources:
-    - machinedeployments
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - bootstrap.cluster.x-k8s.io
-  resources:
-    - kubeadmconfigtemplates
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -72,10 +72,19 @@ type VCDClusterReconciler struct {
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdclusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdclusters/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdclusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;clusters/status,verbs=get;list;watch
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=addons.cluster.x-k8s.io,resources=clusterresourcesetbindings,verbs=get;list;watch
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdmachines,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdmachines/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdmachines/finalizers,verbs=update
+//+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kubeadmcontrolplanes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vcdmachinetemplates,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,verbs=get;list;watch;create;update;patch;delete
 
 func (r *VCDClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, rerr error) {
 	log := ctrl.LoggerFrom(ctx)

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -457,8 +457,8 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 				ReclaimPolicy:             reclaimPolicy,
 				VcdStorageProfileName:     vcdStorageProfileName,
 				FileSystemFormat:          fileSystemFormat,
-				CpiVersion:                "1.1.1", // TODO: get from crs
-				CsiVersion:                "1.2.0", // TODO: get from crs
+				CpiVersion:                "vkp", // TODO: get from crs
+				CsiVersion:                "vkp", // TODO: get from crs
 				VcdHostFormatted:          strings.Replace(vcdCluster.Spec.Site, "/", "\\/", -1),
 				ClusterOrgName:            workloadVCDClient.ClusterOrgName,
 				ClusterOVDCName:           workloadVCDClient.ClusterOVDCName,

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -187,7 +187,7 @@ spec:
               loadBalancer:
                 description: LoadBalancer defines load-balancer configuration for the Cluster both for the control plane nodes and for the CPI
                 properties:
-                  useOneArm:
+                  UseOneArm:
                     type: boolean
                 type: object
               org:
@@ -959,32 +959,6 @@ subjects:
   namespace: capvcd-system
 ---
 apiVersion: v1
-data:
-  controller_manager_config.yaml: |
-    vcd:
-      vipSubnet: "" # Virtual IP CIDR for the external network
-    loadbalancer:
-      oneArm:
-        startIP: "192.168.8.2" # First IP in the IP range used for load balancer virtual service
-        endIP: "192.168.8.100" # Last IP in the IP range used for load balancer virtual service
-      ports:
-        tcp: 6443
-    # managementClusterRDEId is the RDE ID of this management cluster if it exists; if this cluster is a child of another CAPVCD based cluster,
-    # an associated RDE will be created in VCD of Entity Type "urn:vcloud:type:vmware:capvcdCluster:1.0.0".
-    # Retrieve that RDEId using the API - https://VCD_IP/cloudapi/1.0.0/entities/types/vmware/capvcdCluster/1.0.0
-    managementClusterRDEId: ""
-    clusterResourceSet:
-      csi: vkp # CSI version to be used in the workload cluster
-      cpi: vkp # CPI version to be used in the workload cluster
-      cni: 0.11.3 # Antrea version to be used in the workload cluster
-kind: ConfigMap
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: infrastructure-vcd
-  name: capvcd-manager-config
-  namespace: capvcd-system
----
-apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -1054,8 +1028,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-        - mountPath: /etc/kubernetes/vcloud
-          name: controller-manager-config-volume
       securityContext:
         runAsNonRoot: false
       serviceAccountName: capvcd-controller-manager
@@ -1066,7 +1038,7 @@ spec:
           defaultMode: 420
           secretName: webhook-server-cert
       - configMap:
-          name: capvcd-manager-config
+          name: manager-config
         name: controller-manager-config-volume
 ---
 apiVersion: cert-manager.io/v1

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -43,10 +43,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -98,26 +102,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -127,7 +146,8 @@ spec:
               infraId:
                 type: string
               ready:
-                description: Ready denotes that the vcd cluster (infrastructure) is ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is
+                  ready.
                 type: boolean
             required:
             - ready
@@ -145,10 +165,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -185,10 +209,13 @@ spec:
                 - vcdStorageProfileName
                 type: object
               loadBalancer:
-                description: LoadBalancer defines load-balancer configuration for the Cluster both for the control plane nodes and for the CPI
+                description: LoadBalancer defines load-balancer configuration for
+                  the Cluster both for the control plane nodes and for the CPI
                 properties:
                   UseOneArm:
                     type: boolean
+                  vipSubnet:
+                    type: string
                 type: object
               org:
                 type: string
@@ -199,7 +226,8 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables for containerd
+                description: ProxyConfig defines HTTP proxy environment variables
+                  for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -221,20 +249,21 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
-                        description: name is unique within a namespace to reference a secret resource.
+                        description: name is unique within a namespace to reference
+                          a secret resource.
                         type: string
                       namespace:
-                        description: namespace defines the space within which the secret name must be unique.
+                        description: namespace defines the space within which the
+                          secret name must be unique.
                         type: string
                     type: object
                   username:
                     type: string
                 type: object
-              vipSubnet:
-                type: string
             required:
             - org
             - ovdc
@@ -248,26 +277,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -280,7 +324,8 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables for containerd
+                description: ProxyConfig defines HTTP proxy environment variables
+                  for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -291,16 +336,19 @@ spec:
                 type: object
               rdeVersionInUse:
                 default: 1.1.0
-                description: RdeVersionInUse indicates the version of capvcdCluster entity type used by CAPVCD.
+                description: RdeVersionInUse indicates the version of capvcdCluster
+                  entity type used by CAPVCD.
                 type: string
               ready:
                 default: false
-                description: Ready denotes that the vcd cluster (infrastructure) is ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is
+                  ready.
                 type: boolean
               useAsManagementCluster:
                 type: boolean
               vappmetadataUpdated:
-                description: MetadataUpdated denotes that the metadata of Vapp is updated.
+                description: MetadataUpdated denotes that the metadata of Vapp is
+                  updated.
                 type: boolean
             required:
             - rdeVersionInUse
@@ -358,10 +406,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -369,34 +421,41 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
                 type: string
               computePolicy:
-                description: ComputePolicy is the compute policy to be used on this machine
+                description: ComputePolicy is the compute policy to be used on this
+                  machine
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is to be used
+                description: TemplatePath is the path of the template OVA that is
+                  to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker machine.
+                description: Addresses contains the associated addresses for the docker
+                  machine.
                 items:
-                  description: MachineAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -406,26 +465,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -433,7 +507,8 @@ spec:
                   type: object
                 type: array
               ready:
-                description: Ready denotes that the machine (docker container) is ready
+                description: Ready denotes that the machine (docker container) is
+                  ready
                 type: boolean
             type: object
         type: object
@@ -447,10 +522,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -458,7 +537,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -467,41 +547,53 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: DiskSize is the size, in bytes, of the disk for this machine
+                description: DiskSize is the size, in bytes, of the disk for this
+                  machine
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               nvidiaGPU:
-                description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
+                description: NvidiaGPU is true when a VM should be created with the
+                  relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               placementPolicy:
-                description: PlacementPolicy is the placement policy to be used on this machine.
+                description: PlacementPolicy is the placement policy to be used on
+                  this machine.
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
-                description: StorageProfile is the storage profile to be used on this machine
+                description: StorageProfile is the storage profile to be used on this
+                  machine
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is to be used
+                description: TemplatePath is the path of the template OVA that is
+                  to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker machine.
+                description: Addresses contains the associated addresses for the docker
+                  machine.
                 items:
-                  description: MachineAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -511,26 +603,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -539,13 +646,16 @@ spec:
                   type: object
                 type: array
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               ready:
-                description: Ready denotes that the machine (docker container) is ready
+                description: Ready denotes that the machine (docker container) is
+                  ready
                 type: boolean
               template:
-                description: Template is the path of the template OVA that is to be used
+                description: Template is the path of the template OVA that is to be
+                  used
                 type: string
             type: object
         type: object
@@ -595,13 +705,18 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -611,22 +726,27 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior of the machine.
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
                         type: string
                       computePolicy:
-                        description: ComputePolicy is the compute policy to be used on this machine
+                        description: ComputePolicy is the compute policy to be used
+                          on this machine
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID
+                          format (vmware-cloud-director://<vm id>)
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA that is to be used
+                        description: TemplatePath is the path of the template OVA
+                          that is to be used
                         type: string
                     type: object
                 required:
@@ -646,13 +766,18 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -662,10 +787,12 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior of the machine.
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -674,26 +801,35 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: DiskSize is the size, in bytes, of the disk for this machine
+                        description: DiskSize is the size, in bytes, of the disk for
+                          this machine
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       nvidiaGPU:
-                        description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
+                        description: NvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       placementPolicy:
-                        description: PlacementPolicy is the placement policy to be used on this machine.
+                        description: PlacementPolicy is the placement policy to be
+                          used on this machine.
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID
+                          format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
-                        description: StorageProfile is the storage profile to be used on this machine
+                        description: StorageProfile is the storage profile to be used
+                          on this machine
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA that is to be used
+                        description: TemplatePath is the path of the template OVA
+                          that is to be used
                         type: string
                     type: object
                 required:
@@ -785,24 +921,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
-  - clusters/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machines
-  - machines/status
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - ""
   resources:
   - namespaces
@@ -825,6 +943,60 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - kubeadmconfigtemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
@@ -879,45 +1051,9 @@ rules:
   - patch
   - update
 - apiGroups:
-  - controlplane.cluster.x-k8s.io
-  resources:
-  - kubeadmcontrolplanes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
   - vcdmachinetemplates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machinedeployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - bootstrap.cluster.x-k8s.io
-  resources:
-  - kubeadmconfigtemplates
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add missing rbac kubebuilder codes in `vcdclustercontroller.go`.
- Update role.yaml and infrastructure-components.yaml

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [X] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [X] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [X] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [X] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [X] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/199)
<!-- Reviewable:end -->
