### PR TITLE
[VCDA-3896] Add executeWithoutRDE flag and populate rde id in spec

### DIFF
--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -1,8 +1,10 @@
 package v1alpha4
 
 import (
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	"strings"
 )
 
 // ConvertTo converts this (v1alpha4)VCDCluster to the Hub version (v1beta1).
@@ -15,6 +17,7 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ProxyConfig = v1beta1.ProxyConfig{}
 	// TODO: Update the new params to match previous release's Status; ex) dst.Spec.* = src.Status.*, maybe RDE.Status
 	dst.Spec.RDEId = src.Status.InfraId
+	dst.Spec.ExecuteWithoutRDE = strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix)
 	dst.Spec.ParentUID = ""
 	dst.Spec.UseAsManagementCluster = false // defaults to false
 	dst.Status.RdeVersionInUse = "1.0.0"

--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -17,7 +17,7 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ProxyConfig = v1beta1.ProxyConfig{}
 	// TODO: Update the new params to match previous release's Status; ex) dst.Spec.* = src.Status.*, maybe RDE.Status
 	dst.Spec.RDEId = src.Status.InfraId
-	dst.Spec.ExecuteWithoutRDE = strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix)
+	dst.Spec.SkipRDE = strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix)
 	dst.Spec.ParentUID = ""
 	dst.Spec.UseAsManagementCluster = false // defaults to false
 	dst.Status.RdeVersionInUse = "1.0.0"

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -339,6 +339,7 @@ func autoConvert_v1beta1_VCDClusterSpec_To_v1alpha4_VCDClusterSpec(in *v1beta1.V
 	// WARNING: in.UseAsManagementCluster requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProxyConfig requires manual conversion: does not exist in peer-type
 	// WARNING: in.LoadBalancer requires manual conversion: does not exist in peer-type
+	// WARNING: in.ExecuteWithoutRDE requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -339,7 +339,7 @@ func autoConvert_v1beta1_VCDClusterSpec_To_v1alpha4_VCDClusterSpec(in *v1beta1.V
 	// WARNING: in.UseAsManagementCluster requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProxyConfig requires manual conversion: does not exist in peer-type
 	// WARNING: in.LoadBalancer requires manual conversion: does not exist in peer-type
-	// WARNING: in.ExecuteWithoutRDE requires manual conversion: does not exist in peer-type
+	// WARNING: in.SkipRDE requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -102,6 +102,7 @@ type VCDClusterSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 	// +optional
 	LoadBalancer LoadBalancer `json:"loadBalancer,omitempty"`
+	// ExecuteWithoutRDE tells CAPVCD if an RDE should be created for the cluster
 	// +kubebuilder:default=false
 	ExecuteWithoutRDE bool `json:"executeWithoutRDE,omitempty"`
 }

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -102,9 +102,9 @@ type VCDClusterSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 	// +optional
 	LoadBalancer LoadBalancer `json:"loadBalancer,omitempty"`
-	// ExecuteWithoutRDE tells CAPVCD if an RDE should be created for the cluster
+	// SkipRDE tells CAPVCD if an RDE should be created for the cluster or not
 	// +kubebuilder:default=false
-	ExecuteWithoutRDE bool `json:"executeWithoutRDE,omitempty"`
+	SkipRDE bool `json:"skipRDE,omitempty"`
 }
 
 // VCDClusterStatus defines the observed state of VCDCluster

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -102,6 +102,8 @@ type VCDClusterSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 	// +optional
 	LoadBalancer LoadBalancer `json:"loadBalancer,omitempty"`
+	// +kubebuilder:default=false
+	ExecuteWithoutRDE bool `json:"executeWithoutRDE,omitempty"`
 }
 
 // VCDClusterStatus defines the observed state of VCDCluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -187,6 +187,9 @@ spec:
                 required:
                 - vcdStorageProfileName
                 type: object
+              executeWithoutRDE:
+                default: false
+                type: boolean
               loadBalancer:
                 description: LoadBalancer defines load-balancer configuration for
                   the Cluster both for the control plane nodes and for the CPI

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -189,6 +189,8 @@ spec:
                 type: object
               executeWithoutRDE:
                 default: false
+                description: ExecuteWithoutRDE tells CAPVCD if an RDE should be created
+                  for the cluster
                 type: boolean
               loadBalancer:
                 description: LoadBalancer defines load-balancer configuration for

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -187,11 +187,6 @@ spec:
                 required:
                 - vcdStorageProfileName
                 type: object
