### PR TITLE
[VCDA-4086] Add metadata/extraConfig values for metering

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -17,6 +17,14 @@ import (
 	"strings"
 )
 
+func getTKGVersion(cluster *clusterv1.Cluster) string {
+	annotationsMap := cluster.GetAnnotations()
+	if tkgVersion, exists := annotationsMap["TKGVERSION"]; exists {
+		return tkgVersion
+	}
+	return ""
+}
+
 // filterTypeMetaAndObjectMetaFromK8sObjectMap is a helper function to remove extraneous contents in "objectmeta" and "typemeta"
 //  keys. The function moves name and namespace from "objectmeta" key to "metadata" key and moves all the keys from "typemeta"
 //  key to objMap

--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -17,9 +17,11 @@ import (
 	"strings"
 )
 
+const tkgVersionLabel = "TKGVERSION"
+
 func getTKGVersion(cluster *clusterv1.Cluster) string {
 	annotationsMap := cluster.GetAnnotations()
-	if tkgVersion, exists := annotationsMap["TKGVERSION"]; exists {
+	if tkgVersion, exists := annotationsMap[tkgVersionLabel]; exists {
 		return tkgVersion
 	}
 	return ""

--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -1,7 +1,4 @@
 #cloud-config
-users:
-  - name: root
-    lock_passwd: false
 write_files: {{- if .ControlPlane }}
 - path: /root/vcloud-basic-auth.yaml
   owner: root

--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -1,4 +1,7 @@
 #cloud-config
+users:
+  - name: root
+    lock_passwd: false
 write_files: {{- if .ControlPlane }}
 - path: /root/vcloud-basic-auth.yaml
   owner: root
@@ -14,7 +17,7 @@ write_files: {{- if .ControlPlane }}
       name: vcloud-basic-auth
       namespace: kube-system
     --- {{- end }}
-- path: /root/metering.sh
+- path: /opt/vmware/cloud-director/metering.sh
   owner: root
   content: |
      #!/usr/bin/env bash
@@ -37,7 +40,7 @@ write_files: {{- if .ControlPlane }}
     [Service]
     Type=simple
     EnvironmentFile=/etc/vcloud/metering
-    ExecStart=/bin/bash /root/metering.sh
+    ExecStart=/bin/bash /opt/vmware/cloud-director/metering.sh
 
     [Install]
     WantedBy=multi-user.target
@@ -80,6 +83,12 @@ write_files: {{- if .ControlPlane }}
     # also remove ipv6 localhost entry from /etc/hosts
     sed -i 's/::1/127.0.0.1/g' /etc/hosts || true
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
+
+    vmtoolsd --cmd "info-set guestinfo.metering.status in_progress"
+    systemctl enable metering
+    systemctl daemon-reload
+    systemctl restart metering
+    vmtoolsd --cmd "info-set guestinfo.metering.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
     export HTTP_PROXY="{{.HTTPProxy}}"
@@ -175,14 +184,11 @@ write_files: {{- if .ControlPlane }}
     systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.containerd.nvidia.configuration.status successful" {{- end }}
 
-    systemctl enable metering.service
-    systemctl restart metering
-
     echo "$(date) post customization script execution completed" &>> /var/log/capvcd/customization/status.log
     exit 0
 runcmd:
 - 'cloud-init clean'
-- '[ ! -f /root/metering.sh ] && sudo reboot'
+- '[ ! -f /opt/vmware/cloud-director/metering.sh ] && sudo reboot'
 - '[ ! -f /etc/vcloud/metering ] && sudo reboot'
 {{ if .ControlPlane }}
 - '[ ! -f /root/vcloud-basic-auth.yaml ] && sudo reboot'

--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -17,6 +17,33 @@ write_files: {{- if .ControlPlane }}
       name: vcloud-basic-auth
       namespace: kube-system
     --- {{- end }}
+- path: /root/metering.sh
+  owner: root
+  content: |
+     #!/usr/bin/env bash
+     vmtoolsd --cmd "info-set guestinfo.metering.vcd_site_id $VCD_SITE_ID"
+     vmtoolsd --cmd "info-set guestinfo.metering.cluster_id $CLUSTER_ID"
+     vmtoolsd --cmd "info-set guestinfo.metering.tkg_version $TKG_VERSION"
+     vmtoolsd --cmd "info-set guestinfo.metering.machine_type $MACHINE_TYPE"
+     vmtoolsd --cmd "info-set guestinfo.metering.mgmt $MGMT"
+- path: /etc/vcloud/metering
+  owner: root
+  content: |
+    VCD_SITE_ID={{ .VcdHostFormatted }}
+    CLUSTER_ID={{ .ClusterID }}
+    TKG_VERSION={{ .TKGVersion }}
+    MACHINE_TYPE={{- if .ControlPlane -}} control_plane {{- else -}} worker {{- end }}
+    MGMT=true
+- path: /etc/systemd/system/metering.service
+  owner: root
+  content: |
+    [Service]
+    Type=simple
+    EnvironmentFile=/etc/vcloud/metering
+    ExecStart=/bin/bash /root/metering.sh
+
+    [Install]
+    WantedBy=multi-user.target
 - path: /root/ {{- if .ControlPlane -}} control_plane {{- else -}} node {{- end -}} .sh
   owner: root
   content: |
@@ -151,10 +178,15 @@ write_files: {{- if .ControlPlane }}
     systemctl restart containerd
     vmtoolsd --cmd "info-set guestinfo.postcustomization.containerd.nvidia.configuration.status successful" {{- end }}
 
+    systemctl enable metering.service
+    systemctl restart metering
+
     echo "$(date) post customization script execution completed" &>> /var/log/capvcd/customization/status.log
     exit 0
 runcmd:
 - 'cloud-init clean'
+- '[ ! -f /root/metering.sh ] && sudo reboot'
+- '[ ! -f /etc/vcloud/metering ] && sudo reboot'
 {{ if .ControlPlane }}
 - '[ ! -f /root/vcloud-basic-auth.yaml ] && sudo reboot'
 - '[ ! -f /root/control_plane.sh ] && sudo reboot'

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -450,6 +450,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		cloudInitInput.HTTPSProxy = vcdCluster.Spec.ProxyConfig.HTTPSProxy
 		cloudInitInput.NoProxy = vcdCluster.Spec.ProxyConfig.NoProxy
 		cloudInitInput.MachineName = machine.Name
+		// TODO: After tenants has access to siteId, populate siteId to cloudInitInput as opposed to the site
 		cloudInitInput.VcdHostFormatted = strings.Replace(vcdCluster.Spec.Site, "/", "\\/", -1)
 		cloudInitInput.NvidiaGPU = vcdMachine.Spec.NvidiaGPU
 		cloudInitInput.TKGVersion = getTKGVersion(cluster) // needed for both worker & control plane machines for metering

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -58,6 +58,8 @@ type CloudInitScriptInput struct {
 	HTTPSProxy            string // httpsProxy endpoint
 	NoProxy               string // no proxy values
 	MachineName           string // vm host name
+	VcdHostFormatted      string // vcd host
+	TKGVersion            string // tkgVersion
 }
 
 const (
@@ -448,8 +450,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		cloudInitInput.HTTPSProxy = vcdCluster.Spec.ProxyConfig.HTTPSProxy
 		cloudInitInput.NoProxy = vcdCluster.Spec.ProxyConfig.NoProxy
 		cloudInitInput.MachineName = machine.Name
+		cloudInitInput.VcdHostFormatted = strings.Replace(vcdCluster.Spec.Site, "/", "\\/", -1)
 		cloudInitInput.NvidiaGPU = vcdMachine.Spec.NvidiaGPU
-
+		cloudInitInput.TKGVersion = getTKGVersion(cluster) // needed for both worker & control plane machines for metering
 	}
 
 	mergedCloudInitBytes, err := MergeJinjaToCloudInitScript(cloudInitInput, bootstrapJinjaScript)


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Adds VCD_SITE_ID, CLUSTER_ID, TKG_VERSION, MACHINE_TYPE, MGMT fields to VM's created by CAPVCD. 

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/226)
<!-- Reviewable:end -->
