### PR TITLE
fix: bump cloud provider version

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -9,6 +9,12 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/antihax/optional"
 	"github.com/blang/semver"
 	"github.com/google/uuid"
@@ -26,9 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
-	"net/http"
-	"os"
-	"reflect"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	kcpv1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
@@ -39,8 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-	"time"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/replicatedhq/troubleshoot v0.35.0
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221007220419-682657f6f5f1
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221013201317-709327d2db34
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.1

--- a/go.sum
+++ b/go.sum
@@ -532,6 +532,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221007220419-682657f6f5f1 h1:Hi7ZlyjNak7ZsP1gxc5wAtUfiTmqIfiGlM4UnB/77Fw=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221007220419-682657f6f5f1/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221013201317-709327d2db34 h1:0stTbbURidkdQVK+/lo7Sba9iR1uRhLnFSt9bZMS68Q=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221013201317-709327d2db34/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
@@ -119,10 +119,10 @@ func (gatewayManager *GatewayManager) getOVDCNetwork(ctx context.Context, networ
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if networkFound {
-				return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
-			}
 			if ovdcNetwork.Name == gatewayManager.NetworkName {
+				if networkFound {
+					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - please ensure the network name is unique within an org", gatewayManager.NetworkName, client.ClusterOrgName)
+				}
 				ovdcNetworkID = ovdcNetwork.Id
 				networkFound = true
 			}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient/api_certificate_library_modified.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient/api_certificate_library_modified.go
@@ -25,10 +25,6 @@ var (
 	_ context.Context
 )
 
-const (
-	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
-)
-
 type CertificateLibraryApiService service
 
 /*

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient/vcdconstants.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient/vcdconstants.go
@@ -1,0 +1,5 @@
+package swagger
+
+const (
+	TenantContextHeader = "X-VMWARE-VCLOUD-TENANT-CONTEXT"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -255,7 +255,7 @@ github.com/replicatedhq/troubleshoot/pkg/redact
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.2
 ## explicit; go 1.13
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221007220419-682657f6f5f1
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221013201317-709327d2db34
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk


### PR DESCRIPTION
Bump cloud provider version to fix the issue with duplicate network validation

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Bump cloud provider version to fix the issue with duplicate network validation

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/300)
<!-- Reviewable:end -->
