### PR TITLE
Vcda 4336

### DIFF
--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -16,7 +16,6 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.ProxyConfig = v1beta1.ProxyConfig{}
 	// TODO: Update the new params to match previous release's Status; ex) dst.Spec.* = src.Status.*, maybe RDE.Status
 	dst.Spec.RDEId = src.Status.InfraId
-	dst.Spec.SkipRDE = strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix)
 	dst.Spec.ParentUID = ""
 	dst.Spec.UseAsManagementCluster = false // defaults to false
 	if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -333,13 +333,11 @@ func autoConvert_v1beta1_VCDClusterSpec_To_v1alpha4_VCDClusterSpec(in *v1beta1.V
 	if err := Convert_v1beta1_UserCredentialsContext_To_v1alpha4_UserCredentialsContext(&in.UserCredentialsContext, &out.UserCredentialsContext, s); err != nil {
 		return err
 	}
-	// WARNING: in.DefaultStorageClassOptions requires manual conversion: does not exist in peer-type
 	// WARNING: in.RDEId requires manual conversion: does not exist in peer-type
 	// WARNING: in.ParentUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.UseAsManagementCluster requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProxyConfig requires manual conversion: does not exist in peer-type
 	// WARNING: in.LoadBalancer requires manual conversion: does not exist in peer-type
-	// WARNING: in.SkipRDE requires manual conversion: does not exist in peer-type
 	return nil
 }
 
@@ -364,7 +362,6 @@ func autoConvert_v1beta1_VCDClusterStatus_To_v1alpha4_VCDClusterStatus(in *v1bet
 	// WARNING: in.ParentUID requires manual conversion: does not exist in peer-type
 	// WARNING: in.UseAsManagementCluster requires manual conversion: does not exist in peer-type
 	// WARNING: in.ProxyConfig requires manual conversion: does not exist in peer-type
-	// WARNING: in.DefaultStorageClassOptions requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/api/v1beta1/vcdcluster_types.go
+++ b/api/v1beta1/vcdcluster_types.go
@@ -90,9 +90,6 @@ type VCDClusterSpec struct {
 	ProxyConfig ProxyConfig `json:"proxyConfig,omitempty"`
 	// +optional
 	LoadBalancer LoadBalancer `json:"loadBalancer,omitempty"`
-	// SkipRDE tells CAPVCD if an RDE should be created for the cluster or not
-	// +kubebuilder:default=false
-	SkipRDE bool `json:"skipRDE,omitempty"`
 }
 
 // VCDClusterStatus defines the observed state of VCDCluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -203,11 +203,6 @@ spec:
                 type: string
               site:
                 type: string
-              skipRDE:
-                default: false
-                description: SkipRDE tells CAPVCD if an RDE should be created for
-                  the cluster or not
-                type: boolean
               useAsManagementCluster:
                 type: boolean
               userContext:

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -531,7 +531,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			if !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
 				return ctrl.Result{}, errors.Wrapf(errors.New("capvcdCluster entity type not registered or capvcdCluster rights missing from the user's role"),
 					"cluster create issued with executeWithoutRDE=[%v] but unable to create capvcdCluster entity at version [%s]",
-					vcdCluster.Spec.SkipRDE, rdeType.CapvcdRDETypeVersion)
+					SkipRDE, rdeType.CapvcdRDETypeVersion)
 			}
 			// create RDE
 			nameFilter := &swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 	"net/http"
+	"os"
 	"reflect"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -40,6 +41,8 @@ import (
 )
 
 const (
+	EnvSkipRDE = "CAPVCD_SKIP_RDE"
+
 	CAPVCDClusterCniName = "antrea" // TODO: Get the correct value for CNI name
 
 	RDEStatusResolved = "RESOLVED"
@@ -61,6 +64,7 @@ var (
 		StartIP: "192.168.8.2",
 		EndIP:   "192.168.8.100",
 	}
+	SkipRDE = vcdutil.Str2Bool(os.Getenv(EnvSkipRDE))
 )
 
 // VCDClusterReconciler reconciles a VCDCluster object
