### PR TITLE
[VCDA-4199] Fix SSH host keys delete per reboot

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -17,6 +17,10 @@ write_files: {{- if .ControlPlane }}
       name: vcloud-basic-auth
       namespace: kube-system
     --- {{- end }}
+- path: /etc/cloud/cloud.cfg.d/cse.cfg
+  owner: root
+  content: |
+     ssh_deletekeys: false
 - path: /opt/vmware/cloud-director/metering.sh
   owner: root
   content: |
@@ -189,6 +193,7 @@ write_files: {{- if .ControlPlane }}
 runcmd:
 - 'cloud-init clean'
 - '[ ! -f /opt/vmware/cloud-director/metering.sh ] && sudo reboot'
+- '[ ! -f /etc/cloud/cloud.cfg.d/cse.cfg ] && sudo reboot'
 - '[ ! -f /etc/vcloud/metering ] && sudo reboot'
 {{ if .ControlPlane }}
 - '[ ! -f /root/vcloud-basic-auth.yaml ] && sudo reboot'


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Fixes the issue where reboot would generate new ssh host causing users to delete known_hosts in order to re-ssh into the machines

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/233)
<!-- Reviewable:end -->
