### PR TITLE
[CAFV-125] Update common core to commit bf93908 to prevent CAPVCD from crashing …

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -1076,7 +1076,7 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			// 2. If vcdmachine controller picks up first, then it would update the LB according to vcdCluster.Spec.ControlPlaneEndpoint.Host.
 			// Hence, we are deciding to pass externalIp="" in this case, as UpdateVirtualService() would see it's an empty string, so it would just update the VS Object with what's already present.
 			// Users should not be updating control plane IP after it has been created, so this is not a valid use case.
-			// TODO: VCDA-5080 - In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
+			// TODO: CAFV-143 - In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
 			_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedIPs,
 				"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 				oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -619,7 +619,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 		// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
 		_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedUniqueIPs,
-			int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
+			vcdCluster.Spec.ControlPlaneEndpoint.Host, int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 			oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)
 		if err != nil {
 			updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDMachineCreationError, "", machine.Name, fmt.Sprintf("%v", err))
@@ -1064,8 +1064,9 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			}
 
 			// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
+			// If user specified a specific IP to use for Control Plane, we should pass vcdCluster.Spec.ControlPlaneEndpoint.Host as the externalIP when updating LB.
 			_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedIPs,
-				int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
+				vcdCluster.Spec.ControlPlaneEndpoint.Host, int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 				oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)
 			if err != nil {
 				updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.LoadBalancerError, "", machine.Name, fmt.Sprintf("%v", err))

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -623,7 +623,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		// 2. If vcdmachine controller picks up first, then it would update the LB according to vcdCluster.Spec.ControlPlaneEndpoint.Host.
 		// We are deciding to pass externalIp="" in this case, as UpdateVirtualService() would see it's an empty string, so it would just update the VS Object with what's already present.
 		// Users should not be updating control plane IP after it has been created, so this is not a valid use case.
-		// TODO: In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
+		// TODO: CAFV-143 In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
 		_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedUniqueIPs,
 			"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 			oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -618,8 +618,10 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 
 		// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
+		// Because vcdcluster_controller will get the existing virtual service IP, it will overwrite with that each time.
+		// So we are currently passing in an empty string as externalIP to UpdateLoadBalancer() as we are not updating the virtual service IP.
 		_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedUniqueIPs,
-			vcdCluster.Spec.ControlPlaneEndpoint.Host, int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
+			"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 			oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)
 		if err != nil {
 			updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDMachineCreationError, "", machine.Name, fmt.Sprintf("%v", err))
@@ -1064,9 +1066,10 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			}
 
 			// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
-			// If user specified a specific IP to use for Control Plane, we should pass vcdCluster.Spec.ControlPlaneEndpoint.Host as the externalIP when updating LB.
+			// Because vcdcluster_controller will get the existing virtual service IP, it will overwrite with that each time.
+			// So we are currently passing in an empty string as externalIP as we are not updating the virtual service IP.
 			_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedIPs,
-				vcdCluster.Spec.ControlPlaneEndpoint.Host, int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
+				"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 				oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)
 			if err != nil {
 				updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.LoadBalancerError, "", machine.Name, fmt.Sprintf("%v", err))

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -618,8 +618,12 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 
 		// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
-		// Because vcdcluster_controller will get the existing virtual service IP, it will overwrite with that each time.
-		// So we are currently passing in an empty string as externalIP to UpdateLoadBalancer() as we are not updating the virtual service IP.
+		// We are not using externalIp=vcdCluster.Spec.ControlPlaneEndpoint.Host because of a possible race between which controller picks ups according to the spec.
+		// 1. If vcdcluster controller picks up vcdCluster.Spec.ControlPlaneEndpoint.Host, there is no issue as it will retrieve it from existing VCD VirtualService.
+		// 2. If vcdmachine controller picks up first, then it would update the LB according to vcdCluster.Spec.ControlPlaneEndpoint.Host.
+		// We are deciding to pass externalIp="" in this case, as UpdateVirtualService() would see it's an empty string, so it would just update the VS Object with what's already present.
+		// Users should not be updating control plane IP after it has been created, so this is not a valid use case.
+		// TODO: In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
 		_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedUniqueIPs,
 			"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 			oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)
@@ -1066,8 +1070,13 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 			}
 
 			// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
