### PR TITLE
[CAFV-158] Add node unhealthy event to the RDE

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -317,8 +317,7 @@ func getVMIDFromProviderID(providerID *string) string {
 	if providerID == nil {
 		return ""
 	}
-	x := strings.TrimPrefix(*providerID, "vmware-cloud-director://", )
-	return x
+	return strings.TrimPrefix(*providerID, "vmware-cloud-director://")
 }
 
 // checkIfMachineNodeIsUnhealthy returns true if the Node associated with the Machine is regarded as unhealthy, and false otherwise.

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -317,7 +317,8 @@ func getVMIDFromProviderID(providerID *string) string {
 	if providerID == nil {
 		return ""
 	}
-	return strings.TrimPrefix("vmware-cloud-director://", *providerID)
+	x := strings.TrimPrefix(*providerID, "vmware-cloud-director://", )
+	return x
 }
 
 // checkIfMachineNodeIsUnhealthy returns true if the Node associated with the Machine is regarded as unhealthy, and false otherwise.

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -61,6 +61,7 @@ const (
 	InfraVmBootstrapped      = "VcdMachineBootstrapped"
 	InfraVmDeleted           = "VcdMachineInfraVmDeleted"
 	NodeHealthCheckFailed    = "VcdMachineHealthCheckFailedEvent"
+	NodeUnhealthy            = "VcdMachineNodeUnhealthy"
 
 	// VCDMachine Errors
 	// Set VCDMachineScriptGenerationError for any errors that occurs during the process of generating and setting the script on the VM


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Node unhealthiness should be posted as an event to the RDE when CAPVCD detects that the node is unhealthy
- NodeUnhealthy event should NOT be generated when the node is being provisioned.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/377)
<!-- Reviewable:end -->