@@ -506,77 +510,95 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	infraID := vcdCluster.Status.InfraId
-	shouldCreateRDE := !vcdCluster.Spec.SkipRDE
+	specInfraID := vcdCluster.Spec.RDEId
 
-	// General note on RDE operations, always ensure CAPVCD cluster reconciliation progress
-	//is not affected by any RDE operation failures.
-	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
-
-	// fail cluster creation if RDE should be created but capvcdCluster entity type is not registered
-	if shouldCreateRDE && !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
-		return ctrl.Result{}, errors.Wrapf(errors.New("capvcdCluster entity type not registered or capvcdCluster rights missing from the user's role"),
-			"cluster create issued with executeWithoutRDE=[%v] but unable to create capvcdCluster entity at version [%s]",
-			vcdCluster.Spec.SkipRDE, rdeType.CapvcdRDETypeVersion)
-	}
-
-	// Use the pre-created RDEId specified in the CAPI yaml specification.
-	// TODO validate if the RDE ID format is correct.
-	if infraID == "" && len(vcdCluster.Spec.RDEId) > 0 {
-		infraID = vcdCluster.Spec.RDEId
-		if shouldCreateRDE {
-			_, rdeVersion, err := capvcdRdeManager.GetRDEVersion(ctx, infraID)
-			if err != nil {
-				return ctrl.Result{}, errors.Wrapf(err,
-					"\"Unexpected error retrieving RDE [%s] for the cluster [%s]", infraID, vcdCluster.Name)
-			}
-			// update the RdeVersionInUse with the entity type version of the rde.
-			vcdCluster.Status.RdeVersionInUse = rdeVersion
-		}
-	}
-
-	// Create a new RDE if it was not already created or assigned.
 	if infraID == "" {
-		if shouldCreateRDE {
+		infraID = specInfraID
+	}
+
+	// creating RDEs for the clusters -
+	// 1. clusters already created will have NO_RDE_ prefix in the infra ID. We should make sure that the cluster can co-exist
+	// 2. Clusters which are newly created should check for CAPVCD_SKIP_RDE environment variable to determine if an RDE should be created for the cluster
+
+	// NOTE: If CAPVCD_SKIP_RDE is not set, CAPVCD will error out if there is any error in RDE creation
+	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
+	rdeVersionInUse := vcdCluster.Status.RdeVersionInUse
+	if infraID == "" {
+		// Create RDE for the cluster or generate a NO_RDE infra ID for the cluster.
+		if !SkipRDE {
+			// Create an RDE for the cluster. If RDE creation results in a failure, error out cluster creation.
+			// check rights for RDE creation and create an RDE
+			if !capvcdRdeManager.IsCapvcdEntityTypeRegistered(rdeType.CapvcdRDETypeVersion) {
+				return ctrl.Result{}, errors.Wrapf(errors.New("capvcdCluster entity type not registered or capvcdCluster rights missing from the user's role"),
+					"cluster create issued with executeWithoutRDE=[%v] but unable to create capvcdCluster entity at version [%s]",
+					vcdCluster.Spec.SkipRDE, rdeType.CapvcdRDETypeVersion)
+			}
+			// create RDE
 			nameFilter := &swagger.DefinedEntityApiGetDefinedEntitiesByEntityTypeOpts{
 				Filter: optional.NewString(fmt.Sprintf("name==%s", vcdCluster.Name)),
 			}
+			// the following api call will return an empty list if there are no entities with the same name as the cluster
 			definedEntities, resp, err := workloadVCDClient.APIClient.DefinedEntityApi.GetDefinedEntitiesByEntityType(ctx,
 				capisdk.CAPVCDTypeVendor, capisdk.CAPVCDTypeNss, rdeType.CapvcdRDETypeVersion, 1, 25, nameFilter)
 			if err != nil {
 				log.Error(err, "Error while checking if RDE is already present for the cluster",
 					"entityTypeId", CAPVCDEntityTypeID)
+				return ctrl.Result{}, errors.Wrapf(err, "Error while checking if RDE is already present for the cluster with entity type ID [%s]",
+					CAPVCDEntityTypeID)
 			}
 			if resp == nil {
-				log.Error(nil, "Error while checking if RDE is already present for the cluster; "+
-					"obtained an empty response for get defined entity call for the cluster")
+				msg := fmt.Sprintf("Error while checking if RDE for the cluster [%s] is already present for the cluster; "+
+					"obtained an empty response for get defined entity call for the cluster", vcdCluster.Name)
+				log.Error(nil, msg)
+				return ctrl.Result{}, errors.Wrapf(fmt.Errorf(msg), msg)
+
 			} else if resp.StatusCode != http.StatusOK {
-				log.Error(nil, "Error while checking if RDE is already present for the cluster",
-					"entityTypeId", CAPVCDEntityTypeID, "responseStatusCode", resp.StatusCode)
+				msg := fmt.Sprintf("Invalid status code [%d] while checking if RDE is already present for the cluster using the entityTYpeID [%s]",
+					resp.StatusCode, CAPVCDEntityTypeID)
+				log.Error(nil, msg)
+				return ctrl.Result{}, errors.Wrapf(err, msg)
 			}
+			// create an RDE with the same name as the vcdCluster object if there are no RDEs with the same name as the vcdCluster object
 			if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 				if len(definedEntities.Values) == 0 {
 					rdeID, err := r.constructAndCreateRDEFromCluster(ctx, workloadVCDClient, cluster, vcdCluster)
 					if err != nil {
 						log.Error(err, "Error creating RDE for the cluster")
-					} else {
-						infraID = rdeID
+						return ctrl.Result{}, errors.Wrapf(err, "error creating RDE for the cluster %s", vcdCluster.Name)
 					}
-					vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
+					infraID = rdeID
 				} else {
 					log.Info("RDE for the cluster is already present; skipping RDE creation", "InfraId",
 						definedEntities.Values[0].Id)
 					infraID = definedEntities.Values[0].Id
 				}
 			}
+			rdeVersionInUse = rdeType.CapvcdRDETypeVersion
 		} else {
 			// If there is no RDE ID specified (or) created for any reason, self-generate one and use.
 			// We need UUIDs to single-instance cleanly in the Virtual Services etc.
 			noRDEID := NoRdePrefix + uuid.New().String()
 			log.Info("Error retrieving InfraId. Hence using a self-generated UUID", "UUID", noRDEID)
 			infraID = noRDEID
+			rdeVersionInUse = NoRdePrefix
 		}
+
 	} else {
 		log.V(3).Info("Reusing already available InfraID", "infraID", infraID)
+		if strings.Contains(infraID, NoRdePrefix) {
+			log.V(3).Info("Infra ID has NO_RDE_ prefix. Using RdeVersionInUse -", "RdeVersionInUse", NoRdePrefix)
+			rdeVersionInUse = NoRdePrefix
+		} else {
+			_, rdeVersion, err := capvcdRdeManager.GetRDEVersion(ctx, infraID)
+			if err != nil {
+				return ctrl.Result{}, errors.Wrapf(err,
+					"\"Unexpected error retrieving RDE [%s] for the cluster [%s]", infraID, vcdCluster.Name)
+			}
+			// update the RdeVersionInUse with the entity type version of the rde.
+			rdeVersionInUse = rdeVersion
+		}
+
+		// upgrade RDE if necessary
 		if !strings.Contains(infraID, NoRdePrefix) && vcdCluster.Status.RdeVersionInUse != "" &&
 			vcdCluster.Status.RdeVersionInUse != rdeType.CapvcdRDETypeVersion {
 			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
@@ -607,7 +629,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			if err != nil {
 				log.Error(err, "failed to remove RDE-upgrade error (RDE upgraded successfully) ", "rdeID", infraID)
 			}
-			vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
+			rdeVersionInUse = rdeType.CapvcdRDETypeVersion
 		}
 	}
 