-			// Because vcdcluster_controller will get the existing virtual service IP, it will overwrite with that each time.
-			// So we are currently passing in an empty string as externalIP as we are not updating the virtual service IP.
+			// At this point the vcdCluster.Spec.ControlPlaneEndpoint should have been set correctly.
+			// We are not using externalIp=vcdCluster.Spec.ControlPlaneEndpoint.Host because of a possible race between which controller picks ups according to the spec.
+			// 1. If vcdcluster controller picks up vcdCluster.Spec.ControlPlaneEndpoint.Host, there is no issue as it will retrieve it from existing VCD VirtualService.
+			// 2. If vcdmachine controller picks up first, then it would update the LB according to vcdCluster.Spec.ControlPlaneEndpoint.Host.
+			// Hence, we are deciding to pass externalIp="" in this case, as UpdateVirtualService() would see it's an empty string, so it would just update the VS Object with what's already present.
+			// Users should not be updating control plane IP after it has been created, so this is not a valid use case.
+			// TODO: VCDA-5080 - In the the future, ideally we should add ControlPlaneEndpoint.Host, ControlPlaneEndpoint.Port into VCDClusterStatus, and pass externalIp=vcdCluster.Status.ControlPlaneEndpoint.Host instead
 			_, err = gateway.UpdateLoadBalancer(ctx, lbPoolName, virtualServiceName, updatedIPs,
 				"", int32(vcdCluster.Spec.ControlPlaneEndpoint.Port), int32(vcdCluster.Spec.ControlPlaneEndpoint.Port),
 				oneArm, !vcdCluster.Spec.LoadBalancerConfigSpec.UseOneArm, "TCP", resourcesAllocated)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221104192532-8946fef8b046
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230105201324-bf93908b793c
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	go.uber.org/zap v1.19.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221104192532-8946fef8b046 h1:TwEvefDIIQLpdrulehmUGNk4fxga8mEfQQjk92GAc4g=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221104192532-8946fef8b046/go.mod h1:E7pd/SaAz3M2PGN0T9BbByiwGia4SSJ7+cNZkpE6f60=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230105201324-bf93908b793c h1:jUK1PPLhBfXcLh6FFrCsQ5n7OBe35R+ZCP+RVRRfIPM=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230105201324-bf93908b793c/go.mod h1:HTrbzJ/Alt4T79LWz5YTZYdHO2VIRCA7pdfhGoHQb3Q=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/ipam.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/ipam.go
@@ -57,6 +57,11 @@ func (gm *GatewayManager) GetUnusedExternalIPAddress(ctx context.Context, allowe
 
 	ipRangeList := make([]IPRange, 0)
 	for _, edgeGWUplink := range edgeGW.EdgeGatewayUplinks {
+		// A nil check is needed for edgeGWUplink.Subnet because there is a possibility for subnet to be null which can cause CCM pod to crash.
+		// An example is the usage of IP Spaces which is in VCD 10.4.1.
+		if edgeGWUplink.Subnets == nil {
+			continue
+		}
 		for _, subnet := range edgeGWUplink.Subnets.Values {
 			if subnet.IpRanges == nil {
 				continue

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/vapp.go
@@ -29,8 +29,8 @@ const (
 )
 
 var (
-	trueVar     = true
-	falseVar    = false
+	trueVar  = true
+	falseVar = false
 )
 
 type VdcManager struct {
@@ -346,6 +346,11 @@ func (vdc *VdcManager) FindVMByUUID(VAppName string, vcdVmUUID string) (*govcd.V
 
 	vm, err := vApp.GetVMById(vmUUID, true)
 	if err != nil {
+		// CPI uses this function via vminfocache which finds VmInfo by using GetByUUID() which calls FindVMByUUID().
+		// In CPI, we are handling ErrorEntityNotFound case, but we were not returning it so it skipped this case causing nodes to not get deleted as it was not found.
+		if err == govcd.ErrorEntityNotFound {
+			return nil, govcd.ErrorEntityNotFound
+		}
 		return nil, fmt.Errorf("unable to find vm UUID [%s] in vApp [%s]: [%v]",
 			vmUUID, VAppName, err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,7 +241,7 @@ github.com/prometheus/procfs/internal/util
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.2
 ## explicit; go 1.13
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20221104192532-8946fef8b046
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230105201324-bf93908b793c
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk


### PR DESCRIPTION
…when using IP Spaces

Signed-off-by: lzichong <lzichong@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Common core update for CAPVCD – where UpdateLoadBalancer() introduced a new param as a result of allowing specifying IP in CPI

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/372)
<!-- Reviewable:end -->
