### PR TITLE
[VCDA-4413] Change vcdOrg in vcdProperties to an array in the schema

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.52c9aa7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.1a7feb7
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.52c9aa7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.1a7feb7
         livenessProbe:
           httpGet:
             path: /healthz

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -176,7 +176,7 @@
               "type": "object",
               "properties": {
                 "vcdOrg": {
-                  "type": "object",
+                  "type": "array",
                   "properties": {
                     "name": {
                       "type": "string"

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -177,12 +177,15 @@
               "properties": {
                 "vcdOrg": {
                   "type": "array",
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "id": {
-                      "type": "string"
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string"
+                      }
                     }
                   }
                 },


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request
- Schema for vcdOrg should be changed from an object to an array

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/258)
<!-- Reviewable:end -->
