### PR TITLE
[VCDA-4059] Update Log VM details when network address check fails

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -553,16 +553,23 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// checks before setting address in machine status
 	if vm.VM == nil {
-		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get the machine address of vm [%#v]", vm))
+		log.Error(nil, fmt.Sprintf("Requeuing...; vm.VM should not be nil: [%#v]", vm))
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 	if vm.VM.NetworkConnectionSection == nil || len(vm.VM.NetworkConnectionSection.NetworkConnection) == 0 {
-		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get the network connection section for vm [%s(%s)]: [%#v]", vm.VM.Name, vm.VM.ID, vm.VM))
+		log.Error(nil, fmt.Sprintf("Requeuing...; network connection section was not found for vm [%s(%s)]: [%#v]", vm.VM.Name, vm.VM.ID, vm.VM))
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
-	if vm.VM.NetworkConnectionSection.NetworkConnection[0] == nil || vm.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress == "" {
-		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get the network connection for vm [%s(%s)]: [%#v]", vm.VM.Name, vm.VM.ID, vm.VM.NetworkConnectionSection))
+	if vm.VM.NetworkConnectionSection.NetworkConnection[0] == nil {
+		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get existing network connection information for vm [%s(%s)]: [%#v]. NetworkConnection[0] should not be nil",
+			vm.VM.Name, vm.VM.ID, vm.VM.NetworkConnectionSection))
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	if vm.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress == "" {
+		log.Error(nil, fmt.Sprintf("Requeuing...; NetworkConnection[0] IP Address should not be empty for vm [%s(%s)]: [%#v]",
+			vm.VM.Name, vm.VM.ID, *vm.VM.NetworkConnectionSection.NetworkConnection[0]))
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

-  Updated logging information to show the VM info if exists other than just a pointer.
- Separate conditions and logs for future root causes and understandings

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies [N/A]
- [ ] updated any relevant documentation or examples [N/A]

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/209)
<!-- Reviewable:end -->