@@ -616,25 +638,19 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.Error(err, "failed to add RdeAvailable event", "rdeID", infraID)
 	}
 
-	vcdCluster.Spec.RDEId = infraID
-	log.Info("infraID for the cluster is", "infraID", infraID)
+	if vcdCluster.Status.InfraId != infraID || vcdCluster.Status.RdeVersionInUse != rdeVersionInUse {
+		log.Info("updating vcdCluster with the following data", "vcdCluster.Status.InfraId", infraID, "vcdCluster.Status.RdeVersionInUse", rdeVersionInUse)
 
-	// If the vcdClusterObject does not have the InfraId set, we need to set it. If it has one, we can reuse it.
-	if vcdCluster.Status.InfraId == "" {
 		oldVCDCluster := vcdCluster.DeepCopy()
-
 		vcdCluster.Status.InfraId = infraID
-		if vcdCluster.Spec.SkipRDE {
-			vcdCluster.Status.RdeVersionInUse = NoRdePrefix
-		} else {
-			vcdCluster.Status.RdeVersionInUse = rdeType.CapvcdRDETypeVersion
-		}
+		vcdCluster.Status.RdeVersionInUse = rdeVersionInUse
 		if err := r.Status().Patch(ctx, vcdCluster, client.MergeFrom(oldVCDCluster)); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err,
 				"unable to patch status of vcdCluster [%s] with InfraID [%s], RDEVersion [%s]",
 				vcdCluster.Name, infraID, rdeType.CapvcdRDETypeVersion)
 		}
 	}
