### PR TITLE
VCDA-4777 modify enablement/starting of metering.service (#341)

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -101,9 +101,7 @@ write_files:
     vmtoolsd --cmd "info-set guestinfo.postcustomization.networkconfiguration.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.metering.status in_progress"
-    systemctl enable metering
-    systemctl daemon-reload
-    systemctl restart metering
+    systemctl enable --now metering
     vmtoolsd --cmd "info-set guestinfo.metering.status successful"
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"


### PR DESCRIPTION
(cherry picked from commit 6d1a7d6b69c623952f874db52738fa7e3e37940a)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/342)
<!-- Reviewable:end -->
