### PR TITLE
[VCDA-4773] When converting from v1alpha4 to v1beta1, make sure to set provider ID in vcdMachine status (#327)

### DIFF
--- a/api/v1alpha4/vcdmachine_conversion.go
+++ b/api/v1alpha4/vcdmachine_conversion.go
@@ -15,7 +15,7 @@ func (src *VCDMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.SizingPolicy = src.Spec.ComputePolicy
 	dst.Spec.StorageProfile = ""
 	dst.Status.Template = ""
-	dst.Status.ProviderID = nil
+	dst.Status.ProviderID = src.Spec.ProviderID
 	return nil
 }
 


### PR DESCRIPTION

## Description
Please provide a brief description of the changes proposed in this Pull Request

- vcdmachine conversion logic should set vcdmachine.status.providerID = vcdmachine.spec.providerID
- Fixes clusterctl upgrade operation

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/331)
<!-- Reviewable:end -->
