### PR TITLE
[VCDA-4029] Update common core dependencies for CAPVCD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.35.0
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220627163332-050c2a42d11b
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220708214416-a03d0d9e871f
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220627163332-050c2a42d11b h1:c0DJcd+ktQBhdD4ddCvI9Ky/n0uUXyENrckjibMXKx0=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220627163332-050c2a42d11b/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220708214416-a03d0d9e871f h1:F8LqZ5luskCWYBWyZO1Oqen2LAI1xgY2egjdPZSwyzw=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220708214416-a03d0d9e871f/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
@@ -691,7 +691,7 @@ func (gatewayManager *GatewayManager) formLoadBalancerPool(lbPoolName string, ip
 		GracefulTimeoutPeriod: int32(0), // when service outage occurs, immediately mark as bad
 		Algorithm:             "ROUND_ROBIN",
 	}
-	if healthMonitor != nil {
+	if healthMonitor != nil && healthMonitor.Type_ == "TCP" {
 		lbPool.HealthMonitors = []swaggerClient.EdgeLoadBalancerHealthMonitor{*healthMonitor}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -255,7 +255,7 @@ github.com/replicatedhq/troubleshoot/pkg/redact
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.2
 ## explicit; go 1.13
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220627163332-050c2a42d11b
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220708214416-a03d0d9e871f
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Update CPI dependencies after regressions code change fix for VCDA-4026, VCDA-4025, VCDA-4015 from July 8th. 

- Commit reference: https://github.com/vmware/cloud-provider-for-cloud-director/commit/a03d0d9e871f8129e780de455e50de23bedbfb71

## Checklist
- [x] tested locally [yes from CPI side, will follow up with CAPVCD testings]
- [x] updated any relevant dependencies
- [ ] updated any relevant documentation or examples [N/A]

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/203)
<!-- Reviewable:end -->
