### PR TITLE
[CAFV-130] add health check failed event to RDE when MHC fails

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -339,7 +339,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if conditions.IsFalse(machine, clusterv1.MachineHealthCheckSucceededCondition) {
 		err := capvcdRdeManager.AddToEventSet(ctx, capisdk.MachineHealthCheckFailed, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineHealthCheckSucceededCondition), false)
 		if err != nil {
-			log.Error(err, "failed to add HealthCheckFailedEvent event into RDE", "rdeID", vcdCluster.Status.InfraId)
+			log.Error(err, "failed to add VcdMachineHealthCheckFailedEvent event into RDE", "rdeID", vcdCluster.Status.InfraId)
 		}
 	}
 	if vcdMachine.Spec.ProviderID != nil && vcdMachine.Status.ProviderID != nil {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -309,6 +309,14 @@ func (r *VCDMachineReconciler) waitForPostCustomizationPhase(ctx context.Context
 
 }
 
+// getVMIDFromProviderID returns VMID from the provider ID if providerID is not nil. If the providerID is nil, empty string is returned as providerID.
+func getVMIDFromProviderID(providerID *string) string {
+	if providerID == nil {
+		return ""
+	}
+	return strings.TrimPrefix("vmware-cloud-director://", *providerID)
+}
+
 func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clusterv1.Cluster,
 	machine *clusterv1.Machine, vcdMachine *infrav1.VCDMachine, vcdCluster *infrav1.VCDCluster) (res ctrl.Result, retErr error) {
 
@@ -326,7 +334,14 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "Unable to create VCD client to reconcile infrastructure for the Machine [%s]", machine.Name)
 	}
+
 	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
+	if conditions.IsFalse(machine, clusterv1.MachineHealthCheckSucceededCondition) {
+		err := capvcdRdeManager.AddToEventSet(ctx, capisdk.MachineHealthCheckFailed, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineHealthCheckSucceededCondition), false)
+		if err != nil {
+			log.Error(err, "failed to add HealthCheckFailedEvent event into RDE", "rdeID", vcdCluster.Status.InfraId)
+		}
+	}
 	if vcdMachine.Spec.ProviderID != nil && vcdMachine.Status.ProviderID != nil {
 		vcdMachine.Status.Ready = true
 		conditions.MarkTrue(vcdMachine, ContainerProvisionedCondition)

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -337,7 +337,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
 	if conditions.IsFalse(machine, clusterv1.MachineHealthCheckSucceededCondition) {
-		err := capvcdRdeManager.AddToEventSet(ctx, capisdk.MachineHealthCheckFailed, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineHealthCheckSucceededCondition), false)
+		err := capvcdRdeManager.AddToEventSet(ctx, capisdk.NodeHealthCheckFailed, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineHealthCheckSucceededCondition), false)
 		if err != nil {
 			log.Error(err, "failed to add VcdMachineHealthCheckFailedEvent event into RDE", "rdeID", vcdCluster.Status.InfraId)
 		}

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -60,7 +60,7 @@ const (
 	CloudInitScriptGenerated = "VcdMachineBootstrapScriptGenerated"
 	InfraVmBootstrapped      = "VcdMachineBootstrapped"
 	InfraVmDeleted           = "VcdMachineInfraVmDeleted"
-	MachineHealthCheckFailed = "HealthCheckFailedEvent"
+	MachineHealthCheckFailed = "VcdMachineHealthCheckFailedEvent"
 
 	// VCDMachine Errors
 	// Set VCDMachineScriptGenerationError for any errors that occurs during the process of generating and setting the script on the VM

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -60,7 +60,7 @@ const (
 	CloudInitScriptGenerated = "VcdMachineBootstrapScriptGenerated"
 	InfraVmBootstrapped      = "VcdMachineBootstrapped"
 	InfraVmDeleted           = "VcdMachineInfraVmDeleted"
-	MachineHealthCheckFailed = "VcdMachineHealthCheckFailedEvent"
+	NodeHealthCheckFailed    = "VcdMachineHealthCheckFailedEvent"
 
 	// VCDMachine Errors
 	// Set VCDMachineScriptGenerationError for any errors that occurs during the process of generating and setting the script on the VM

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -60,6 +60,7 @@ const (
 	CloudInitScriptGenerated = "VcdMachineBootstrapScriptGenerated"
 	InfraVmBootstrapped      = "VcdMachineBootstrapped"
 	InfraVmDeleted           = "VcdMachineInfraVmDeleted"
+	MachineHealthCheckFailed = "HealthCheckFailedEvent"
 
 	// VCDMachine Errors
 	// Set VCDMachineScriptGenerationError for any errors that occurs during the process of generating and setting the script on the VM


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Added an event HealthCheckFailedEvent
- Will be added to the RDE when Health Check for a machine in the cluster fails.
- Tested with and without MHC enabled
Sample event from the UI:
<img width="870" alt="Screen Shot 2023-01-23 at 4 22 18 PM" src="https://user-images.githubusercontent.com/16699642/214184336-7a658749-f522-47be-8b18-cc4edfac405c.png">


## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/373)
<!-- Reviewable:end -->