-              executeWithoutRDE:
-                default: false
-                description: ExecuteWithoutRDE tells CAPVCD if an RDE should be created
-                  for the cluster
-                type: boolean
               loadBalancer:
                 description: LoadBalancer defines load-balancer configuration for
                   the Cluster both for the control plane nodes and for the CPI
@@ -224,6 +219,11 @@ spec:
                 type: string
               site:
                 type: string
+              skipRDE:
+                default: false
+                description: SkipRDE tells CAPVCD if an RDE should be created for
+                  the cluster or not
+                type: boolean
               useAsManagementCluster:
                 type: boolean
               userContext:

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -528,7 +528,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	infraID := vcdCluster.Status.InfraId
-	shouldCreateRDE := !vcdCluster.Spec.ExecuteWithoutRDE
+	shouldCreateRDE := !vcdCluster.Spec.SkipRDE
 
 	// General note on RDE operations, always ensure CAPVCD cluster reconciliation progress
 	//is not affected by any RDE operation failures.
@@ -538,7 +538,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if shouldCreateRDE && !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
 		return ctrl.Result{}, errors.Wrapf(errors.New("capvcdCluster entity type not registered or capvcdCluster rights missing from the user's role"),
 			"cluster create issued with executeWithoutRDE=[%v] but unable to create capvcdCluster entity at version [%s]",
-			vcdCluster.Spec.ExecuteWithoutRDE, rdeType.CapvcdRDETypeVersion)
+			vcdCluster.Spec.SkipRDE, rdeType.CapvcdRDETypeVersion)
 	}
 
 	// Use the pre-created RDEId specified in the CAPI yaml specification.
@@ -646,7 +646,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		oldVCDCluster := vcdCluster.DeepCopy()
 
 		vcdCluster.Status.InfraId = infraID
