### PR TITLE
VCDA-4559: Set cluster type to workload to attach to TMC

### DIFF
--- a/tanzu/crs/v1.4.3/v1.4.3.yaml.template
+++ b/tanzu/crs/v1.4.3/v1.4.3.yaml.template
@@ -1592,12 +1592,12 @@ stringData:
       metadata.yaml: |
         cluster:
           name: __CLUSTER_NAME__
-          type: management
+          type: workload
           plan: dev
           kubernetesProvider: VMware Tanzu Kubernetes Grid
           tkgVersion: v1.4.3
           infrastructure:
-            provider: vsphere
+            provider: cloud-director
         bom:
           configmapRef:
             name: tkg-bom

--- a/tanzu/crs/v1.5.4/v1.5.4.yaml.template
+++ b/tanzu/crs/v1.5.4/v1.5.4.yaml.template
@@ -2116,13 +2116,13 @@ stringData:
       metadata.yaml: |
         cluster:
           name: __CLUSTER_NAME__
-          type: management
+          type: workload
           plan: dev
           kubernetesProvider: VMware Tanzu Kubernetes Grid
           tkgVersion: v1.5.4
           edition: tkg
           infrastructure:
-            provider: vsphere
+            provider: cloud-director
         bom:
           configmapRef:
             name: tkg-bom


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Set the type of Cluster as Workload so that TMC allows it to be attached. The relevant code of interest in TMC is https://gitlab.eng.vmware.com/olympus/extension-framework/-/blob/master/pkg/clustermetadata/metadata.go#L268

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/283)
<!-- Reviewable:end -->
