### PR TITLE
[VCDA-4198] Add capvcd created by version to capvcd RDE

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -246,6 +246,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 				},
 				CapiStatusYaml:             "",
 				ClusterResourceSetBindings: nil,
+				CreatedByVersion:           release.CAPVCDVersion,
 			},
 		},
 	}

--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -91,6 +91,7 @@
           }
         }
       ],
+      "createdByVersion": "1.1.0",
       "capvcdVersion": "ABCD",
       "vcdProperties": {
         "orgName": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -135,6 +135,7 @@ type CAPVCDStatus struct {
 	CapiStatusYaml             string                      `json:"capiStatusYaml,omitempty"`
 	ClusterResourceSetBindings []ClusterResourceSetBinding `json:"clusterResourceSetBindings,omitempty"`
 	DefaultStorageClass        DefaultStorageClass         `json:"defaultStorageClass"`
+	CreatedByVersion           string                      `json:"createdByVersion"`
 }
 
 type Status struct {

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -216,6 +216,10 @@
                 "properties": {}
               }
             },
+            "createdByVersion": {
+              "type": "string",
+              "description": "CAPVCD version used to create the cluster"
+            },
             "defaultStorageClass": {
               "type": "object",
               "description": "Default storage class configuration options.",


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add created by CAPVCD version to the schema.
- code changes to add created by version

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies - updated schema_1_1_0.json
- [x] updated any relevant documentation or examples - updated examples/rde_1_1_0.json

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/229)
<!-- Reviewable:end -->
