### PR TITLE
[VCDA-4429] Revert metadata changes and add ovdc network for the vdc list in vcdProperties

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -260,8 +260,9 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 	}
 	ovdcList := []rdeType.Ovdc{
 		rdeType.Ovdc{
-			Name: vdc.Name,
-			ID:   vdc.ID,
+			Name:        vdc.Name,
+			ID:          vdc.ID,
+			OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
 		},
 	}
 
@@ -274,8 +275,8 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 		ApiVersion: capisdk.CAPVCDClusterEntityApiVersion,
 		Metadata: rdeType.Metadata{
 			Name: vcdCluster.Name,
-			Org:  orgList,
-			Ovdc: ovdcList,
+			Org:  vcdOrg.Name,
+			Vdc:  vdc.Name,
 			Site: vcdCluster.Spec.Site,
 		},
 		Spec: rdeType.CAPVCDSpec{},
@@ -301,10 +302,9 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 				},
 				ParentUID: vcdCluster.Spec.ParentUID,
 				VcdProperties: rdeType.VCDProperties{
-					Site:        vcdCluster.Spec.Site,
-					Org:         orgList,
-					Ovdc:        ovdcList,
-					OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
+					Site: vcdCluster.Spec.Site,
+					Org:  orgList,
+					Ovdc: ovdcList,
 				},
 				CapiStatusYaml:             "",
 				ClusterResourceSetBindings: nil,
@@ -381,28 +381,17 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 
 	// TODO(VCDA-3107): Should we be updating org and vdc information here.
 	metadataPatch := make(map[string]interface{})