-		if vcdCluster.Spec.ExecuteWithoutRDE {
+		if vcdCluster.Spec.SkipRDE {
 			vcdCluster.Status.RdeVersionInUse = NoRdePrefix
 		} else {
 			vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -536,7 +536,8 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// fail cluster creation if RDE should be created but capvcdCluster entity type is not registered
 	if shouldCreateRDE && !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
-		return ctrl.Result{}, errors.Wrapf(errors.New("CAPVCD entity type not registered"), "cluster create issued with executeWithoutRDE=[%v] but unable to find capvcdCluster entity type at version [%s]",
+		return ctrl.Result{}, errors.Wrapf(errors.New("capvcdCluster entity type not registered or capvcdCluster rights missing from the user's role"),
+			"cluster create issued with executeWithoutRDE=[%v] but unable to create capvcdCluster entity at version [%s]",
 			vcdCluster.Spec.ExecuteWithoutRDE, rdeType.CapvcdRDETypeVersion)
 	}
 

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -528,16 +528,23 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	infraID := vcdCluster.Status.InfraId
+	shouldCreateRDE := !vcdCluster.Spec.ExecuteWithoutRDE
 
 	// General note on RDE operations, always ensure CAPVCD cluster reconciliation progress
 	//is not affected by any RDE operation failures.
 	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
 
+	// fail cluster creation if RDE should be created but capvcdCluster entity type is not registered
+	if shouldCreateRDE && !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
+		return ctrl.Result{}, errors.Wrapf(errors.New("CAPVCD entity type not registered"), "cluster create issued with executeWithoutRDE=[%v] but unable to find capvcdCluster entity type at version [%s]",
+			vcdCluster.Spec.ExecuteWithoutRDE, rdeType.CapvcdRDETypeVersion)
+	}
+
 	// Use the pre-created RDEId specified in the CAPI yaml specification.
 	// TODO validate if the RDE ID format is correct.
 	if infraID == "" && len(vcdCluster.Spec.RDEId) > 0 {
 		infraID = vcdCluster.Spec.RDEId
-		if !strings.HasPrefix(vcdCluster.Spec.RDEId, NoRdePrefix) {
+		if shouldCreateRDE {
 			_, rdeVersion, err := capvcdRdeManager.GetRDEVersion(ctx, infraID)
 			if err != nil {
 				return ctrl.Result{}, errors.Wrapf(err,
@@ -550,36 +557,44 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// Create a new RDE if it was not already created or assigned.
 	if infraID == "" {
-		nameFilter := &swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{
-			Filter: optional.NewString(fmt.Sprintf("name==%s", vcdCluster.Name)),
-		}
-		definedEntities, resp, err := workloadVCDClient.APIClient.DefinedEntityApi.GetDefinedEntitiesByEntityType(ctx,
-			capisdk.CAPVCDTypeVendor, capisdk.CAPVCDTypeNss, rdeType.CapvcdRDETypeVersion, 1, 25, nameFilter)
-		if err != nil {
-			log.Error(err, "Error while checking if RDE is already present for the cluster",
-				"entityTypeId", CAPVCDEntityTypeID)
-		}
-		if resp == nil {
-			log.Error(nil, "Error while checking if RDE is already present for the cluster; "+
-				"obtained an empty response for get defined entity call for the cluster")
-		} else if resp.StatusCode != http.StatusOK {
-			log.Error(nil, "Error while checking if RDE is already present for the cluster",
-				"entityTypeId", CAPVCDEntityTypeID, "responseStatusCode", resp.StatusCode)
-		}
-		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
-			if len(definedEntities.Values) == 0 {
-				rdeID, err := r.constructAndCreateRDEFromCluster(ctx, workloadVCDClient, cluster, vcdCluster)
-				if err != nil {
-					log.Error(err, "Error creating RDE for the cluster")
-				} else {
-					infraID = rdeID
-				}
-				vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
-			} else {
-				log.Info("RDE for the cluster is already present; skipping RDE creation", "InfraId",
-					definedEntities.Values[0].Id)
-				infraID = definedEntities.Values[0].Id
+		if shouldCreateRDE {
+			nameFilter := &swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{
+				Filter: optional.NewString(fmt.Sprintf("name==%s", vcdCluster.Name)),
 			}
+			definedEntities, resp, err := workloadVCDClient.APIClient.DefinedEntityApi.GetDefinedEntitiesByEntityType(ctx,
+				capisdk.CAPVCDTypeVendor, capisdk.CAPVCDTypeNss, rdeType.CapvcdRDETypeVersion, 1, 25, nameFilter)
+			if err != nil {
+				log.Error(err, "Error while checking if RDE is already present for the cluster",
+					"entityTypeId", CAPVCDEntityTypeID)
+			}
+			if resp == nil {
+				log.Error(nil, "Error while checking if RDE is already present for the cluster; "+
+					"obtained an empty response for get defined entity call for the cluster")
+			} else if resp.StatusCode != http.StatusOK {
+				log.Error(nil, "Error while checking if RDE is already present for the cluster",
+					"entityTypeId", CAPVCDEntityTypeID, "responseStatusCode", resp.StatusCode)
+			}
+			if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
+				if len(definedEntities.Values) == 0 {
+					rdeID, err := r.constructAndCreateRDEFromCluster(ctx, workloadVCDClient, cluster, vcdCluster)
+					if err != nil {
+						log.Error(err, "Error creating RDE for the cluster")
+					} else {
+						infraID = rdeID
+					}
+					vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
+				} else {
+					log.Info("RDE for the cluster is already present; skipping RDE creation", "InfraId",
+						definedEntities.Values[0].Id)
+					infraID = definedEntities.Values[0].Id
+				}
+			}
+		} else {
+			// If there is no RDE ID specified (or) created for any reason, self-generate one and use.
+			// We need UUIDs to single-instance cleanly in the Virtual Services etc.
+			noRDEID := NoRdePrefix + uuid.New().String()
+			log.Info("Error retrieving InfraId. Hence using a self-generated UUID", "UUID", noRDEID)
+			infraID = noRDEID
 		}
 	} else {
 		log.V(3).Info("Reusing already available InfraID", "infraID", infraID)
@@ -617,25 +632,20 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 	}
 
-	// If there is no RDE ID specified (or) created for any reason, self-generate one and use.
-	// We need UUIDs to single-instance cleanly in the Virtual Services etc.
-	if infraID == "" {
-		noRDEID := NoRdePrefix + uuid.New().String()
-		log.Info("Error retrieving InfraId. Hence using a self-generated UUID", "UUID", noRDEID)
-		infraID = noRDEID
-	} else {
-		err = capvcdRdeManager.AddToEventSet(ctx, capisdk.RdeAvailable, infraID, "", "")
-		if err != nil {
-			log.Error(err, "failed to add RdeAvailable event", "rdeID", infraID)
-		}
+	err = capvcdRdeManager.AddToEventSet(ctx, capisdk.RdeAvailable, infraID, "", "")
+	if err != nil {
+		log.Error(err, "failed to add RdeAvailable event", "rdeID", infraID)
 	}
+
+	vcdCluster.Spec.RDEId = infraID
+	log.Info("infraID for the cluster is", "infraID", infraID)
 
 	// If the vcdClusterObject does not have the InfraId set, we need to set it. If it has one, we can reuse it.
 	if vcdCluster.Status.InfraId == "" {
 		oldVCDCluster := vcdCluster.DeepCopy()
 
 		vcdCluster.Status.InfraId = infraID
-		if strings.HasPrefix(infraID, NoRdePrefix) {
+		if vcdCluster.Spec.ExecuteWithoutRDE {
 			vcdCluster.Status.RdeVersionInUse = NoRdePrefix
 		} else {
 			vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion

--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -60,6 +60,7 @@ spec:
   rdeId: "urn:vcloud:entity:vmware:capvcdCluster:UUID" # rdeId if it is already created. If empty, CAPVCD will create one for the cluster.
   loadBalancer:
     vipSubnet: "" # Virtual IP CIDR for the external network
+  executeWithoutRDE: false
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDMachineTemplate

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -43,10 +43,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -98,26 +102,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -127,7 +146,8 @@ spec:
               infraId:
                 type: string
               ready:
-                description: Ready denotes that the vcd cluster (infrastructure) is ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is
+                  ready.
                 type: boolean
             required:
             - ready
@@ -145,10 +165,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -184,12 +208,9 @@ spec:
                 required:
                 - vcdStorageProfileName
                 type: object
-              executeWithoutRDE:
-                default: false
-                description: ExecuteWithoutRDE tells CAPVCD if an RDE should be created for the cluster
-                type: boolean
               loadBalancer:
-                description: LoadBalancer defines load-balancer configuration for the Cluster both for the control plane nodes and for the CPI
+                description: LoadBalancer defines load-balancer configuration for
+                  the Cluster both for the control plane nodes and for the CPI
                 properties:
                   useOneArm:
                     type: boolean
@@ -205,7 +226,8 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables for containerd
+                description: ProxyConfig defines HTTP proxy environment variables
+                  for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -218,6 +240,11 @@ spec:
                 type: string
               site:
                 type: string
+              skipRDE:
+                default: false
+                description: SkipRDE tells CAPVCD if an RDE should be created for
+                  the cluster or not
+                type: boolean
               useAsManagementCluster:
                 type: boolean
               userContext:
@@ -227,13 +254,16 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
-                        description: name is unique within a namespace to reference a secret resource.
+                        description: name is unique within a namespace to reference
+                          a secret resource.
                         type: string
                       namespace:
-                        description: namespace defines the space within which the secret name must be unique.
+                        description: namespace defines the space within which the
+                          secret name must be unique.
                         type: string
                     type: object
                   username:
@@ -252,26 +282,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -300,7 +345,8 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables for containerd
+                description: ProxyConfig defines HTTP proxy environment variables
+                  for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -311,16 +357,19 @@ spec:
                 type: object
               rdeVersionInUse:
                 default: 1.1.0
-                description: RdeVersionInUse indicates the version of capvcdCluster entity type used by CAPVCD.
+                description: RdeVersionInUse indicates the version of capvcdCluster
+                  entity type used by CAPVCD.
                 type: string
               ready:
                 default: false
-                description: Ready denotes that the vcd cluster (infrastructure) is ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is
+                  ready.
                 type: boolean
               useAsManagementCluster:
                 type: boolean
               vappmetadataUpdated:
-                description: MetadataUpdated denotes that the metadata of Vapp is updated.
+                description: MetadataUpdated denotes that the metadata of Vapp is
+                  updated.
                 type: boolean
             required:
             - rdeVersionInUse
@@ -378,10 +427,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -389,34 +442,41 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
                 type: string
               computePolicy:
-                description: ComputePolicy is the compute policy to be used on this machine
+                description: ComputePolicy is the compute policy to be used on this
+                  machine
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is to be used
+                description: TemplatePath is the path of the template OVA that is
+                  to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker machine.
+                description: Addresses contains the associated addresses for the docker
+                  machine.
                 items:
-                  description: MachineAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -426,26 +486,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -453,7 +528,8 @@ spec:
                   type: object
                 type: array
               ready:
-                description: Ready denotes that the machine (docker container) is ready
+                description: Ready denotes that the machine (docker container) is
+                  ready
                 type: boolean
             type: object
         type: object
@@ -467,10 +543,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -478,7 +558,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -487,41 +568,53 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: DiskSize is the size, in bytes, of the disk for this machine
+                description: DiskSize is the size, in bytes, of the disk for this
+                  machine
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               nvidiaGPU:
-                description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
+                description: NvidiaGPU is true when a VM should be created with the
+                  relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               placementPolicy:
-                description: PlacementPolicy is the placement policy to be used on this machine.
+                description: PlacementPolicy is the placement policy to be used on
+                  this machine.
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
-                description: StorageProfile is the storage profile to be used on this machine
+                description: StorageProfile is the storage profile to be used on this
+                  machine
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is to be used
+                description: TemplatePath is the path of the template OVA that is
+                  to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker machine.
+                description: Addresses contains the associated addresses for the docker
+                  machine.
                 items:
-                  description: MachineAddress contains information for the node's address.
+                  description: MachineAddress contains information for the node's
+                    address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
                   required:
                   - address
@@ -531,26 +624,41 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource operational state.
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition. This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -559,13 +667,16 @@ spec:
                   type: object
                 type: array
               providerID:
-                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format
+                  (vmware-cloud-director://<vm id>)
                 type: string
               ready:
-                description: Ready denotes that the machine (docker container) is ready
+                description: Ready denotes that the machine (docker container) is
+                  ready
                 type: boolean
               template:
-                description: Template is the path of the template OVA that is to be used
+                description: Template is the path of the template OVA that is to be
+                  used
                 type: string
             type: object
         type: object
@@ -615,13 +726,18 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -631,22 +747,27 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior of the machine.
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
                         type: string
                       computePolicy:
-                        description: ComputePolicy is the compute policy to be used on this machine
+                        description: ComputePolicy is the compute policy to be used
+                          on this machine
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID
+                          format (vmware-cloud-director://<vm id>)
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA that is to be used
+                        description: TemplatePath is the path of the template OVA
+                          that is to be used
                         type: string
                     type: object
                 required:
@@ -666,13 +787,18 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -682,10 +808,12 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior of the machine.
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -694,26 +822,35 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: DiskSize is the size, in bytes, of the disk for this machine
+                        description: DiskSize is the size, in bytes, of the disk for
+                          this machine
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       nvidiaGPU:
-                        description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
+                        description: NvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       placementPolicy:
-                        description: PlacementPolicy is the placement policy to be used on this machine.
+                        description: PlacementPolicy is the placement policy to be
+                          used on this machine.
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID
+                          format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
-                        description: StorageProfile is the storage profile to be used on this machine
+                        description: StorageProfile is the storage profile to be used
+                          on this machine
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA that is to be used
+                        description: TemplatePath is the path of the template OVA
+                          that is to be used
                         type: string
                     type: object
                 required:

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -43,14 +43,10 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -102,41 +98,26 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition defines an observation of a Cluster API resource operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: A human readable message indicating details about the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - status
@@ -146,8 +127,7 @@ spec:
               infraId:
                 type: string
               ready:
-                description: Ready denotes that the vcd cluster (infrastructure) is
-                  ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is ready.
                 type: boolean
             required:
             - ready
@@ -165,14 +145,10 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -208,9 +184,11 @@ spec:
                 required:
                 - vcdStorageProfileName
                 type: object
+              executeWithoutRDE:
+                default: false
+                type: boolean
               loadBalancer:
-                description: LoadBalancer defines load-balancer configuration for
-                  the Cluster both for the control plane nodes and for the CPI
+                description: LoadBalancer defines load-balancer configuration for the Cluster both for the control plane nodes and for the CPI
                 properties:
                   useOneArm:
                     type: boolean
@@ -226,8 +204,7 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables
-                  for containerd
+                description: ProxyConfig defines HTTP proxy environment variables for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -249,16 +226,13 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: SecretReference represents a Secret Reference. It
-                      has enough information to retrieve secret in any namespace
+                    description: SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
                     properties:
                       name:
-                        description: name is unique within a namespace to reference
-                          a secret resource.
+                        description: name is unique within a namespace to reference a secret resource.
                         type: string
                       namespace:
-                        description: namespace defines the space within which the
-                          secret name must be unique.
+                        description: namespace defines the space within which the secret name must be unique.
                         type: string
                     type: object
                   username:
@@ -277,41 +251,26 @@ spec:
               conditions:
                 description: Conditions defines current service state of the VCDCluster.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition defines an observation of a Cluster API resource operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: A human readable message indicating details about the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -340,8 +299,7 @@ spec:
               parentUid:
                 type: string
               proxyConfig:
-                description: ProxyConfig defines HTTP proxy environment variables
-                  for containerd
+                description: ProxyConfig defines HTTP proxy environment variables for containerd
                 properties:
                   httpProxy:
                     type: string
@@ -352,19 +310,16 @@ spec:
                 type: object
               rdeVersionInUse:
                 default: 1.1.0
-                description: RdeVersionInUse indicates the version of capvcdCluster
-                  entity type used by CAPVCD.
+                description: RdeVersionInUse indicates the version of capvcdCluster entity type used by CAPVCD.
                 type: string
               ready:
                 default: false
-                description: Ready denotes that the vcd cluster (infrastructure) is
-                  ready.
+                description: Ready denotes that the vcd cluster (infrastructure) is ready.
                 type: boolean
               useAsManagementCluster:
                 type: boolean
               vappmetadataUpdated:
-                description: MetadataUpdated denotes that the metadata of Vapp is
-                  updated.
+                description: MetadataUpdated denotes that the metadata of Vapp is updated.
                 type: boolean
             required:
             - rdeVersionInUse
@@ -422,14 +377,10 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -437,41 +388,34 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has
-                  been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
                 type: string
               computePolicy:
-                description: ComputePolicy is the compute policy to be used on this
-                  machine
+                description: ComputePolicy is the compute policy to be used on this machine
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format
-                  (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is
-                  to be used
+                description: TemplatePath is the path of the template OVA that is to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker
-                  machine.
+                description: Addresses contains the associated addresses for the docker machine.
                 items:
-                  description: MachineAddress contains information for the node's
-                    address.
+                  description: MachineAddress contains information for the node's address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
                       type: string
                   required:
                   - address
@@ -481,41 +425,26 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition defines an observation of a Cluster API resource operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: A human readable message indicating details about the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - status
@@ -523,8 +452,7 @@ spec:
                   type: object
                 type: array
               ready:
-                description: Ready denotes that the machine (docker container) is
-                  ready
+                description: Ready denotes that the machine (docker container) is ready
                 type: boolean
             type: object
         type: object
@@ -538,14 +466,10 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -553,8 +477,7 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has
-                  been run against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -563,53 +486,41 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: DiskSize is the size, in bytes, of the disk for this
-                  machine
+                description: DiskSize is the size, in bytes, of the disk for this machine
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               nvidiaGPU:
-                description: NvidiaGPU is true when a VM should be created with the
-                  relevant binaries installed If true, then an appropriate placement
-                  policy should be set
+                description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
                 type: boolean
               placementPolicy:
-                description: PlacementPolicy is the placement policy to be used on
-                  this machine.
+                description: PlacementPolicy is the placement policy to be used on this machine.
                 type: string
               providerID:
-                description: ProviderID will be the container name in ProviderID format
-                  (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: SizingPolicy is the sizing policy to be used on this
-                  machine. If no sizing policy is specified, default sizing policy
-                  will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
                 type: string
               storageProfile:
-                description: StorageProfile is the storage profile to be used on this
-                  machine
+                description: StorageProfile is the storage profile to be used on this machine
                 type: string
               template:
-                description: TemplatePath is the path of the template OVA that is
-                  to be used
+                description: TemplatePath is the path of the template OVA that is to be used
                 type: string
             type: object
           status:
             description: VCDMachineStatus defines the observed state of VCDMachine
             properties:
               addresses:
-                description: Addresses contains the associated addresses for the docker
-                  machine.
+                description: Addresses contains the associated addresses for the docker machine.
                 items:
-                  description: MachineAddress contains information for the node's
-                    address.
+                  description: MachineAddress contains information for the node's address.
                   properties:
                     address:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
                       type: string
                   required:
                   - address
@@ -619,41 +530,26 @@ spec:
               conditions:
                 description: Conditions defines current service state of the DockerMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition defines an observation of a Cluster API resource operational state.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another. This should be when the underlying condition changed.
-                        If that is not known, then using the time when the API field
-                        changed is acceptable.
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about
-                        the transition. This field may be empty.
+                      description: A human readable message indicating details about the transition. This field may be empty.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition
-                        in CamelCase. The specific API may choose whether or not this
-                        field is considered a guaranteed API. This field may not be
-                        empty.
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
                       type: string
                     severity:
-                      description: Severity provides an explicit classification of
-                        Reason code, so the users or machines can immediately understand
-                        the current situation and act accordingly. The Severity field
-                        MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -662,16 +558,13 @@ spec:
                   type: object
                 type: array
               providerID:
-                description: ProviderID will be the container name in ProviderID format
-                  (vmware-cloud-director://<vm id>)
+                description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
                 type: string
               ready:
-                description: Ready denotes that the machine (docker container) is
-                  ready
+                description: Ready denotes that the machine (docker container) is ready
                 type: boolean
               template:
-                description: Template is the path of the template OVA that is to be
-                  used
+                description: Template is the path of the template OVA that is to be used
                 type: string
             type: object
         type: object
@@ -721,18 +614,13 @@ spec:
   - name: v1alpha4
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
-          API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -742,27 +630,22 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior
-                      of the machine.
+                    description: Spec is the specification of the desired behavior of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping
-                          has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
                         type: string
                       computePolicy:
-                        description: ComputePolicy is the compute policy to be used
-                          on this machine
+                        description: ComputePolicy is the compute policy to be used on this machine
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID
-                          format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA
-                          that is to be used
+                        description: TemplatePath is the path of the template OVA that is to be used
                         type: string
                     type: object
                 required:
@@ -782,18 +665,13 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates
-          API
+        description: VCDMachineTemplate is the Schema for the vcdmachinetemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -803,12 +681,10 @@ spec:
               template:
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior
-                      of the machine.
+                    description: Spec is the specification of the desired behavior of the machine.
                     properties:
                       bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping
-                          has been run against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -817,35 +693,26 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: DiskSize is the size, in bytes, of the disk for
-                          this machine
+                        description: DiskSize is the size, in bytes, of the disk for this machine
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       nvidiaGPU:
-                        description: NvidiaGPU is true when a VM should be created
-                          with the relevant binaries installed If true, then an appropriate
-                          placement policy should be set
+                        description: NvidiaGPU is true when a VM should be created with the relevant binaries installed If true, then an appropriate placement policy should be set
                         type: boolean
                       placementPolicy:
-                        description: PlacementPolicy is the placement policy to be
-                          used on this machine.
+                        description: PlacementPolicy is the placement policy to be used on this machine.
                         type: string
                       providerID:
-                        description: ProviderID will be the container name in ProviderID
-                          format (vmware-cloud-director://<vm id>)
+                        description: ProviderID will be the container name in ProviderID format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: SizingPolicy is the sizing policy to be used
-                          on this machine. If no sizing policy is specified, default
-                          sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used on this machine. If no sizing policy is specified, default sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
-                        description: StorageProfile is the storage profile to be used
-                          on this machine
+                        description: StorageProfile is the storage profile to be used on this machine
                         type: string
                       template:
-                        description: TemplatePath is the path of the template OVA
-                          that is to be used
+                        description: TemplatePath is the path of the template OVA that is to be used
                         type: string
                     type: object
                 required:

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -186,6 +186,7 @@ spec:
                 type: object
               executeWithoutRDE:
                 default: false
+                description: ExecuteWithoutRDE tells CAPVCD if an RDE should be created for the cluster
                 type: boolean
               loadBalancer:
                 description: LoadBalancer defines load-balancer configuration for the Cluster both for the control plane nodes and for the CPI


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add executeWithoutRDE flag to VCDCluster. Which when set to true will instruct CAPVCD not to create RDEs for the cluster.
- Populate vcdCluster.Spec.RDEID so that clusterctl move when NO_RDE_ id is autogenerated also copies the ID in the vcdCluster spec. (There is an existing issue that clusterctl move does not copy the values in the status to the target cluster)

Testing done:
- Create cluster (NO_RDE)
- Resize cluster (NO_RDE)
- Clusterctl move (NO_RDE)
- Delete cluster (NO_RDE)
- Create cluster
- Resize cluster
- Clusterctl move
- Delete cluster 

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [x] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [x] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [x] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [x] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [x] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [x] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes https://github.com/vmware/cluster-api-provider-cloud-director/issues/211

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/223)
<!-- Reviewable:end -->
