### PR TITLE
[VCDA-4713] Fix cluster creation with CAPVCD_SKIP_RDE set to true

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -191,7 +191,7 @@ func addLBResourcesToVCDResourceSet(ctx context.Context, rdeManager *vcdsdk.RDEM
 // The values for infra ID is not expected to change. rdeVersionInUse is not expected to change too unless the CAPVCD is being upgraded and the new
 // CAPVCD version makes use of a higher RDE version.
 // Derived values for infraID and rdeVersionInUse are essentially the final computed values - i.e either created or picked from the VCDCluster object.
-// validateDerivedRDEProperties makes sure the infra ID and the RDE version in-use doesn't change to unexpected versions over different reconciliations.
+// validateDerivedRDEProperties makes sure the infra ID and the RDE version in-use doesn't change to unexpected values over different reconciliations.
 func validateDerivedRDEProperties(vcdCluster *infrav1.VCDCluster, infraID string, rdeVersionInUse string) error {
 	// If the RDEVersionInUse is NO_RDE_ then there RDEVersionInUse cannot change
 	// If the RDEVersionInUse is a semantic version, RDEVersionInUse can only be upgraded to a higher version

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -218,13 +218,15 @@ func validateDerivedRDEProperties(vcdCluster *infrav1.VCDCluster, infraID string
 				rdeVersionInUse, vcdCluster.Status.RdeVersionInUse)
 		}
 	}
-	if vcdCluster.Status.RdeVersionInUse == NoRdePrefix && rdeVersionInUse != NoRdePrefix {
-		return fmt.Errorf("RDE version in VCDCluster status [%s] is auto generated while the derived RDE version [%s] is not ",
-			vcdCluster.Status.RdeVersionInUse, rdeVersionInUse)
-	}
-	if vcdCluster.Status.RdeVersionInUse != NoRdePrefix && rdeVersionInUse == NoRdePrefix {
-		return fmt.Errorf("derived RDE version in VCDCluster [%s] is auto generated while RDE version in VCDCluster status [%s] is not",
-			rdeVersionInUse, vcdCluster.Status.RdeVersionInUse)
+	if vcdCluster.Status.RdeVersionInUse != "" {
+		if vcdCluster.Status.RdeVersionInUse == NoRdePrefix && rdeVersionInUse != NoRdePrefix {
+			return fmt.Errorf("RDE version in VCDCluster status [%s] is auto generated while the derived RDE version [%s] is not ",
+				vcdCluster.Status.RdeVersionInUse, rdeVersionInUse)
+		}
+		if vcdCluster.Status.RdeVersionInUse != NoRdePrefix && rdeVersionInUse == NoRdePrefix {
+			return fmt.Errorf("derived RDE version in VCDCluster [%s] is auto generated while RDE version in VCDCluster status [%s] is not",
+				rdeVersionInUse, vcdCluster.Status.RdeVersionInUse)
+		}
 	}
 	return nil
 }

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -187,6 +187,11 @@ func addLBResourcesToVCDResourceSet(ctx context.Context, rdeManager *vcdsdk.RDEM
 	return nil
 }
 
+// On VCDCluster reconciliation, we either create a new Infra ID or use an existing Infra ID from the VCDCluster object.
+// The values for infra ID is not expected to change. rdeVersionInUse is not expected to change too unless the CAPVCD is being upgraded and the new
+// CAPVCD version makes use of a higher RDE version.
+// Derived values for infraID and rdeVersionInUse are essentially the final computed values - i.e either created or picked from the VCDCluster object.
+// validateDerivedRDEProperties makes sure the infra ID and the RDE version in-use doesn't change to unexpected versions over different reconciliations.
 func validateDerivedRDEProperties(vcdCluster *infrav1.VCDCluster, infraID string, rdeVersionInUse string) error {
 	// If the RDEVersionInUse is NO_RDE_ then there RDEVersionInUse cannot change
 	// If the RDEVersionInUse is a semantic version, RDEVersionInUse can only be upgraded to a higher version
@@ -232,9 +237,10 @@ func validateDerivedRDEProperties(vcdCluster *infrav1.VCDCluster, infraID string
 		return nil
 	}
 
-	// return error on anything else
-	return fmt.Errorf("stored and derived RDE versions mismatched: status says [%s] while derived version says [%s]",
-		vcdCluster.Status.RdeVersionInUse, rdeVersionInUse)
+	// rdeVersionInUse cannot change from a valid semantic version (valid RDE) to NO_RDE_ (RDE creation skipped). This can occur
+	// when the there is an update to VCDCluster object from an external source, some misconfiguration or a bug in the logic to obtain infraID/rdeVersionInUse.
+	return fmt.Errorf("stored and derived RDE versions mismatched for the cluster [%s]: status says [%s] while derived version says [%s]",
+		vcdCluster.Name, vcdCluster.Status.RdeVersionInUse, rdeVersionInUse)
 }
 
 // TODO: Remove uncommented code when decision to only keep capi.yaml as part of RDE spec is finalized


### PR DESCRIPTION
…n status only if it is empty

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Update the function validateDerivedRDEProperties() to only verify the RDE version in use if VCD cluster status is empty.
- Tested locally by creating a cluster with CAPVCD_SKIP_RDE environment variable set

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes # https://github.com/vmware/cluster-api-provider-cloud-director/issues/309

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/313)
<!-- Reviewable:end -->
