### PR TITLE
[VCDA-4050] Populate nvidiaGpu and storage profile for node pools

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -260,6 +260,8 @@ func getNodePoolList(ctx context.Context, cli client.Client, cluster clusterv1.C
 			Name:            md.Name,
 			SizingPolicy:    vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			PlacementPolicy: vcdMachineTemplate.Spec.Template.Spec.PlacementPolicy,
+			NvidiaGpu:       vcdMachineTemplate.Spec.Template.Spec.NvidiaGPU,
+			StorageProfile:  vcdMachineTemplate.Spec.Template.Spec.StorageProfile,
 			Replicas:        md.Status.Replicas,
 			NodeStatus:      nodeStatusMap,
 		}

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -93,7 +93,8 @@ type NodePool struct {
 	SizingPolicy    string            `json:"sizingPolicy,omitempty"`
 	PlacementPolicy string            `json:"placementPolicy,omitempty"`
 	DiskSizeMb      int32             `json:"diskSizeMb,omitempty"`
-	NvidiaGpu       string            `json:"nvidiaGpu,omitempty"`
+	NvidiaGpu       bool              `json:"nvidiaGpu,omitempty"`
+	StorageProfile  string            `json:"storageProfile,omitempty"`
 	Replicas        int32             `json:"replicas,omitempty"`
 	NodeStatus      map[string]string `json:"nodeStatus,omitempty"`
 }


### PR DESCRIPTION


Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Create and populate storage profile for node pools in capvcd status
- populate nvidiaGpu flag from vcdmachine template

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies - N/A
- [ ] updated any relevant documentation or examples - N/A

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/210)
<!-- Reviewable:end -->