+	vcdCluster.Spec.RDEId = infraID
 
 	rdeManager := vcdsdk.NewRDEManager(workloadVCDClient, vcdCluster.Status.InfraId,
 		capisdk.StatusComponentNameCAPVCD, release.CAPVCDVersion)

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,6 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220718184524-22ee9074d6aa h1:A7YLgknuHJsyDd+U/YBGFnoDe16EHnnw0WZCfxWX7s8=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220718184524-22ee9074d6aa/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220815231236-187fe9886581 h1:kmRZRrbrljRwazgh+U2wIAFxZFnH00h5q8KZe5umXrc=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20220815231236-187fe9886581/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -224,11 +224,6 @@ spec:
                 type: string
               site:
                 type: string
-              skipRDE:
-                default: false
-                description: SkipRDE tells CAPVCD if an RDE should be created for
-                  the cluster or not
-                type: boolean
               useAsManagementCluster:
                 type: boolean
               userContext:

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // indentJsonBody indents raw JSON body for easier readability
@@ -74,4 +75,9 @@ func Int2IntPtr(val int) *int {
 
 func Float2FloatPtr(val float64) *float64 {
 	return &val
+}
+
+// Str2Bool returns true if the string value is not false
+func Str2Bool(val string) bool {
+	return strings.ToLower(val) != "false"
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -79,5 +79,8 @@ func Float2FloatPtr(val float64) *float64 {
 
 // Str2Bool returns true if the string value is not false
 func Str2Bool(val string) bool {
-	return strings.ToLower(val) != "false"
+	if strings.ToLower(val) == "true" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Make skipRDE an environment variable (CAPVCD_SKIP_RDE)
- Testing done:
  - create capvcd cluster without setting CAPVCD_SKIP_RDE environment variable
  - set CAPVCD_SKIP_RDE and make sure existing clusters work as is
  - create another cluster and make sure that the cluster ID is autogenerated and no RDEs are created for the cluster
  - Resize both the clusters

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [x] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [x] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [x] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [x] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [x] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
