### PR TITLE
[VCDA-4369]: Update image tag for consuming common core in CAPVCD

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:1.0.z.ea12a87
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:1.0.z.89ca65f
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1163,7 +1163,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:1.0.z.ea12a87
+        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:1.0.z.89ca65f
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Refresh image up to commit: 89ca65f 

Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/296)
<!-- Reviewable:end -->
