### PR TITLE
[VCDA-4481] CAPVCD logs are spammed with "wrong etag" statements

### DIFF
--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -225,11 +225,11 @@ func (capvcdRdeManager *CapvcdRdeManager) PatchRDE(ctx context.Context, specPatc
 		// update the defined entity
 		rde, resp, err = client.APIClient.DefinedEntityApi.UpdateDefinedEntity(ctx, rde, etag, rdeID, nil)
 		if err != nil {
-			klog.Errorf("failed to update defined entity with ID [%s]: [%v]. Remaining retry attempts: [%d]", rdeID, err, MaxUpdateRetries-retries-1)
+			klog.V(5).Infof("failed to update defined entity with ID [%s] using etag [%s]: [%v]. Remaining retry attempts: [%d]", rdeID, etag, err, MaxUpdateRetries-retries-1)
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			klog.Errorf("error updating the defined entity with ID [%s]. failed with status code [%d]. Remaining retry attempts: [%d]", rdeID, resp.StatusCode, MaxUpdateRetries-retries+1)
+			klog.V(5).Infof("error updating the defined entity with ID [%s] using etag [%s]. failed with status code [%d]. Remaining retry attempts: [%d]", rdeID, etag, resp.StatusCode, MaxUpdateRetries-retries+1)
 			continue
 		}
 		klog.V(4).Infof("successfully updated defined entity with ID [%s]", rdeID)
@@ -384,7 +384,7 @@ func (capvcdRdeManager *CapvcdRdeManager) convertFrom100Format(ctx context.Conte
 			var responseMessageBytes []byte
 			if gsErr, ok := err.(swagger.GenericSwaggerError); ok {
 				responseMessageBytes = gsErr.Body()
-				klog.Errorf("error occurred when upgrading defined entity [%s] to version [%s]: [%s]",
+				klog.V(5).Infof("error occurred when upgrading defined entity [%s] to version [%s]: [%s]",
 					srcRde.Id, rdeType.CapvcdRDETypeVersion, string(responseMessageBytes))
 			}
 			return nil, fmt.Errorf("error when upgrading defined entity [%s] to version [%s]: [%v]",
@@ -394,8 +394,8 @@ func (capvcdRdeManager *CapvcdRdeManager) convertFrom100Format(ctx context.Conte
 				srcRde.Id, rdeType.CapvcdRDETypeVersion)
 		} else {
 			if resp.StatusCode == http.StatusPreconditionFailed {
-				klog.Errorf("wrong etag found when upgrading the defined entity [%s] to version [%s]. Retries remaining: [%d]",
-					srcRde.Id, rdeType.CapvcdRDETypeVersion, MaxUpdateRetries-retries-1)
+				klog.V(5).Infof("wrong etag [%s] while upgrading the defined entity [%s] to version [%s]. Retries remaining: [%d]",
+					etag, srcRde.Id, rdeType.CapvcdRDETypeVersion, MaxUpdateRetries-retries-1)
 				continue
 			} else if resp.StatusCode != http.StatusOK {
 				klog.Errorf("unexpected response status code when upgrading defined entity [%s] to version [%s]. Expected response [%d] obtained [%d]",


### PR DESCRIPTION
Signed-off-by: ymo24 <ymo@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

-  Clean up spammed etag logging statements in CAPVCD
- Increase the verbosity of logging level

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/282)
<!-- Reviewable:end -->
