### PR TITLE
[CAFV-81] Modify conversion logic to restore v1beta1 fields using data annotation

### DIFF
--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -1,10 +1,9 @@
 package v1alpha4
 
 import (
-	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
-	"strings"
 )
 
 // ConvertTo converts this (v1alpha4)VCDCluster to the Hub version (v1beta1).
@@ -13,21 +12,30 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	if err := Convert_v1alpha4_VCDCluster_To_v1beta1_VCDCluster(src, dst, nil); err != nil {
 		return err
 	}
-	dst.Spec.ProxyConfigSpec = v1beta1.ProxyConfig{}
+
+	// manually restore data
+	restored := v1beta1.VCDCluster{}
+	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+		return err
+	}
+	dst.Spec.ProxyConfigSpec = restored.Spec.ProxyConfigSpec
 	// TODO: Update the new params to match previous release's Status; ex) dst.Spec.* = src.Status.*, maybe RDE.Status
 	dst.Spec.RDEId = src.Status.InfraId
-	dst.Spec.ParentUID = ""
-	dst.Spec.UseAsManagementCluster = false // defaults to false
-	if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {
-		dst.Status.RdeVersionInUse = vcdsdk.NoRdePrefix
-	} else {
-		dst.Status.RdeVersionInUse = "1.0.0" // value will be checked by vcdcluster controller if RDE upgrade is necessary
-	}
+	dst.Spec.ParentUID = restored.Spec.ParentUID
+	dst.Spec.UseAsManagementCluster = restored.Spec.UseAsManagementCluster // defaults to false
+	//if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {
+	//	dst.Status.RdeVersionInUse = vcdsdk.NoRdePrefix
+	//} else {
+	//	dst.Status.RdeVersionInUse = "1.0.0" // value will be checked by vcdcluster controller if RDE upgrade is necessary
+	//}
+	dst.Status.RdeVersionInUse = restored.Status.RdeVersionInUse
 
 	// In v1alpha4 DNAT rules (and one-arm) are used by default. Therefore, use that in v1beta1
-	dst.Spec.LoadBalancerConfigSpec.UseOneArm = true
+	//dst.Spec.LoadBalancerConfigSpec.UseOneArm = true
+	dst.Spec.LoadBalancerConfigSpec.UseOneArm = restored.Spec.LoadBalancerConfigSpec.UseOneArm
 
-	dst.Spec.LoadBalancerConfigSpec.VipSubnet = ""
+	//dst.Spec.LoadBalancerConfigSpec.VipSubnet = ""
+	dst.Spec.LoadBalancerConfigSpec.VipSubnet = restored.Spec.LoadBalancerConfigSpec.VipSubnet
 	return nil
 }
 
@@ -37,7 +45,7 @@ func (dst *VCDCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1beta1_VCDCluster_To_v1alpha4_VCDCluster(src, dst, nil); err != nil {
 		return err
 	}
-	return nil
+	return utilconversion.MarshalData(src, dst)
 }
 
 // ConvertTo converts this VCDClusterList to the Hub version (v1beta1).

--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -1,9 +1,11 @@
 package v1alpha4
 
 import (
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
 	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
+	"strings"
 )
 
 // ConvertTo converts this (v1alpha4)VCDCluster to the Hub version (v1beta1).
@@ -12,29 +14,31 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	if err := Convert_v1alpha4_VCDCluster_To_v1beta1_VCDCluster(src, dst, nil); err != nil {
 		return err
 	}
+	// there is a possibility that the older version (v1alpha4) won't have the "cluster.x-k8s.io/conversion-data" annotation.
+	// so use the src object to recover fields which are necessary in the new version
+	dst.Spec.RDEId = src.Status.InfraId
+	if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {
+		dst.Status.RdeVersionInUse = vcdsdk.NoRdePrefix
+	} else {
+		dst.Status.RdeVersionInUse = "1.0.0" // value will be checked by vcdcluster controller if RDE upgrade is necessary
+	}
+	// In v1alpha4 DNAT rules (and one-arm) are used by default. Therefore, use that in v1beta1
+	dst.Spec.LoadBalancerConfigSpec.UseOneArm = true
 
 	// manually restore data
 	restored := v1beta1.VCDCluster{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
 		return err
 	}
+
+	// restore all the fields, even those which were derived using the src object, using the "cluster.x-k8s.io/conversion-data" annotation
+	dst.Spec.RDEId = restored.Spec.RDEId
+	dst.Status.RdeVersionInUse = restored.Status.RdeVersionInUse
 	dst.Spec.ProxyConfigSpec = restored.Spec.ProxyConfigSpec
-	// TODO: Update the new params to match previous release's Status; ex) dst.Spec.* = src.Status.*, maybe RDE.Status
-	dst.Spec.RDEId = src.Status.InfraId
 	dst.Spec.ParentUID = restored.Spec.ParentUID
 	dst.Spec.UseAsManagementCluster = restored.Spec.UseAsManagementCluster // defaults to false