-	orgList := []rdeType.Org{
-		rdeType.Org{
-			Name: org.Org.Name,
-			ID:   org.Org.ID,
-		},
-	}
-	if !reflect.DeepEqual(orgList, capvcdMetadata.Org) {
-		metadataPatch["Org"] = orgList
+	if org.Org.Name != capvcdMetadata.Org {
+		metadataPatch["Org"] = org.Org.Name
 	}
 
-	ovdcList := []rdeType.Ovdc{
-		rdeType.Ovdc{
-			Name: workloadVCDClient.VDC.Vdc.Name,
-			ID:   workloadVCDClient.VDC.Vdc.Name,
-		},
-	}
-	if !reflect.DeepEqual(ovdcList, capvcdMetadata.Ovdc) {
-		metadataPatch["Ovdc"] = ovdcList
+	vdc := vcdCluster.Spec.Ovdc
+	if vdc != capvcdMetadata.Vdc {
+		metadataPatch["Vdc"] = capvcdMetadata.Vdc
 	}
 
 	if capvcdMetadata.Site != vcdCluster.Spec.Site {
-		metadataPatch["Org"] = vcdCluster.Spec.Site
+		metadataPatch["Site"] = vcdCluster.Spec.Site
 	}
 
 	specPatch := make(map[string]interface{})
@@ -564,11 +553,23 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		capvcdStatusPatch["NodePool"] = nodePoolList
 	}
 
+	ovdcList := []rdeType.Ovdc{
+		rdeType.Ovdc{
+			Name:        workloadVCDClient.VDC.Vdc.Name,
+			ID:          workloadVCDClient.VDC.Vdc.Name,
+			OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
+		},
+	}
+	orgList := []rdeType.Org{
+		rdeType.Org{
+			Name: org.Org.Name,
+			ID:   org.Org.ID,
+		},
+	}
 	vcdResources := rdeType.VCDProperties{
-		Site:        vcdCluster.Spec.Site,
-		Org:         orgList,
-		Ovdc:        ovdcList,
-		OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
+		Site: vcdCluster.Spec.Site,
+		Org:  orgList,
+		Ovdc: ovdcList,
 	}
 	if !reflect.DeepEqual(vcdResources, capvcdStatus.VcdProperties) {
 		capvcdStatusPatch["VcdProperties"] = vcdResources
@@ -962,7 +963,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	// Update the vcdCluster resource with updated information
-	// TODO Check if updating ovdcNetwork, Org and Ovdc should be done somewhere earlier in the code.
+	// TODO Check if updating ovdcNetwork, Org and Vdc should be done somewhere earlier in the code.
 	vcdCluster.Status.Ready = true
 	conditions.MarkTrue(vcdCluster, LoadBalancerAvailableCondition)
 	if cluster.Status.ControlPlaneReady {

--- a/examples/rde1_1_0.json
+++ b/examples/rde1_1_0.json
@@ -13,18 +13,8 @@
     }
   },
   "metadata": {
-    "organizations": [
-      {
-        "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
-        "id": "274c6240-3304-11ed-a261-0242ac120002"
-      }
-    ],
-    "orgVdcs": [
-      {
-        "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
-        "id": "274c6240-3304-11ed-a261-0242ac120002"
-      }
-    ],
+    "orgName": "ABCDEFGHIJKLMNOPQRSTUVWXYZA",
+    "virtualDataCenterName": "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
     "name": "ABCDEFGH",
     "site": "ABCD"
   },
@@ -112,19 +102,19 @@
       "createdByVersion": "1.1.0",
       "capvcdVersion": "ABCD",
       "vcdProperties": {
-        "vcdOrg": [
+        "organizations": [
           {
             "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
             "id": "274c6240-3304-11ed-a261-0242ac120002"
           }
         ],
-        "orgVdc": [
+        "orgVdcs": [
           {
             "name": "ABCDEFGHIJKLMNOPQRSTUVWXYZAB",
-            "id": "274c6240-3304-11ed-a261-0242ac120002"
+            "id": "274c6240-3304-11ed-a261-0242ac120002",
+            "ovdcNetworkName": "ABCDEFGHIJKLMNOPQ"
           }
         ],
-        "ovdcNetworkName": "ABCDEFGHIJKLMNOPQ",
         "site": "ABCDEFGHIJKLMNOPQRSTUVWX"
       },
       "vcdResourceSet": [

--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -8,8 +8,8 @@ const (
 
 type Metadata struct {
 	Name string `json:"name,omitempty"`
-	Ovdc []Ovdc `json:"orgVdcs,omitempty"`
-	Org  []Org  `json:"organizations,omitempty"`
+	Vdc  string `json:"virtualDataCenterName,omitempty"`
+	Org  string `json:"orgName,omitempty"`
 	Site string `json:"site,omitempty"`
 }
 
@@ -47,8 +47,9 @@ type Services struct {
 }
 
 type Ovdc struct {
-	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ID          string `json:"id,omitempty"`
+	OvdcNetwork string `json:"ovdcNetworkName,omitempty"`
 }
 
 type Org struct {
@@ -57,10 +58,9 @@ type Org struct {
 }
 
 type VCDProperties struct {
-	Site        string `json:"site,omitempty"`
-	OvdcNetwork string `json:"ovdcNetworkName,omitempty"`
-	Ovdc        []Ovdc `json:"orgVdc,omitempty"`
-	Org         []Org  `json:"vcdOrg,omitempty"`
+	Site string `json:"site,omitempty"`
+	Ovdc []Ovdc `json:"orgVdcs,omitempty"`
+	Org  []Org  `json:"organizations,omitempty"`
 }
 
 type ApiEndpoints struct {

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -59,39 +59,13 @@
     "metadata": {
       "type": "object",
       "properties": {
-        "organizations": {
-          "type": "array",
-          "items":  {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Organization name in which the cluster needs to be managed"
-              },
-              "id": {
-                "type": "string",
-                "description": "organizaiton ID of the Organization in which the cluster needs to be managed"
-              }
-            }
-          },
-          "description": "The Organizations in which cluster needs to be created or managed."
+        "orgName": {
+          "type": "string",
+          "description": "The name of the Organization in which cluster needs to be created or managed."
         },
-        "orgVdcs": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "description": "organization virtual data centers in which the cluster needs to be managed",
-            "properties": {
-              "name": {
-                "type": "string",
-                "description": "Org VDC name of the virtual data center in which the cluster needs to be managed"
-              },
-              "id": {
-                "type": "string",
-                "description": "Org VDC ID of the virtual data center in which the cluster needs to be managed"
-              }
-            }
-          }
+        "virtualDataCenterName": {
+          "type": "string",
+          "description": "The name of the Organization data center in which the cluster need to be created or managed."
         },
         "name": {
           "type": "string",
@@ -211,12 +185,12 @@
                       },
                       "id": {
                         "type": "string"
+                      },
+                      "ovdcNetworkName": {
+                        "type": "string"
                       }
                     }
                   }
-                },
-                "ovdcNetworkName": {
-                  "type": "string"
                 },
                 "site": {
                   "type": "string"


### PR DESCRIPTION
…roperties

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Rename entity.status.capvcd.vcdOrg -> entity.status.capvcd.organizations
- Rename entity.status.capvcd.orgVdc -> entitty.status.capvcd.orgVdcs
- include ovdcNetworkName in entity.status.orgVdcs
- Revert metadata chages (to have arrays for org and vdc)

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/265)
<!-- Reviewable:end -->
