### PR TITLE
changes to logic for RDE version in use during CAPVCD upgrade

### DIFF
--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -20,7 +20,11 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.SkipRDE = strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix)
 	dst.Spec.ParentUID = ""
 	dst.Spec.UseAsManagementCluster = false // defaults to false
-	dst.Status.RdeVersionInUse = "1.0.0"
+	if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {
+		dst.Status.RdeVersionInUse = vcdsdk.NoRdePrefix
+	} else {
+		dst.Status.RdeVersionInUse = "1.0.0" // value will be checked by vcdcluster controller if RDE upgrade is necessary
+	}
 
 	// In v1alpha4 DNAT rules (and one-arm) are used by default. Therefore, use that in v1beta1
 	dst.Spec.LoadBalancer.UseOneArm = true


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request
- If CAPVCD RDE ID has a NO_RDE_ prefix, the RDEVersion in use should be set to NO_RDE_ when upgrading CAPVCD.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/239)
<!-- Reviewable:end -->
