### PR TITLE
[VCDA-4741] Use double quotes for username, password and refresh token variables in templates

### DIFF
--- a/templates/cluster-template-v1.20.8-crs.yaml
+++ b/templates/cluster-template-v1.20.8-crs.yaml
@@ -34,9 +34,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # B64 encoded password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template-v1.20.8.yaml
+++ b/templates/cluster-template-v1.20.8.yaml
@@ -30,9 +30,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # username of the VCD persona creating the cluster. If system administrator is the user, please use 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # username of the VCD persona creating the cluster. If system administrator is the user, please use 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template-v1.21.8-crs.yaml
+++ b/templates/cluster-template-v1.21.8-crs.yaml
@@ -34,9 +34,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # B64 encoded password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template-v1.21.8.yaml
+++ b/templates/cluster-template-v1.21.8.yaml
@@ -30,9 +30,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # B64 encoded password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template-v1.22.9-crs.yaml
+++ b/templates/cluster-template-v1.22.9-crs.yaml
@@ -34,9 +34,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # B64 encoded password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template-v1.22.9.yaml
+++ b/templates/cluster-template-v1.22.9.yaml
@@ -30,9 +30,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # B64 encoded password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # B64 encoded username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -34,9 +34,9 @@ metadata:
   namespace: ${TARGET_NAMESPACE}
 type: Opaque
 data:
-  username: ${VCD_USERNAME_B64} # username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
-  password: ${VCD_PASSWORD_B64} # password associated with the user creating the cluster
-  refreshToken: ${VCD_REFRESH_TOKEN_B64} # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
+  username: "${VCD_USERNAME_B64}" # username of the VCD persona creating the cluster. If system administrator is the user, please encode 'system/administrator' as the username.
+  password: "${VCD_PASSWORD_B64}" # password associated with the user creating the cluster
+  refreshToken: "${VCD_REFRESH_TOKEN_B64}" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VCDCluster


### PR DESCRIPTION

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Fix clusterctl templates so that they can be used directly

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/319)
<!-- Reviewable:end -->
