### PR TITLE
[VCDA-4786] set username and password as empty strings in clusterctl.yaml

### DIFF
--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -31,8 +31,8 @@ VCD_ORGANIZATION_VDC: "test_ovdc"
 VCD_ORGANIZATION_VDC_NETWORK: "test_ovdc_nw"
 
 # Variables specific to "clusterctl generate" only
-VCD_USERNAME_B64: "vcduser_encoded"
-VCD_PASSWORD_B64: "password_encoded"
+VCD_USERNAME_B64: ""
+VCD_PASSWORD_B64: ""
 VCD_REFRESH_TOKEN_B64: ""
 VCD_CATALOG: "test_catalog"
 VCD_CONTROL_PLANE_SIZING_POLICY: "large_4core16gb"


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request
- set username and password as empty strings in clusterctl.yaml

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/343)
<!-- Reviewable:end -->
