### PR TITLE
[VCDA-4507] Correct schema to move ovdcNetworkName under orgVdc section

### DIFF
--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -219,9 +219,6 @@
                       },
                       "id": {
                         "type": "string"
-                      },
-                      "ovdcNetworkName": {
-                        "type": "string"
                       }
                     }
                   }
@@ -238,6 +235,9 @@
                         "type": "string"
                       },
                       "id": {
+                        "type": "string"
+                      },
+                      "ovdcNetworkName": {
                         "type": "string"
                       }
                     }

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -226,7 +226,7 @@
                 "site": {
                   "type": "string"
                 },
-                "orgVdc": {
+                "orgVdcs": {
                   "type": "array",
                   "items": {
                     "type": "object",

--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -209,7 +209,7 @@
             "vcdProperties": {
               "type": "object",
               "properties": {
-                "vcdOrg": {
+                "organizations": {
                   "type": "array",
                   "items": {
                     "type": "object",


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Correct schema to reflect the code
- move ovdcNetworkName under orgVdc section in the schema

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples - example rde is correct

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/273)
<!-- Reviewable:end -->
