### PR TITLE
fix: fields in example resources

### DIFF
--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -75,7 +75,7 @@ spec:
       placementPolicy: tkgm-placement-policy # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
       storageProfile: "*" # Storage profile to be used for the control plane VMs (this must be pre-published on the chosen organization virtual datacenter)
       diskSize: 20Gi  # DiskSize is the size of VM storage
-#      enableNvidiaGPU: false   # NvidiaGPU is true when a VM should be created with the relevant binaries installed. If true, then an appropriate placement policy should be set
+      enableNvidiaGPU: false   # enableNvidiaGPU is true when a VM should be created with the relevant binaries installed. If true, then an appropriate placement policy should be set
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -139,7 +139,7 @@ spec:
       placementPolicy: tkgm-placement-policy # Placement policy to be used for worker VMs (this must be pre-published on the chosen organization virtual datacenter)
       storageProfile: "*" # Storage profile to be used for the worker VMs (this must be pre-published on the chosen organization virtual datacenter)
       diskSize: 20Gi   # DiskSize is the size of VM storage
-      nvidiaGPU: false   # NvidiaGPU is true when a VM should be created with the relevant binaries installed. If true, then an appropriate placement policy should be set
+      enableNvidiaGPU: false   # enableNvidiaGPU is true when a VM should be created with the relevant binaries installed. If true, then an appropriate placement policy should be set
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- I tried to use the example workload resource file to create manifest for a cluster by updating the values in the example file but it failed due to invalid names in some of the objects. 

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/314)
<!-- Reviewable:end -->
