### PR TITLE
VCDA-4136 update rde with default storage class options in reconcileRDE

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -461,11 +461,14 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	}
 
 	if vcdCluster.Status.DefaultStorageClassOptions.VCDStorageProfileName != "" {
-		capvcdStatusPatch["DefaultStorageClass"] = rdeType.DefaultStorageClass{
+		defaultStorageClass := rdeType.DefaultStorageClass{
 			VCDStorageProfileName:  vcdCluster.Status.DefaultStorageClassOptions.VCDStorageProfileName,
 			K8sStorageClassName:    vcdCluster.Status.DefaultStorageClassOptions.K8sStorageClassName,
 			UseDeleteReclaimPolicy: vcdCluster.Status.DefaultStorageClassOptions.UseDeleteReclaimPolicy,
 			FileSystem:             vcdCluster.Status.DefaultStorageClassOptions.FileSystem,
+		}
+		if !reflect.DeepEqual(capvcdStatus.DefaultStorageClass, defaultStorageClass) {
+			capvcdStatusPatch["DefaultStorageClass"] = defaultStorageClass
 		}
 	}
 

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -460,6 +460,15 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		capvcdStatusPatch["VcdProperties"] = vcdResources
 	}
 
+	if vcdCluster.Status.DefaultStorageClassOptions.VCDStorageProfileName != "" {
+		capvcdStatusPatch["DefaultStorageClass"] = rdeType.DefaultStorageClass{
+			VCDStorageProfileName:  vcdCluster.Status.DefaultStorageClassOptions.VCDStorageProfileName,
+			K8sStorageClassName:    vcdCluster.Status.DefaultStorageClassOptions.K8sStorageClassName,
+			UseDeleteReclaimPolicy: vcdCluster.Status.DefaultStorageClassOptions.UseDeleteReclaimPolicy,
+			FileSystem:             vcdCluster.Status.DefaultStorageClassOptions.FileSystem,
+		}
+	}
+
 	obj := client.ObjectKey{
 		Namespace: cluster.Namespace,
 		Name:      cluster.Name,


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/212)
<!-- Reviewable:end -->
