### PR TITLE
[VCDA-4743] Iterate all machines to compute ready flag

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -267,9 +267,12 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 
 	mdList, err := getAllMachineDeploymentsForCluster(ctx, r.Client, *cluster)
 	if err != nil {
-		return nil, fmt.Errorf("error gettin all machine deployment objects for the cluster [%s]: [%v]", vcdCluster.Name, err)
+		return nil, fmt.Errorf("error getting all machine deployment objects for the cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
-	ready := hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesVersion)
+	ready, err := hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while determining the value for the ready flag for cluster [%s]: [%v]", vcdCluster.Name, err)
+	}
 
 	orgList := []rdeType.Org{
 		rdeType.Org{
@@ -461,7 +464,11 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 
 	upgradeObject := capvcdStatus.Upgrade
 	var ready bool
-	ready = hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesSpecVersion)
+	ready, err = hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesSpecVersion)
+	if err != nil {
+		return fmt.Errorf("failed to determine the value for ready flag for upgrades for cluster [%s(%s)]: [%v]",
+			vcdCluster.Name, vcdCluster.Status.InfraId, err)
+	}
 
 	if kcpObj != nil {
 		if upgradeObject.Current == nil {

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -269,7 +269,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 	if err != nil {
 		return nil, fmt.Errorf("error gettin all machine deployment objects for the cluster [%s]: [%v]", vcdCluster.Name, err)
 	}
-	ready := hasClusterReconciledToDesiredK8Version(kcpList, mdList)
+	ready := hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesVersion)
 
 	orgList := []rdeType.Org{
 		rdeType.Org{
@@ -459,8 +459,10 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 		capvcdStatusPatch["Phase"] = cluster.Status.Phase
 	}
 
-	ready := hasClusterReconciledToDesiredK8Version(kcpList, mdList)
 	upgradeObject := capvcdStatus.Upgrade
+	var ready bool
+	ready = hasClusterReconciledToDesiredK8Version(ctx, r.Client, vcdCluster.Name, kcpList, mdList, kubernetesSpecVersion)
+
 	if kcpObj != nil {
 		if upgradeObject.Current == nil {
 			upgradeObject = rdeType.Upgrade{

--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -22,6 +22,8 @@ providers:
     url: "~/go/cluster-api-provider-cloud-director/infrastructure-vcd/v1.0.0/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 
+EXP_CLUSTER_RESOURCE_SET: true
+
 # Variables specific to both "cluster init" and "clusterctl generate"
 VCD_SITE: "https://VCD_FQDN"
 VCD_ORGANIZATION: "test_org"


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Ready flag should not be set when the cluster is being resized
- Check if all the machines created are at the same version as expected to set the ready flag

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/330)
<!-- Reviewable:end -->
