### PR TITLE
[VCDA-4150] Update missing storage profile, nvidia GPU field from control plane nodepools in RDE

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -291,6 +291,8 @@ func getNodePoolList(ctx context.Context, cli client.Client, cluster clusterv1.C
 			Name:            kcp.Name,
 			SizingPolicy:    vcdMachineTemplate.Spec.Template.Spec.SizingPolicy,
 			PlacementPolicy: vcdMachineTemplate.Spec.Template.Spec.PlacementPolicy,
+			NvidiaGpu:       vcdMachineTemplate.Spec.Template.Spec.NvidiaGPU,
+			StorageProfile:  vcdMachineTemplate.Spec.Template.Spec.StorageProfile,
 			Replicas:        kcp.Status.Replicas,
 			NodeStatus:      nodeStatusMap,
 		}


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Storage profile was missing from the RDE section in control plane nodepools while worker nodepools showed correctly
- Populated nvidiaGPU field for future use cases in control plane machine

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/218)
<!-- Reviewable:end -->