-	//if strings.HasPrefix(src.Status.InfraId, vcdsdk.NoRdePrefix) {
-	//	dst.Status.RdeVersionInUse = vcdsdk.NoRdePrefix
-	//} else {
-	//	dst.Status.RdeVersionInUse = "1.0.0" // value will be checked by vcdcluster controller if RDE upgrade is necessary
-	//}
 	dst.Status.RdeVersionInUse = restored.Status.RdeVersionInUse
-
-	// In v1alpha4 DNAT rules (and one-arm) are used by default. Therefore, use that in v1beta1
-	//dst.Spec.LoadBalancerConfigSpec.UseOneArm = true
 	dst.Spec.LoadBalancerConfigSpec.UseOneArm = restored.Spec.LoadBalancerConfigSpec.UseOneArm
-
-	//dst.Spec.LoadBalancerConfigSpec.VipSubnet = ""
 	dst.Spec.LoadBalancerConfigSpec.VipSubnet = restored.Spec.LoadBalancerConfigSpec.VipSubnet
 	return nil
 }
@@ -45,6 +49,7 @@ func (dst *VCDCluster) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1beta1_VCDCluster_To_v1alpha4_VCDCluster(src, dst, nil); err != nil {
 		return err
 	}
+	// add annotation "cluster.x-k8s.io/conversion-data" and return
 	return utilconversion.MarshalData(src, dst)
 }
 

--- a/api/v1alpha4/vcdcluster_conversion.go
+++ b/api/v1alpha4/vcdcluster_conversion.go
@@ -28,10 +28,13 @@ func (src *VCDCluster) ConvertTo(dstRaw conversion.Hub) error {
 	// manually restore data
 	restored := v1beta1.VCDCluster{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+		// in the case of missing v1beta1 annotation, the return value of UnmarshalData() would be (false, nil)
+		// so the return value would be nil NOT err
 		return err
 	}
 
 	// restore all the fields, even those which were derived using the src object, using the "cluster.x-k8s.io/conversion-data" annotation
+	// Also note that dst and restored are of the same type
 	dst.Spec.RDEId = restored.Spec.RDEId
 	dst.Status.RdeVersionInUse = restored.Status.RdeVersionInUse
 	dst.Spec.ProxyConfigSpec = restored.Spec.ProxyConfigSpec

--- a/api/v1alpha4/vcdmachine_conversion.go
+++ b/api/v1alpha4/vcdmachine_conversion.go
@@ -21,10 +21,13 @@ func (src *VCDMachine) ConvertTo(dstRaw conversion.Hub) error {
 	// manually restore data
 	restored := v1beta1.VCDMachine{}
 	if ok, err := utilconversion.UnmarshalData(src, restored); err != nil || !ok {
+		// in the case of missing v1beta1 annotation, the return value of UnmarshalData() would be (false, nil)
+		// so the return value would be nil NOT err
 		return err
 	}
 
 	// restore all the fields, even those which were derived using the src object, using the "cluster.x-k8s.io/conversion-data" annotation
+	// Also note that dst and restored are of the same type
 	dst.Spec.SizingPolicy = restored.Spec.SizingPolicy
 	dst.Spec.StorageProfile = restored.Spec.StorageProfile
 	dst.Status.Template = restored.Status.Template

--- a/api/v1alpha4/vcdmachinetemplate_conversion.go
+++ b/api/v1alpha4/vcdmachinetemplate_conversion.go
@@ -23,6 +23,7 @@ func (dst *VCDMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1beta1_VCDMachineTemplate_To_v1alpha4_VCDMachineTemplate(src, dst, nil); err != nil {
 		return err
 	}
+	// add annotation "cluster.x-k8s.io/conversion-data" and return
 	return utilconversion.MarshalData(src, dst)
 }
 

--- a/api/v1alpha4/vcdmachinetemplate_conversion.go
+++ b/api/v1alpha4/vcdmachinetemplate_conversion.go
@@ -3,6 +3,7 @@ package v1alpha4
 import (
 	//"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
 	"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
+	utilconversion "sigs.k8s.io/cluster-api/util/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 
@@ -22,7 +23,7 @@ func (dst *VCDMachineTemplate) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := Convert_v1beta1_VCDMachineTemplate_To_v1alpha4_VCDMachineTemplate(src, dst, nil); err != nil {
 		return err
 	}
-	return nil
+	return utilconversion.MarshalData(src, dst)
 }
 
 // ConvertTo converts this VCDClusterList to the Hub version (v1beta1).


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add conversion logic to restore newly created fields using data annotation.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [x] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [x] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes # https://github.com/vmware/cluster-api-provider-cloud-director/issues/355

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/367)
<!-- Reviewable:end -->
