### PR TITLE
Add check for no rde before getting the RDE entity type version

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -537,13 +537,15 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	// TODO validate if the RDE ID format is correct.
 	if infraID == "" && len(vcdCluster.Spec.RDEId) > 0 {
 		infraID = vcdCluster.Spec.RDEId
-		_, rdeVersion, err := capvcdRdeManager.GetRDEVersion(ctx, infraID)
-		if err != nil {
-			return ctrl.Result{}, errors.Wrapf(err,
-				"\"Unexpected error retrieving RDE [%s] for the cluster [%s]", infraID, vcdCluster.Name)
+		if !strings.HasPrefix(vcdCluster.Spec.RDEId, NoRdePrefix) {
+			_, rdeVersion, err := capvcdRdeManager.GetRDEVersion(ctx, infraID)
+			if err != nil {
+				return ctrl.Result{}, errors.Wrapf(err,
+					"\"Unexpected error retrieving RDE [%s] for the cluster [%s]", infraID, vcdCluster.Name)
+			}
+			// update the RdeVersionInUse with the entity type version of the rde.
+			vcdCluster.Status.RdeVersionInUse = rdeVersion
 		}
-		// update the RdeVersionInUse with the entity type version of the rde.
-		vcdCluster.Status.RdeVersionInUse = rdeVersion
 	}
 
 	// Create a new RDE if it was not already created or assigned.

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -635,7 +635,11 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		oldVCDCluster := vcdCluster.DeepCopy()
 
 		vcdCluster.Status.InfraId = infraID
-		vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
+		if strings.HasPrefix(infraID, NoRdePrefix) {
+			vcdCluster.Status.RdeVersionInUse = NoRdePrefix
+		} else {
+			vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
+		}
 		if err := r.Status().Patch(ctx, vcdCluster, client.MergeFrom(oldVCDCluster)); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
 				"unable to patch status of vcdCluster [%s] with InfraID [%s], RDEVersion [%s]",


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Get the entity type version of the RDE only if it doesn't have NO_RDE prefix

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [ ] updated any relevant documentation or examples - N/A

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/221)
<!-- Reviewable:end -->
