### PR TITLE
remove containerd proxy config

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -106,26 +106,7 @@ write_files:
     systemctl restart metering
     vmtoolsd --cmd "info-set guestinfo.metering.status successful"
 
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
-    export HTTP_PROXY="{{.HTTPProxy}}"
-    export HTTPS_PROXY="{{.HTTPSProxy}}"
-    export http_proxy="{{.HTTPProxy}}"
-    export https_proxy="{{.HTTPSProxy}}"
-    export NO_PROXY="{{.NoProxy}}"
-    export no_proxy="{{.NoProxy}}"
-    cat <<END > /etc/systemd/system/containerd.service.d/http-proxy.conf
-    [Service]
-    Environment="HTTP_PROXY={{.HTTPProxy}}"
-    Environment="HTTPS_PROXY={{.HTTPSProxy}}"
-    Environment="http_proxy={{.HTTPProxy}}"
-    Environment="https_proxy={{.HTTPSProxy}}"
-    Environment="no_proxy={{.NoProxy}}"
-    Environment="NO_PROXY={{.NoProxy}}"
-    END
-    systemctl daemon-reload
-    systemctl restart containerd
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- if .NvidiaGPU }}
-
+    {{- if .NvidiaGPU }}
     vmtoolsd --cmd "info-set guestinfo.postcustomization.nvidia.runtime.install.status in_progress"
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
     curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -


### PR DESCRIPTION
as we do the containerd proxy config via kubeadm and the build-in config overwrite our own config we have to remove it.

Signed-off-by: Mario Constanti <mario@constanti.de>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/340)
<!-- Reviewable:end -->
