### PR TITLE
[VCDA-4052] Add errorSet and eventSet to CAPVCD status so PatchRDE() doesn't erase it

### DIFF
--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -1,5 +1,7 @@
 package rde_type_1_1_0
 
+import "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+
 const (
 	CapvcdRDETypeVersion = "1.1.0"
 )
@@ -122,7 +124,8 @@ type CAPVCDStatus struct {
 	NodePool                   []NodePool                  `json:"nodePool,omitempty"`
 	CapvcdVersion              string                      `json:"capvcdVersion,omitempty"`
 	UseAsManagementCluster     bool                        `json:"useAsManagementCluster,omitempty"`
-	Errors                     []string                    `json:"errors,omitempty"`
+	ErrorSet                   []vcdsdk.BackendError       `json:"errorSet,omitempty"`
+	EventSet                   []vcdsdk.BackendEvent       `json:"eventSet,omitempty"`
 	K8sNetwork                 K8sNetwork                  `json:"k8sNetwork,omitempty"`
 	ParentUID                  string                      `json:"parentUid,omitempty"`
 	ClusterResourceSet         []ClusterResource           `json:"clusterResourceSet,omitempty"`


### PR DESCRIPTION


Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Since errorSet and eventSet were missing from CAPVCD status definition, PatchRDE can reset the errors and events array in CAPVCD

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/215)
<!-- Reviewable:end -->
