### PR TITLE
[VCDA-4369] Update createdBby version only when capvcd status is misisng

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -586,6 +586,9 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 			capvcdStatusPatch["Private.KubeConfig"] = string(kubeConfigBytes)
 		}
 	}
+	if release.CAPVCDVersion != capvcdStatus.CapvcdVersion {
+		capvcdStatusPatch["CapvcdVersion"] = release.CAPVCDVersion
+	}
 
 	updatedRDE, err := capvcdRdeManager.PatchRDE(ctx, specPatch, metadataPatch, capvcdStatusPatch, vcdCluster.Status.InfraId, vappID, updateExternalID)
 	if err != nil {
@@ -716,6 +719,11 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			}
 			// update the RdeVersionInUse with the entity type version of the rde.
 			rdeVersionInUse = rdeVersion
+
+			// update the createdByVersion if not present already
+			if err := capvcdRdeManager.CheckForEmptyRDEAndUpdateCreatedByVersions(ctx, infraID); err != nil {
+				return ctrl.Result{}, errors.Wrapf(err, "Failed to update RDE [%s] with created by version", infraID)
+			}
 		}
 
 		// upgrade RDE if necessary

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch-cb1
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.750b6d6
         livenessProbe:
           httpGet:
             path: /healthz

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.750b6d6
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch-cb1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Update createdBy capvcd version before the first update to the capvcd RDE

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies - N/A
- [ ] updated any relevant documentation or examples - N/A

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/256)
<!-- Reviewable:end -->
