### PR TITLE
VCDA-3853,3854: Remove install of CPI, CSI and default storage-class from CAPVCD

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -16,22 +16,6 @@ write_files: {{- if .ControlPlane }}
     metadata:
       name: vcloud-basic-auth
       namespace: kube-system
-    ---
-- path: /root/default-storage-class.yaml
-  owner: root
-  content: |
-    ---
-    kind: StorageClass
-    apiVersion: storage.k8s.io/v1
-    metadata:
-      annotations:
-        storageclass.kubernetes.io/is-default-class: "true"
-      name: "{{ .K8sStorageClassName }}"
-    provisioner: named-disk.csi.cloud-director.vmware.com
-    reclaimPolicy: "{{ .ReclaimPolicy }}"
-    parameters:
-      storageProfile: "{{ .VcdStorageProfileName }}"
-      filesystem: "{{ .FileSystemFormat }}"
     --- {{- end }}
 - path: /root/ {{- if .ControlPlane -}} control_plane {{- else -}} node {{- end -}} .sh
   owner: root
@@ -121,50 +105,10 @@ write_files: {{- if .ControlPlane }}
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')" {{- end }}
     vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} successful" {{- if .ControlPlane }}
 
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cpi.install.status in_progress"
-    kubectl apply -f $VCLOUD_BASIC_AUTH_PATH
-    CPI_VERSION={{ .CpiVersion }}
-    wget -O $VCLOUD_CONFIGMAP_PATH https://raw.githubusercontent.com/vmware/cloud-provider-for-cloud-director/$CPI_VERSION/manifests/vcloud-configmap.yaml
-    sed -i 's/VCD_HOST/"{{ .VcdHostFormatted }}"/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/ORG/"{{ .ClusterOrgName }}"/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/OVDC/"{{ .ClusterOVDCName }}"/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/NETWORK/"{{ .NetworkName }}"/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/VIP_SUBNET_CIDR/"{{ .VipSubnetCidr }}"/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/VAPP/{{ .VAppName }}/' $VCLOUD_CONFIGMAP_PATH
-    sed -i 's/CLUSTER_ID/{{ .ClusterID }}/' $VCLOUD_CONFIGMAP_PATH
-    kubectl apply -f $VCLOUD_CONFIGMAP_PATH
-    wget -O $VCLOUD_CCM_PATH https://raw.githubusercontent.com/vmware/cloud-provider-for-cloud-director/$CPI_VERSION/manifests/cloud-director-ccm.yaml
-    kubectl apply -f $VCLOUD_CCM_PATH
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.cpi.install.status successful"
-
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.csi.install.status in_progress"
-    CSI_VERSION={{ .CsiVersion }}
-    wget -O $VCLOUD_CSI_CONFIGMAP_PATH https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/$CSI_VERSION/manifests/vcloud-csi-config.yaml
-    sed -i 's/VCD_HOST/"{{ .VcdHostFormatted }}"/' $VCLOUD_CSI_CONFIGMAP_PATH
-    sed -i 's/ORG/"{{ .ClusterOrgName }}"/' $VCLOUD_CSI_CONFIGMAP_PATH
-    sed -i 's/OVDC/"{{ .ClusterOVDCName }}"/' $VCLOUD_CSI_CONFIGMAP_PATH
-    sed -i 's/VAPP/{{ .VAppName }}/' $VCLOUD_CSI_CONFIGMAP_PATH
-    sed -i 's/CLUSTER_ID/"{{ .ClusterID }}"/' $VCLOUD_CSI_CONFIGMAP_PATH
-    kubectl apply -f $VCLOUD_CSI_CONFIGMAP_PATH
-    wget -O $CSI_DRIVER_PATH https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/$CSI_VERSION/manifests/csi-driver.yaml
-    wget -O $CSI_CONTROLLER_PATH https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/$CSI_VERSION/manifests/csi-controller.yaml
-    wget -O $CSI_NODE_PATH https://raw.githubusercontent.com/vmware/cloud-director-named-disk-csi-driver/$CSI_VERSION/manifests/csi-node.yaml
-    kubectl apply -f $CSI_DRIVER_PATH
-    kubectl apply -f $CSI_CONTROLLER_PATH
-    kubectl apply -f $CSI_NODE_PATH
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.csi.install.status successful"
-
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status in_progress"
     KUBEADM_JOIN_INFO=$(kubeadm token create --print-join-command 2> /dev/null)
     vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.info $KUBEADM_JOIN_INFO"
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status successful"
-
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.default_storage_class.install.status in_progress"
-    STORAGE_CLASS_ENABLED={{ .EnableDefaultStorageClass }}
-    if [[ "$STORAGE_CLASS_ENABLED" == "true" ]]; then
-      kubectl apply -f /root/default-storage-class.yaml
-    fi
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubectl.default_storage_class.install.status successful" {{- end }} {{- if .NvidiaGPU }}
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status successful" {{- if .NvidiaGPU }}
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.containerd.nvidia.configuration.status in_progress"
     cat > /etc/containerd/config.toml << EOF

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -53,9 +53,6 @@ const (
 	VCDResourceVApp = "VApp"
 
 	TcpPort = 6443
-
-	CpiDefaultVersion = "main"
-	CsiDefaultVersion = "main"
 )
 
 var (

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -44,30 +44,20 @@ import (
 )
 
 type CloudInitScriptInput struct {
-	ControlPlane              bool   // control plane node
-	NvidiaGPU                 bool   // configure containerd for NVIDIA libraries
-	BootstrapRunCmd           string // bootstrap run command
-	B64OrgUser                string // base 64 org/username
-	B64Password               string // base64 password
-	B64RefreshToken           string // refresh token
-	K8sStorageClassName       string // default storage class name
-	ReclaimPolicy             string // reclaim policy
-	VcdStorageProfileName     string // vcd storage profile
-	FileSystemFormat          string // filesystem
-	HTTPProxy                 string // httpProxy endpoint
-	HTTPSProxy                string // httpsProxy endpoint
-	NoProxy                   string // no proxy values
-	CpiVersion                string // cpi version
-	VcdHostFormatted          string // vcd host
-	ClusterOrgName            string // org
-	ClusterOVDCName           string // ovdc
-	NetworkName               string // network
-	VipSubnetCidr             string // vip subnet cidr - empty for now for CPI to select subnet
-	VAppName                  string // vApp name
-	ClusterID                 string // cluster id
-	CsiVersion                string // csi version
-	EnableDefaultStorageClass string // is_storage_class_enabled
-	MachineName               string // vm host name
+	ControlPlane          bool   // control plane node
+	NvidiaGPU             bool   // configure containerd for NVIDIA libraries
+	BootstrapRunCmd       string // bootstrap run command
+	B64OrgUser            string // base 64 org/username
+	B64Password           string // base64 password
+	B64RefreshToken       string // refresh token
+	K8sStorageClassName   string // default storage class name
+	ReclaimPolicy         string // reclaim policy
+	VcdStorageProfileName string // vcd storage profile
+	FileSystemFormat      string // filesystem
+	HTTPProxy             string // httpProxy endpoint
+	HTTPSProxy            string // httpsProxy endpoint
+	NoProxy               string // no proxy values
+	MachineName           string // vm host name
 }
 
 const (
@@ -214,10 +204,7 @@ const (
 	NetworkConfiguration                   = "guestinfo.postcustomization.networkconfiguration.status"
 	ProxyConfiguration                     = "guestinfo.postcustomization.proxy.setting.status"
 	KubeadmInit                            = "guestinfo.postcustomization.kubeinit.status"
-	KubectlApplyCpi                        = "guestinfo.postcustomization.kubectl.cpi.install.status"
-	KubectlApplyCsi                        = "guestinfo.postcustomization.kubectl.csi.install.status"
 	KubeadmTokenGenerate                   = "guestinfo.postcustomization.kubeadm.token.generate.status"
-	KubectlApplyDefaultStorageClass        = "guestinfo.postcustomization.kubectl.default_storage_class.install.status"
 	KubeadmNodeJoin                        = "guestinfo.postcustomization.kubeadm.node.join.status"
 	NvidiaRuntimeInstall                   = "guestinfo.postcustomization.nvidia.runtime.install.status"
 	NvidiaContainerdConfiguration          = "guestinfo.postcustomization.containerd.nvidia.configuration.status"
@@ -229,10 +216,7 @@ var controlPlanePostCustPhases = []string{
 	NetworkConfiguration,
 	ProxyConfiguration,
 	KubeadmInit,
-	KubectlApplyCpi,
-	KubectlApplyCsi,
 	KubeadmTokenGenerate,
-	KubectlApplyDefaultStorageClass,
 }
 
 var joinPostCustPhases = []string{
@@ -449,26 +433,17 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			}
 
 			cloudInitInput = CloudInitScriptInput{
-				ControlPlane:              true,
-				B64OrgUser:                b64.StdEncoding.EncodeToString([]byte(orgUserStr)),
-				B64Password:               b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.Password)),
-				B64RefreshToken:           b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.RefreshToken)),
-				K8sStorageClassName:       k8sStorageClassName,
-				ReclaimPolicy:             reclaimPolicy,
-				VcdStorageProfileName:     vcdStorageProfileName,
-				FileSystemFormat:          fileSystemFormat,
-				CpiVersion:                CpiDefaultVersion, // TODO: get from crs
-				CsiVersion:                CsiDefaultVersion, // TODO: get from crs
-				VcdHostFormatted:          strings.Replace(vcdCluster.Spec.Site, "/", "\\/", -1),
-				ClusterOrgName:            workloadVCDClient.ClusterOrgName,
-				ClusterOVDCName:           workloadVCDClient.ClusterOVDCName,
-				NetworkName:               vcdCluster.Spec.OvdcNetwork,
-				VipSubnetCidr:             "", // vip subnet cidr - empty for now for CPI to select subnet
-				VAppName:                  vAppName,
-				ClusterID:                 vcdCluster.Status.InfraId,
-				EnableDefaultStorageClass: strconv.FormatBool(enableDefaultStorageClass),
+				ControlPlane:          true,
+				B64OrgUser:            b64.StdEncoding.EncodeToString([]byte(orgUserStr)),
+				B64Password:           b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.Password)),
+				B64RefreshToken:       b64.StdEncoding.EncodeToString([]byte(workloadVCDClient.VCDAuthConfig.RefreshToken)),
+				K8sStorageClassName:   k8sStorageClassName,
+				ReclaimPolicy:         reclaimPolicy,
+				VcdStorageProfileName: vcdStorageProfileName,
+				FileSystemFormat:      fileSystemFormat,
 			}
 		}
+
 		cloudInitInput.HTTPSProxy = vcdCluster.Spec.ProxyConfig.HTTPProxy
 		cloudInitInput.HTTPSProxy = vcdCluster.Spec.ProxyConfig.HTTPSProxy
 		cloudInitInput.NoProxy = vcdCluster.Spec.ProxyConfig.NoProxy


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- This removes installation of CPI, CSI and default storage-class in Kubernetes. The unnecessary phases and variables are also cleaned up.

## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [X] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/228)
<!-- Reviewable:end -->
