### PR TITLE
[VCDA-4477] Remove lines generating a kubeadm token in the cloud init script

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -152,12 +152,7 @@ write_files:
     export KUBECONFIG=/etc/kubernetes/ {{- if .ControlPlane -}} admin {{- else -}} kubelet {{- end -}} .conf
     kubectl get po -A -owide {{- if .ControlPlane }}
     vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')" {{- end }}
-    vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} successful" {{- if .ControlPlane }}
-
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status in_progress"
-    KUBEADM_JOIN_INFO=$(kubeadm token create --print-join-command 2> /dev/null)
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.info $KUBEADM_JOIN_INFO"
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.kubeadm.token.generate.status successful" {{- end }}
+    vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} successful"
 
     echo "$(date) post customization script execution completed" &>> /var/log/capvcd/customization/status.log
     exit 0

--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -149,9 +149,6 @@ write_files:
       echo "file /run/cluster-api/bootstrap-success.complete not found" &>> /var/log/capvcd/customization/error.log
     exit 1
     fi
-    export KUBECONFIG=/etc/kubernetes/ {{- if .ControlPlane -}} admin {{- else -}} kubelet {{- end -}} .conf
-    kubectl get po -A -owide {{- if .ControlPlane }}
-    vmtoolsd --cmd "info-set guestinfo.kubeconfig $(cat /etc/kubernetes/admin.conf | base64 | tr -d '\n')" {{- end }}
     vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} successful"
 
     echo "$(date) post customization script execution completed" &>> /var/log/capvcd/customization/status.log

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -202,7 +202,6 @@ const (
 	ProxyConfiguration                     = "guestinfo.postcustomization.proxy.setting.status"
 	MeteringConfiguration                  = "guestinfo.metering.status"
 	KubeadmInit                            = "guestinfo.postcustomization.kubeinit.status"
-	KubeadmTokenGenerate                   = "guestinfo.postcustomization.kubeadm.token.generate.status"
 	KubeadmNodeJoin                        = "guestinfo.postcustomization.kubeadm.node.join.status"
 	NvidiaRuntimeInstall                   = "guestinfo.postcustomization.nvidia.runtime.install.status"
 	PostCustomizationScriptExecutionStatus = "guestinfo.post_customization_script_execution_status"
@@ -214,7 +213,6 @@ var controlPlanePostCustPhases = []string{
 	MeteringConfiguration,
 	ProxyConfiguration,
 	KubeadmInit,
-	KubeadmTokenGenerate,
 }
 
 var joinPostCustPhases = []string{


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Remove cloud init lines where kubeadm join token is being generated as it is not used anywhere in the code.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/280)
<!-- Reviewable:end -->
