### PR TITLE
[VCDA-4414] Make org and vdc in metadata as arrays

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.dcdebf7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.5fb5056
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.1a7feb7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.dcdebf7
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -275,7 +275,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		Metadata: rdeType.Metadata{
 			Name: vcdCluster.Name,
 			Org:  orgList,
-			Ovdc:  ovdcList,
+			Ovdc: ovdcList,
 			Site: vcdCluster.Spec.Site,
 		},
 		Spec: rdeType.CAPVCDSpec{},
@@ -301,9 +301,9 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 				},
 				ParentUID: vcdCluster.Spec.ParentUID,
 				VcdProperties: rdeType.VCDProperties{
-					Site: vcdCluster.Spec.Site,
-					Org: orgList,
-					Ovdc: ovdcList,
+					Site:        vcdCluster.Spec.Site,
+					Org:         orgList,
+					Ovdc:        ovdcList,
 					OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
 				},
 				CapiStatusYaml:             "",
@@ -379,16 +379,16 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		return fmt.Errorf("failed to get RDE with ID [%s] for cluster [%s]: [%v]", vcdCluster.Status.InfraId, vcdCluster.Name, err)
 	}
 
-		// TODO(VCDA-3107): Should we be updating org and vdc information here.
+	// TODO(VCDA-3107): Should we be updating org and vdc information here.
 	metadataPatch := make(map[string]interface{})
 	orgList := []rdeType.Org{
 		rdeType.Org{
 			Name: org.Org.Name,
-			ID: org.Org.ID,
+			ID:   org.Org.ID,
 		},
 	}
 	if !reflect.DeepEqual(orgList, capvcdMetadata.Org) {
-		metadataPatch["vcdOrg"] = orgList
+		metadataPatch["Org"] = orgList
 	}
 
 	ovdcList := []rdeType.Ovdc{
@@ -398,11 +398,11 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		},
 	}
 	if !reflect.DeepEqual(ovdcList, capvcdMetadata.Ovdc) {
-		metadataPatch["orgVdc"] = ovdcList
+		metadataPatch["Ovdc"] = ovdcList
 	}
 
 	if capvcdMetadata.Site != vcdCluster.Spec.Site {
-		metadataPatch["Site"] = vcdCluster.Spec.Site
+		metadataPatch["Org"] = vcdCluster.Spec.Site
 	}
 
 	specPatch := make(map[string]interface{})
@@ -565,9 +565,9 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 	}
 
 	vcdResources := rdeType.VCDProperties{
-		Site: vcdCluster.Spec.Site,
-		Org: orgList,
-		Ovdc: ovdcList,
+		Site:        vcdCluster.Spec.Site,
+		Org:         orgList,
+		Ovdc:        ovdcList,
 		OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
 	}
 	if !reflect.DeepEqual(vcdResources, capvcdStatus.VcdProperties) {

--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -13,8 +13,18 @@
     }
   },
   "metadata": {
-    "orgName": "ABCDEFGHIJKLMNOPQRSTUVWXYZA",
-    "virtualDataCenterName": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "vcdOrg": [
+      {
+        "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
+        "id": "274c6240-3304-11ed-a261-0242ac120002"
+      }
+    ],
+    "orgVdc": [
+      {
+        "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
+        "id": "274c6240-3304-11ed-a261-0242ac120002"
+      }
+    ],
     "name": "ABCDEFGH",
     "site": "ABCD"
   },

--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -13,13 +13,13 @@
     }
   },
   "metadata": {
-    "vcdOrg": [
+    "organizations": [
       {
         "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
         "id": "274c6240-3304-11ed-a261-0242ac120002"
       }
     ],
-    "orgVdc": [
+    "orgVdcs": [
       {
         "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
         "id": "274c6240-3304-11ed-a261-0242ac120002"

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.dcdebf7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.5fb5056
         livenessProbe:
           httpGet:
             path: /healthz

--- a/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
+++ b/infrastructure-vcd/v1.0.0/infrastructure-components.yaml
@@ -1117,7 +1117,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.1a7feb7
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.dcdebf7
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -119,7 +119,7 @@ func patchObject(inputObj interface{}, patchMap map[string]interface{}) (map[str
 				// if objVal is nil ptr/doesn't exist, we can't write to the direct value.
 				// so we should not set objVal to it's value directly without checking.
 				ptrValue := objVal.Elem()
-				if ptrValue.IsZero() { // ptr is not nil, we can update objVal to the value for update
+				if ptrValue.IsValid() { // ptr is not nil, we can update objVal to the value for update
 					objVal = objVal.Elem()
 				}
 			}

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -116,7 +116,12 @@ func patchObject(inputObj interface{}, patchMap map[string]interface{}) (map[str
 			// cannot call fieldByName on a zero value
 			objVal = objVal.FieldByName(attr)
 			if objVal.Kind() == reflect.Ptr {
-				objVal = objVal.Elem()
+				// if objVal is nil ptr/doesn't exist, we can't write to the direct value.
+				// so we should not set objVal to it's value directly without checking.
+				ptrValue := objVal.Elem()
+				if ptrValue.IsZero() { // ptr is not nil, we can update objVal to the value for update
+					objVal = objVal.Elem()
+				}
 			}
 		}
 		objVal.Set(updatedVal)

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -8,8 +8,8 @@ const (
 
 type Metadata struct {
 	Name string `json:"name,omitempty"`
-	Ovdc []Ovdc `json:"orgVdc,omitempty"`
-	Org  []Org  `json:"vcdOrg,omitempty"`
+	Ovdc []Ovdc `json:"orgVdcs,omitempty"`
+	Org  []Org  `json:"organizations,omitempty"`
 	Site string `json:"site,omitempty"`
 }
 

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -8,8 +8,8 @@ const (
 
 type Metadata struct {
 	Name string `json:"name,omitempty"`
-	Org  string `json:"orgName,omitempty"`
-	Vdc  string `json:"virtualDataCenterName,omitempty"`
+	Ovdc []Ovdc `json:"orgVdc,omitempty"`
+	Org  []Org  `json:"vcdOrg,omitempty"`
 	Site string `json:"site,omitempty"`
 }
 

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -59,7 +59,7 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "vcdOrg": {
+        "organizations": {
           "type": "array",
           "items":  {
             "type": "object",
@@ -76,7 +76,7 @@
           },
           "description": "The Organizations in which cluster needs to be created or managed."
         },
-        "orgVdc": {
+        "orgVdcs": {
           "type": "array",
           "items": {
             "type": "object",

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -59,13 +59,39 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "orgName": {
-          "type": "string",
-          "description": "The name of the Organization in which cluster needs to be created or managed."
+        "vcdOrg": {
+          "type": "array",
+          "items":  {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Organization name in which the cluster needs to be managed"
+              },
+              "id": {
+                "type": "string",
+                "description": "organizaiton ID of the Organization in which the cluster needs to be managed"
+              }
+            }
+          },
+          "description": "The Organizations in which cluster needs to be created or managed."
         },
-        "virtualDataCenterName": {
-          "type": "string",
-          "description": "The name of the Organization data center in which the cluster need to be created or managed."
+        "orgVdc": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "organization virtual data centers in which the cluster needs to be managed",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Org VDC name of the virtual data center in which the cluster needs to be managed"
+              },
+              "id": {
+                "type": "string",
+                "description": "Org VDC ID of the virtual data center in which the cluster needs to be managed"
+              }
+            }
+          }
         },
         "name": {
           "type": "string",


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Make org and vdc in metadata as arrays
- update patchObj to handle nil values

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/261)
<!-- Reviewable:end -->
