### PR TITLE
[VCDA-4743] Iterate all machines to compute ready flag (#330)

### DIFF
--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -22,6 +22,8 @@ providers:
     url: "~/go/cluster-api-provider-cloud-director/infrastructure-vcd/v1.0.0/infrastructure-components.yaml"
     type: "InfrastructureProvider"
 
+EXP_CLUSTER_RESOURCE_SET: true
+
 # Variables specific to both "cluster init" and "clusterctl generate"
 VCD_SITE: "https://VCD_FQDN"
 VCD_ORGANIZATION: "test_org"


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- the code to redact the cloud init file is not necessary anymore.
- Redaction was needed when the cloud init script had authentication information for CPI and CSI.
- currently capvcd uses CRS to install CPI and CSI and they are installed separately
- So, Redacting the cloud init script is not needed

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/338)
<!-- Reviewable:end -->
