### PR TITLE
[VCDA-4558][Fix] Update to the correct CPI CRS file content from CPI repo

### DIFF
--- a/templates/crs/cpi/cloud-director-ccm.yaml
+++ b/templates/crs/cpi/cloud-director-ccm.yaml
@@ -166,6 +166,12 @@ spec:
               mountPath: /etc/kubernetes/vcloud
             - name: vcloud-ccm-vcloud-basic-auth-volume
               mountPath: /etc/kubernetes/vcloud/basic-auth
+          env:
+            - name: CLUSTER_ID
+              valueFrom:
+                secretKeyRef:
+                  name: vcloud-clusterid-secret
+                  key: clusterid
       tolerations:
         - key: node.cloudprovider.kubernetes.io/uninitialized
           value: "true"


### PR DESCRIPTION
Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Previous merge of CPI CRS files was not latest as it was missing CLUSTER_ID env. 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/306)
<!-- Reviewable:end -->
