### PR TITLE
[VCDA-4757] Remove code to redact the cloud init script as redaction logic is not necessary anymore

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -461,6 +461,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	cloudInit := string(mergedCloudInitBytes)
 
+	// nothing is redacted in the cloud init script - please ensure no secrets are present
 	log.Info(fmt.Sprintf("Cloud init Script: [%s]", cloudInit))
 	err = capvcdRdeManager.AddToEventSet(ctx, capisdk.CloudInitScriptGenerated, "", machine.Name, "", skipRDEEventUpdates)
 	if err != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -12,7 +12,6 @@ import (
 	b64 "encoding/base64"
 	"fmt"
 	"github.com/pkg/errors"
-	"github.com/replicatedhq/troubleshoot/pkg/redact"
 	cpiutil "github.com/vmware/cloud-provider-for-cloud-director/pkg/util"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	infrav1 "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
@@ -21,7 +20,6 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
@@ -242,17 +240,6 @@ func strInSlice(findStr string, arr []string) bool {
 
 const phaseSecondTimeout = 600
 
-func redactCloudInit(cloudInitYaml string, path []string) (string, error) {
-	yamlRunner := redact.NewYamlRedactor(strings.Join(path, "."), "", "cloudInitRedactor")
-	outReader := yamlRunner.Redact(bytes.NewReader([]byte(cloudInitYaml)), "")
-	gotBytes, err := ioutil.ReadAll(outReader)
-	if err != nil {
-		return cloudInitYaml, fmt.Errorf("failed to read redacted yaml output : %v", err)
-	}
-	return string(gotBytes), nil
-
-}
-
 func (r *VCDMachineReconciler) waitForPostCustomizationPhase(ctx context.Context,
 	workloadVCDClient *vcdsdk.Client, vm *govcd.VM, phase string) error {
 	log := ctrl.LoggerFrom(ctx)
@@ -472,18 +459,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			vAppName, machine.Name, bootstrapJinjaScript)
 	}
 
-	redactedCloudInit := string(mergedCloudInitBytes)
-	if util.IsControlPlaneMachine(machine) {
-		// redact secrets
-		// NOTE: the position of the key in cluster_scripts/cloud_init is important as the following
-		// code expects the secret to be the first element in write_files.
-		redactedCloudInit, err = redactCloudInit(string(mergedCloudInitBytes), []string{"write_files", "0", "content"})
-		if err != nil {
-			log.Error(err, "failed to redact cloud init script")
-		}
-	}
+	cloudInit := string(mergedCloudInitBytes)
 
-	log.Info(fmt.Sprintf("Cloud init Script: [%s]", redactedCloudInit))
+	log.Info(fmt.Sprintf("Cloud init Script: [%s]", cloudInit))
 	err = capvcdRdeManager.AddToEventSet(ctx, capisdk.CloudInitScriptGenerated, "", machine.Name, "", skipRDEEventUpdates)
 	if err != nil {
 		log.Error(err, "failed to add CloudInitScriptGenerated event into RDE", "rdeID", vcdCluster.Status.InfraId)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- the code to redact the cloud init file is not necessary anymore.
- Redaction was needed when the cloud init script had authentication information for CPI and CSI.
- currently capvcd uses CRS to install CPI and CSI and they are installed separately
- So, Redacting the cloud init script is not needed

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/335)
<!-- Reviewable:end -->
