### PR TITLE
[VCDA-4379] Add tkgVersion and kubernetes version as part of capvcd.upgrade in RDE

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -441,7 +441,8 @@ func getUserCredentialsForCluster(ctx context.Context, cli client.Client, define
 	return userCredentials, nil
 }
 
-func isControlPlaneReady(kcp *kcpv1.KubeadmControlPlane) bool {
+// hasKcpReconciledToDesiredK8Version determines if the rolling upgrade process is complete. Returns false if the upgrade is still on going
+func hasKcpReconciledToDesiredK8Version(kcp *kcpv1.KubeadmControlPlane) bool {
 	return kcp != nil && kcp.Status.Ready &&
 		kcp.Status.Version != nil &&
 		*kcp.Status.Version == kcp.Spec.Version &&

--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -440,3 +440,10 @@ func getUserCredentialsForCluster(ctx context.Context, cli client.Client, define
 
 	return userCredentials, nil
 }
+
+func isControlPlaneReady(kcp *kcpv1.KubeadmControlPlane) bool {
+	return kcp != nil && kcp.Status.Ready &&
+		kcp.Status.Version != nil &&
+		*kcp.Status.Version == kcp.Spec.Version &&
+		kcp.Status.UnavailableReplicas == 0
+}

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -425,7 +425,7 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		}
 	}
 
-	log.Info("upgrade section of the RDE", "previous", capvcdStatus.Upgrade, "updated", upgradeObject)
+	log.V(4).Info("upgrade section of the RDE", "previous", capvcdStatus.Upgrade, "current", upgradeObject)
 
 	if !reflect.DeepEqual(upgradeObject, capvcdStatus.Upgrade) {
 		capvcdStatusPatch["Upgrade"] = upgradeObject

--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -36,6 +36,17 @@
       }
     },
     "capvcd": {
+      "upgrade": {
+        "ready": true,
+        "current": {
+          "tkgVersion": "v1.5.4",
+          "kubernetesVersion": "v1.22.9+vmware.1"
+        },
+        "previous": {
+          "tkgVersion": "v1.4.3",
+          "kubernetesVersion": "v1.21.8+vmware.1"
+        }
+      },
       "phase": "ABCDEFGHIJKLMNOPQRSTUVWX",
       "kubernetes": "ABCDEFGHIJKLMNOPQRST",
       "errors":["Machine<name>creationFailed_timestamp, "],

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/antihax/optional v1.0.0
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
@@ -33,7 +34,6 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coredns/caddy v1.1.0 // indirect
 	github.com/coredns/corefile-migration v1.0.14 // indirect

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -108,6 +108,17 @@ type ClusterResourceSetBinding struct {
 	LastAppliedTime        string `json:"lastAppliedTime,omitempty"`
 }
 
+type K8sInfo struct {
+	TkgVersion string `json:"tkgVersion,omitempty"`
+	K8sVersion string `json:"kubernetesVersion,omitempty"`
+}
+
+type Upgrade struct {
+	Current  *K8sInfo `json:"current"`
+	Previous *K8sInfo `json:"previous"`
+	Ready    bool     `json:"ready"`
+}
+
 type CAPVCDStatus struct {
 	Phase                      string                      `json:"phase,omitempty"`
 	Kubernetes                 string                      `json:"kubernetes,omitempty"`
@@ -127,6 +138,7 @@ type CAPVCDStatus struct {
 	CapiStatusYaml             string                      `json:"capiStatusYaml,omitempty"`
 	ClusterResourceSetBindings []ClusterResourceSetBinding `json:"clusterResourceSetBindings,omitempty"`
 	CreatedByVersion           string                      `json:"createdByVersion"`
+	Upgrade                    Upgrade                     `json:"upgrade,omitempty"`
 }
 
 type Status struct {

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -191,15 +191,18 @@
             },
             "upgrade": {
               "type": "object",
+              "description": "determines the state of upgrade. If no upgrade is issued, only the existing version is stored.",
               "properties": {
                 "current": {
                   "type": "object",
                   "properties": {
                     "kubernetesVersion": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "current kubernetes version of the cluster. If being upgraded, will represent target kubernetes version of the cluster."
                     },
                     "tkgVersion": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "current TKG version of the cluster. If being upgraded, will represent the tarkget TKG version of the cluster."
                     }
                   }
                 },
@@ -207,15 +210,18 @@
                   "type": "object",
                   "properties": {
                     "kubernetesVersion": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "the kubernetes version from which the cluster was upgraded from. If cluster upgrade is still in progress, the field will represent the source kubernetes version from which the cluster is being upgraded."
                     },
                     "tkgVersion": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "the TKG version from which the cluster was upgraded from. If cluster upgrade is still in progress, the field will represent the source TKG versoin from which the cluster is being upgraded."
                     }
                   }
                 },
                 "ready": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "boolean indicating the status of the cluster upgrade."
                 }
               }
             },

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -189,6 +189,36 @@
                 }
               }
             },
+            "upgrade": {
+              "type": "object",
+              "properties": {
+                "current": {
+                  "type": "object",
+                  "properties": {
+                    "kubernetesVersion": {
+                      "type": "string"
+                    },
+                    "tkgVersion": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "previous": {
+                  "type": "object",
+                  "properties": {
+                    "kubernetesVersion": {
+                      "type": "string"
+                    },
+                    "tkgVersion": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "ready": {
+                  "type": "boolean"
+                }
+              }
+            },
             "private": {
               "type": "object",
               "x-vcloud-restricted": "private",


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Change schema and controller code to add entity.status.upgrade containing current and previous kubernetes versions and tkg versions

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/253)
<!-- Reviewable:end -->
