### PR TITLE
[VCDA-4373] Update joined control plane nodes to be marked as control plane for metering

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -48,7 +48,7 @@ write_files:
     VCD_SITE_ID={{ .VcdHostFormatted }}
     CLUSTER_ID={{ .ClusterID }}
     TKG_VERSION={{ .TKGVersion }}
-    MACHINE_TYPE={{- if .ControlPlane -}} control_plane {{- else -}} worker {{- end }}
+    MACHINE_TYPE={{- if or .ControlPlane .ResizedControlPlane -}} control_plane {{- else -}} worker {{- end }}
     MGMT=true
 - path: /etc/systemd/system/metering.service
   owner: root

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -44,16 +44,17 @@ import (
 )
 
 type CloudInitScriptInput struct {
-	ControlPlane     bool   // control plane node
-	NvidiaGPU        bool   // configure containerd for NVIDIA libraries
-	BootstrapRunCmd  string // bootstrap run command
-	HTTPProxy        string // httpProxy endpoint
-	HTTPSProxy       string // httpsProxy endpoint
-	NoProxy          string // no proxy values
-	MachineName      string // vm host name
-	VcdHostFormatted string // vcd host
-	TKGVersion       string // tkgVersion
-	ClusterID        string //cluster id
+	ControlPlane        bool   // control plane node
+	NvidiaGPU           bool   // configure containerd for NVIDIA libraries
+	BootstrapRunCmd     string // bootstrap run command
+	HTTPProxy           string // httpProxy endpoint
+	HTTPSProxy          string // httpsProxy endpoint
+	NoProxy             string // no proxy values
+	MachineName         string // vm host name
+	ResizedControlPlane bool   // resized node type: worker | control_plane
+	VcdHostFormatted    string // vcd host
+	TKGVersion          string // tkgVersion
+	ClusterID           string //cluster id
 }
 
 const (
@@ -407,6 +408,10 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	useControlPlaneScript := util.IsControlPlaneMachine(machine) &&
 		!strings.Contains(bootstrapJinjaScript, "kubeadm join")
 
+	// Scaling up Control Plane initially creates the nodes as worker, which eventually joins the original control plane
+	// Hence we are checking if it contains the control plane label and has kubeadm join in the script
+	isResizedControlPlane := util.IsControlPlaneMachine(machine) && strings.Contains(bootstrapJinjaScript, "kubeadm join")
+
 	// Construct a CloudInitScriptInput struct to pass into template.Execute() function to generate the necessary
 	// cloud init script for the relevant node type, i.e. control plane or worker node
 	cloudInitInput := CloudInitScriptInput{}
@@ -426,6 +431,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		cloudInitInput.NvidiaGPU = vcdMachine.Spec.NvidiaGPU
 		cloudInitInput.TKGVersion = getTKGVersion(cluster)   // needed for both worker & control plane machines for metering
 		cloudInitInput.ClusterID = vcdCluster.Status.InfraId // needed for both worker & control plane machines for metering
+		cloudInitInput.ResizedControlPlane = isResizedControlPlane
 	}
 
 	mergedCloudInitBytes, err := MergeJinjaToCloudInitScript(cloudInitInput, bootstrapJinjaScript)


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Updated script to mark nodes with 'kubeadm join' and control plane labels as control plane machine type for metering

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/252)
<!-- Reviewable:end -->
