### PR TITLE
[VCDA-4484] remove omitempty for integer fields in nodePool type definition

### DIFF
--- a/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
+++ b/pkg/vcdtypes/rde_type_1_1_0/types_1_1_0.go
@@ -106,8 +106,8 @@ type NodePool struct {
 	DiskSizeMb        int32             `json:"diskSizeMb,omitempty"`
 	NvidiaGpuEnabled  bool              `json:"nvidiaGpuEnabled,omitempty"`
 	StorageProfile    string            `json:"storageProfile,omitempty"`
-	DesiredReplicas   int32             `json:"desiredReplicas,omitempty"`
-	AvailableReplicas int32             `json:"availableReplicas,omitempty"`
+	DesiredReplicas   int32             `json:"desiredReplicas"`
+	AvailableReplicas int32             `json:"availableReplicas"`
 	NodeStatus        map[string]string `json:"nodeStatus,omitempty"`
 }
 


### PR DESCRIPTION
…ode pool definition

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request
- if availableReplicas / desiredReplicas are 0, the json created to update the node pools will have missing keys for availableReplicas / desiredReplicas.
- omitempty in the RDE type definition should be removed in the node pools definition.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/270)
<!-- Reviewable:end -->
