### PR TITLE
[VCDA-4679] Attempt adding network to the VM if it is missing

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -561,7 +561,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.V(4).Info("Attempting to update the VM [%s] with network connection section: [%#v]", vm.VM.Name, networkConnectionSection)
 		err := vm.UpdateNetworkConnectionSection(networkConnectionSection)
 		if err != nil {
-			klog.Warningf("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
+			log.V(4).Info("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
 		}
 		log.Error(nil, fmt.Sprintf("Requeuing...; network connection section was not found for vm [%s(%s)]: [%#v]", vm.VM.Name, vm.VM.ID, vm.VM))
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
@@ -571,7 +571,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		log.V(4).Info("Attempting to update the VM [%s] with network connection section: [%#v]", vm.VM.Name, networkConnectionSection)
 		err := vm.UpdateNetworkConnectionSection(networkConnectionSection)
 		if err != nil {
-			klog.Warningf("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
+			log.V(4).Info("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
 		}
 		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get existing network connection information for vm [%s(%s)]: [%#v]. NetworkConnection[0] should not be nil",
 			vm.VM.Name, vm.VM.ID, vm.VM.NetworkConnectionSection))

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -557,35 +557,16 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			},
 		},
 	}
-	if vm.VM.NetworkConnectionSection == nil || len(vm.VM.NetworkConnectionSection.NetworkConnection) == 0 {
+	if (vm.VM.NetworkConnectionSection == nil || len(vm.VM.NetworkConnectionSection.NetworkConnection) == 0) ||
+		(vm.VM.NetworkConnectionSection.NetworkConnection[0] == nil) ||
+		(vm.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress == "") {
 		log.V(4).Info("Attempting to update the VM [%s] with network connection section: [%#v]", vm.VM.Name, networkConnectionSection)
 		err := vm.UpdateNetworkConnectionSection(networkConnectionSection)
 		if err != nil {
 			log.V(4).Info("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
 		}
-		log.Error(nil, fmt.Sprintf("Requeuing...; network connection section was not found for vm [%s(%s)]: [%#v]", vm.VM.Name, vm.VM.ID, vm.VM))
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	if vm.VM.NetworkConnectionSection.NetworkConnection[0] == nil {
-		log.V(4).Info("Attempting to update the VM [%s] with network connection section: [%#v]", vm.VM.Name, networkConnectionSection)
-		err := vm.UpdateNetworkConnectionSection(networkConnectionSection)
-		if err != nil {
-			log.V(4).Info("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
-		}
-		log.Error(nil, fmt.Sprintf("Requeuing...; failed to get existing network connection information for vm [%s(%s)]: [%#v]. NetworkConnection[0] should not be nil",
+		log.Error(nil, fmt.Sprintf("Requeuing...; invalid network connection section for the vm [%s(%s)]- network connection section was not found or the IP Address of the VM was empty: [%#v]",
 			vm.VM.Name, vm.VM.ID, vm.VM.NetworkConnectionSection))
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-	}
-
-	if vm.VM.NetworkConnectionSection.NetworkConnection[0].IPAddress == "" {
-		log.Info("Attempting to update the VM [%s] with network connection section: [%#v]", vm.VM.Name, networkConnectionSection)
-		err := vm.UpdateNetworkConnectionSection(networkConnectionSection)
-		if err != nil {
-			klog.Warningf("Failed to update VM [%s] with network connection section: [%v]", vm.VM.Name, err)
-		}
-		log.Error(nil, fmt.Sprintf("Requeuing...; NetworkConnection[0] IP Address should not be empty for vm [%s(%s)]: [%#v]",
-			vm.VM.Name, vm.VM.ID, *vm.VM.NetworkConnectionSection.NetworkConnection[0]))
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- make attempt to add network to the VM is network connection section for the VM is missing.
- Tested by creating multiple node pools, resizing up one node pool and resizing down one node pool simultaneously.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/310)
<!-- Reviewable:end -->
