### PR TITLE
[VCDA-4498] Add logic to update ready flag in upgrade section of cpavcd status

### DIFF
--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -458,3 +458,32 @@ func hasKcpReconciledToDesiredK8Version(kcp *kcpv1.KubeadmControlPlane) bool {
 		*kcp.Status.Version == kcp.Spec.Version &&
 		kcp.Status.UnavailableReplicas == 0
 }
+
+// hasMachineDeplpymentReconciledToDesiredK8Version returns true if all the machines in the machine deployment have reconciled
+// to the desired kubernetes version, else returns false.
+func hasMachineDeplpymentReconciledToDesiredK8Version(md *clusterv1.MachineDeployment) bool {
+	return md != nil && md.Status.Replicas == md.Status.AvailableReplicas
+}
+
+// hasClusterReconciledToDesiredK8Version returns true if all the kubeadm control plane objects and machine deployments have
+// reconciled to the desired kubernetes version, else returns false.
+func hasClusterReconciledToDesiredK8Version(kcpList *kcpv1.KubeadmControlPlaneList, mdList *clusterv1.MachineDeploymentList) bool {
+	kcpReady := true
+	for _, kcp := range kcpList.Items {
+		if !hasKcpReconciledToDesiredK8Version(&kcp) {
+			kcpReady = false
+		}
+	}
+	if !kcpReady {
+		return false
+	}
+
+	mdReady := true
+	for _, md := range mdList.Items {
+		if !hasMachineDeplpymentReconciledToDesiredK8Version(&md) {
+			mdReady = false
+			break
+		}
+	}
+	return mdReady
+}


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Ready flag in the upgrade section of capvcd status should also consider the machine deployment upgrade status

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies - Not applicable
- [ ] updated any relevant documentation or examples - Not applicable

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [x] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
