### PR TITLE
fix: the script to get etcd and coredns version

### DIFF
--- a/docs/WORKLOAD_CLUSTER.md
+++ b/docs/WORKLOAD_CLUSTER.md
@@ -140,9 +140,9 @@ Ensure docker and yq are pre-installed on your local machine.
 # Extract etcd and coredns info for capi.yaml
 # Change the RAW version to match something similar from your TKG template
 export K8S_VERSION_RAW=v1.20.8+vmware.1-tkg.1
- 
+
 export K8S_VERSION=$(echo ${K8S_VERSION_RAW} | tr -s "+" "_")
- 
+
 # We need to loop through the last value after `tkg.` because of some TKR unexpected design
 no_tkg_found=false
 last=$(echo ${K8S_VERSION//*.})  # get last value after `tkg.`
@@ -163,15 +163,23 @@ if $no_tkg_found; then
 fi
 
 export K8S_VERSION_RAW=$(echo ${K8S_VERSION_RAW} | sed "s/.$/"$last"/")
-docker save projects.registry.vmware.com/tkg/tkr-bom:${K8S_VERSION} | tar Oxf - --strip-components 1 */layer.tar | tar xf -
- 
-ETCD_VERSION=$(yq e ".components.etcd[0].version" tkr-bom-${K8S_VERSION_RAW}.yaml | tr -s "+" "_")
-ETCD_IMAGE_PATH="projects.registry.vmware.com/tkg/$(yq e ".components.etcd[0].images.etcd.imagePath" tkr-bom-${K8S_VERSION_RAW}.yaml)"
-ETCD_IMAGE_TAG=$(yq e ".components.etcd[0].images.etcd.tag" tkr-bom-${K8S_VERSION_RAW}.yaml)
- 
-COREDNS_VERSION=$(yq e ".components.coredns[0].version" tkr-bom-${K8S_VERSION_RAW}.yaml | tr -s "+" "_")
-COREDNS_IMAGE_PATH="projects.registry.vmware.com/tkg/$(yq e ".components.coredns[0].images.coredns.imagePath" tkr-bom-${K8S_VERSION_RAW}.yaml)"
-COREDNS_IMAGE_TAG=$(yq e ".components.coredns[0].images.coredns.tag" tkr-bom-${K8S_VERSION_RAW}.yaml)
+docker save projects.registry.vmware.com/tkg/tkr-bom:${K8S_VERSION} | tar Oxf - --strip-components 1 '*/layer.tar' | tar xf -
+
+ETCD_VERSION=$(yq  -r ".components.etcd[0].version" tkr-bom-${K8S_VERSION_RAW}.yaml | tr -s "+" "_")
+ETCD_IMAGE_PATH="projects.registry.vmware.com/tkg/$(yq -r ".components.etcd[0].images.etcd.imagePath" tkr-bom-${K8S_VERSION_RAW}.yaml)"
+ETCD_IMAGE_TAG=$(yq -r ".components.etcd[0].images.etcd.tag" tkr-bom-${K8S_VERSION_RAW}.yaml)
+
+echo ETCD_VERSION: "${ETCD_VERSION}"
+echo ETCD_IMAGE_PATH: "${ETCD_IMAGE_PATH}"
+echo ETCD_IMAGE_TAG: "${ETCD_IMAGE_TAG}"
+
+COREDNS_VERSION=$(yq -r ".components.coredns[0].version" tkr-bom-${K8S_VERSION_RAW}.yaml | tr -s "+" "_")
+COREDNS_IMAGE_PATH="projects.registry.vmware.com/tkg/$(yq -r ".components.coredns[0].images.coredns.imagePath" tkr-bom-${K8S_VERSION_RAW}.yaml)"
+COREDNS_IMAGE_TAG=$(yq -r ".components.coredns[0].images.coredns.tag" tkr-bom-${K8S_VERSION_RAW}.yaml)
+
+echo COREDNS_VERSION: "${COREDNS_VERSION}"
+echo COREDNS_IMAGE_PATH: "${COREDNS_IMAGE_PATH}"
+echo COREDNS_IMAGE_TAG: "${COREDNS_IMAGE_TAG}"
 ```
 
 


### PR DESCRIPTION
When I tried to run the script on my system it failed with different errors
- As  */layer.tar not quoted it returns (no matches found: */layer.tar)
- yq commands errors as below (yq: error: argument files: can't open '.components.etcd[0].images.etcd.tag': [Errno 2] No such file or directory: '.components.etcd[0].images.etcd.tag')

## Description
Please provide a brief description of the changes proposed in this Pull Request

- When you try to run previous version it results in below errors 
```
Error response from daemon: unknown: artifact tkg/tkr-bom:v1.20.8_vmware.1-tkg.1 not found
v1.20.8_vmware.1-tkg.2: Pulling from tkg/tkr-bom
Digest: sha256:f6f1b8e3ba86b41a035ac9c8489dcf8bac0fbac3e856c32b885a68db63aaa35b
Status: Image is up to date for projects.registry.vmware.com/tkg/tkr-bom:v1.20.8_vmware.1-tkg.2
projects.registry.vmware.com/tkg/tkr-bom:v1.20.8_vmware.1-tkg.2
zsh: no matches found: */layer.tar
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.etcd[0].version': [Errno 2] No such file or directory: '.components.etcd[0].version'
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.etcd[0].images.etcd.imagePath': [Errno 2] No such file or directory: '.components.etcd[0].images.etcd.imagePath'
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.etcd[0].images.etcd.tag': [Errno 2] No such file or directory: '.components.etcd[0].images.etcd.tag'
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.coredns[0].version': [Errno 2] No such file or directory: '.components.coredns[0].version'
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.coredns[0].images.coredns.imagePath': [Errno 2] No such file or directory: '.components.coredns[0].images.coredns.imagePath'
usage: yq [-h] [--yaml-output] [--yaml-roundtrip]
          [--yaml-output-grammar-version {1.1,1.2}] [--width WIDTH]
          [--indentless-lists] [--in-place] [--version]
          [jq_filter] [files ...]
yq: error: argument files: can't open '.components.coredns[0].images.coredns.tag': [Errno 2] No such file or directory: '.components.coredns[0].images.coredns.tag'

```

But with new changes it works fine.

```
Error response from daemon: unknown: artifact tkg/tkr-bom:v1.20.8_vmware.1-tkg.1 not found
v1.20.8_vmware.1-tkg.2: Pulling from tkg/tkr-bom
Digest: sha256:f6f1b8e3ba86b41a035ac9c8489dcf8bac0fbac3e856c32b885a68db63aaa35b
Status: Image is up to date for projects.registry.vmware.com/tkg/tkr-bom:v1.20.8_vmware.1-tkg.2
projects.registry.vmware.com/tkg/tkr-bom:v1.20.8_vmware.1-tkg.2
ETCD_VERSION: v3.4.13_vmware.14
ETCD_IMAGE_PATH: projects.registry.vmware.com/tkg/etcd
ETCD_IMAGE_TAG: v3.4.13_vmware.14
COREDNS_VERSION: v1.7.0_vmware.12
COREDNS_IMAGE_PATH: projects.registry.vmware.com/tkg/coredns
COREDNS_IMAGE_TAG: v1.7.0_vmware.12
```
## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/323)
<!-- Reviewable:end -->
