### PR TITLE
[VCDA-4330]Add git sha to the images and deployment spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ build-within-docker:
 capi: generate fmt vet vendor
 	docker build -f Dockerfile . -t cluster-api-provider-cloud-director:$(version)
 	docker tag cluster-api-provider-cloud-director:$(version) $(IMG)
+	docker tag cluster-api-provider-cloud-director:$(version) $(IMG).$(GITCOMMIT)
 	docker push $(IMG)
 
 vendor: generate fmt vet
@@ -178,3 +179,11 @@ generate_conversions:  ## Runs Go related generate targets.
 		--output-file-base=zz_generated.conversion \
 		--go-header-file=./boilerplate.go.txt
 
+dev: capi
+	docker push $(IMG).$(GITCOMMIT)
+	sed -e "s/__GIT_COMMIT__/$(GITCOMMIT)/g" config/manager/manager.yaml.template > config/manager/manager.yaml
+	make release-manifests
+
+prod: capi
+	sed -e "s/\.__GIT_COMMIT__//g" config/manager/manager.yaml.template > config/manager/manager.yaml
+	make release-manifests

--- a/config/manager/manager.yaml.template
+++ b/config/manager/manager.yaml.template
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.56f1cc6
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.__GIT_COMMIT__
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.56f1cc6
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add git sha to the deployment spec (config/manager/manager.yaml)

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/255)
<!-- Reviewable:end -->
