### PR TITLE
[CAFV-24] Open up the RDE 1.2 upgrade path and write the converter from RDE 1.1.0 to RDE 1.2.0

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_2_0"
 	"net/http"
 	"os"
 	"reflect"
@@ -25,7 +26,6 @@ import (
 	infrav1 "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta1"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/capisdk"
 	vcdutil "github.com/vmware/cluster-api-provider-cloud-director/pkg/util"
-	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
 	"github.com/vmware/cluster-api-provider-cloud-director/release"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
@@ -725,6 +725,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 					"obtained nil org when getting org by name [%s]", workloadVCDClient.ClusterOrgName)
 			}
 			// the following api call will return an empty list if there are no entities with the same name as the cluster
+			// Todo: add capvcdRDEMajor Version
 			definedEntities, resp, err := workloadVCDClient.APIClient.DefinedEntityApi.GetDefinedEntitiesByEntityType(ctx,
 				capisdk.CAPVCDTypeVendor, capisdk.CAPVCDTypeNss, rdeType.CapvcdRDETypeVersion, org.Org.ID, 1, 25, nameFilter)
 			if err != nil {

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
 	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/util"
 	"github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_0_0"
-	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
+	"github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
+	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_2_0"
 	"github.com/vmware/cluster-api-provider-cloud-director/release"
 	"k8s.io/klog"
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -24,9 +27,10 @@ const (
 
 	StatusComponentNameCAPVCD = "cluster-api-provider-cloud-director"
 
-	CAPVCDTypeVendor       = "vmware"
-	CAPVCDTypeNss          = "capvcdCluster"
-	CAPVCDEntityTypePrefix = "urn:vcloud:type:vmware:capvcdCluster"
+	CAPVCDTypeVendor                    = "vmware"
+	CAPVCDTypeNss                       = "capvcdCluster"
+	CAPVCDEntityTypePrefix              = "urn:vcloud:type:vmware:capvcdCluster"
+	CAPVCDEntityTypeDefaultMajorVersion = "1"
 
 	CAPVCDClusterKind             = "CAPVCDCluster"
 	CAPVCDClusterEntityApiVersion = "capvcd.vmware.com/v1.1"
@@ -85,7 +89,7 @@ var (
 	sectionsInStatusRetainedDuringRDEUpgrade = []string{
 		"persistentVolumes",
 		"virtualIPs",
-		"vkp",
+		"vcdKe",
 		"cpi",
 		"csi",
 	}
@@ -352,6 +356,126 @@ func (capvcdRdeManager *CapvcdRdeManager) IsCapvcdEntityTypeRegistered(version s
 	return true
 }
 
+// convertFrom110Format provides an automatic conversion from RDE Version 1.1.0 to the latest RDE Version in use
+// Get the srcCapvcdEntity according to RDE ID.
+// Examine the existence of capiYaml entity in srcCapvcdEntity.entity.spec. Clean up the capiYaml inside srcCapvcdEntity. Capvcd will update capiYaml using the latest vcdCluster Status
+// Provide an automatic conversion of the content in srcCapvcdEntity.entity.status.capvcd content to the latest RDE version format (rdeType.CAPVCDStatus)
+// Add the placeholder for any special conversion logic inside rdeType.CAPVCDStatus (for developers)
+// Updates the srcCapvcdEntity.entityType Id to the latest ENtitytype Version in use
+// Call an API call (PUT) to update CAPVCD entity and persist data into VCD
+// Return dstCapvcdEntity as output. VCD-KE do RDE acquire on dstCapvcdEntit in the parent method AcquireRDEWithClient()
+func (capvcdRdeManager *CapvcdRdeManager) convertFrom110Format(ctx context.Context, srcRde *swagger.DefinedEntity, srcRdeTypeVersion string) (*swagger.DefinedEntity, error) {
+	if srcRdeTypeVersion == rdeType.CapvcdRDETypeVersion {
+		klog.V(4).Infof("RDE [%s] is already upgraded to version [%s]", srcRde.Id, rdeType.CapvcdRDETypeVersion)
+		return srcRde, nil
+	}
+	if capvcdRdeManager.Client == nil {
+		return nil, fmt.Errorf("obtained nil VCD Client while upgrading RDE [%s(%s)] from Version [%s] to Version [%s]",
+			srcRde.Name, srcRde.Id, rde_type_1_1_0.CapvcdRDETypeVersion, rdeType.CapvcdRDETypeVersion)
+	}
+	org, err := capvcdRdeManager.Client.VCDClient.GetOrgByName(capvcdRdeManager.Client.ClusterOrgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the org [%s] while upgrading RDE [%s(%s)] from Version [%s] to Version [%s]: [%v]", capvcdRdeManager.Client.ClusterOrgName,
+			srcRde.Name, srcRde.Id, rde_type_1_1_0.CapvcdRDETypeVersion, rdeType.CapvcdRDETypeVersion, err)
+	}
+	if org == nil || org.Org == nil {
+		return nil, fmt.Errorf("obtained nil org [%s] while upgrading RDE [%s(%s)] from Version [%s] to Version [%s]", capvcdRdeManager.Client.ClusterOrgName,
+			srcRde.Name, srcRde.Id, rde_type_1_1_0.CapvcdRDETypeVersion, rdeType.CapvcdRDETypeVersion)
+	}
+	for retries := 0; retries < MaxUpdateRetries; retries++ {
+		srcCapvcdEntity, resp, etag, err := capvcdRdeManager.Client.APIClient.DefinedEntityApi.GetDefinedEntity(ctx, srcRde.Id, org.Org.ID)
+		if err != nil {
+			var responseMessageBytes []byte
+			if gsErr, ok := err.(swagger.GenericSwaggerError); ok {
+				responseMessageBytes = gsErr.Body()
+				klog.Errorf("error occurred when upgrading defined entity [%s] to version [%s]: [%s]",
+					srcRde.Id, rdeType.CapvcdRDETypeVersion, string(responseMessageBytes))
+			}
+			return nil, fmt.Errorf("failed to get the defined entity to convert RDE to version [%s]", rdeType.CapvcdRDETypeVersion)
+		} else if resp == nil {
+			return nil, fmt.Errorf("unexpected response when fetching the defined entity [%s] to version [%s]; obtained nil response",
+				srcRde.Id, rdeType.CapvcdRDETypeVersion)
+		} else {
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("obtained unexpected response status code [%d] when fetching the defined entity [%s]. expected [%d]",
+					resp.StatusCode, srcRde.Id, http.StatusOK)
+			}
+		}
+		// ******************  clean up spec.capiYaml content  ******************
+		// eventually updated by CAPVCD in parent method reconcileRDE()
+		srcEntitySpecIf, srcEntitySpecOk := srcCapvcdEntity.Entity["spec"]
+		if !srcEntitySpecOk {
+			return nil, fmt.Errorf("failed to find entity Spec from cluster [%s(%s)]", srcCapvcdEntity.Name, srcCapvcdEntity.Id)
+		}
+		srcSpecMapIf, srcSpecMapOk := srcEntitySpecIf.(map[string]interface{})
+		if !srcSpecMapOk {
+			return nil, fmt.Errorf("failed to convert RDE [%s(%s)] Spec from [%T] to map[string]interface{}",
+				srcCapvcdEntity.Name, srcCapvcdEntity.Id, srcEntitySpecIf)
+		}
+		_, srcEntityCapiYamlOk := srcSpecMapIf["capiYaml"]
+		if !srcEntityCapiYamlOk {
+			return nil, fmt.Errorf("failed to find entity capiYaml from cluster [%s(%s)]", srcCapvcdEntity.Name, srcCapvcdEntity.Id)
+		}
+		srcSpecMapIf["capiYaml"] = ""
+
+		var newStatusMap map[string]interface{}
+		newStatusMap = nil
+		// ******************  upgrade status.capvcd  ******************
+		if srcEntityStatusIf, srcStatusOk := srcCapvcdEntity.Entity["status"]; srcStatusOk {
+			if srcStatusMapIf, srcStatusMapOk := srcEntityStatusIf.(map[string]interface{}); srcStatusMapOk {
+				newStatusMap = srcStatusMapIf
+				if srcEntityCAPVCDStatusIf, srcCAPVCDStatusEntityOk := srcStatusMapIf["capvcd"]; srcCAPVCDStatusEntityOk {
+					if srcCAPVCDStatusMapIf, srcCAPVCDStatusMapOk := srcEntityCAPVCDStatusIf.(map[string]interface{}); srcCAPVCDStatusMapOk {
+						CAPVCDStatus, err := util.ConvertMapToCAPVCDStatus(srcCAPVCDStatusMapIf)
+						if err != nil {
+							return nil, fmt.Errorf("failed to convert RDE [%s(%s)] CAPVCD status map [%T] to CAPVCDStatus: [%v]", srcCapvcdEntity.Name, srcCapvcdEntity.Id, srcCAPVCDStatusMapIf, err)
+						}
+						// ******************  placeHolder: add any special conversion logic for CAPVCDStatus  ******************
+						// For example the latest CAPVCDStatus has a property: "PropertyToBeAdded" while old map "srcCAPVCDStatusMap" does not have the property
+						// Developers should set default value here: CAPVCDStatus.PropertyToBeAdded = true
+						dstCAPVCDStatusMap, err := util.ConvertCAPVCDStatusToMap(CAPVCDStatus)
+						if err != nil {
+							return nil, fmt.Errorf("failed to convert upgraded RDE [%s(%s)] CAPVCD Status from [%T] to map[string]interface{}", srcCapvcdEntity.Name, srcCapvcdEntity.Id, CAPVCDStatus)
+						}
+						newStatusMap["capvcd"] = dstCAPVCDStatusMap
+					}
+				}
+			}
+		}
+		if newStatusMap != nil {
+			srcCapvcdEntity.Entity["status"] = newStatusMap
+		}
+		updatedRde, resp, err := capvcdRdeManager.Client.APIClient.DefinedEntityApi.UpdateDefinedEntity(
+			ctx, srcCapvcdEntity, etag, srcRde.Id, org.Org.ID, nil)
+		if err != nil {
+			var responseMessageBytes []byte
+			if gsErr, ok := err.(swagger.GenericSwaggerError); ok {
+				responseMessageBytes = gsErr.Body()
+				klog.V(5).Infof("error occurred when upgrading defined entity [%s(%s)] from version [%s] to version [%s]: [%s]",
+					srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion, string(responseMessageBytes))
+			}
+			return nil, fmt.Errorf("error when upgrading defined entity [%s(%s)] from EntityType Version [%s] to EntityType Version [%s]: [%v]",
+				srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion, err)
+		} else if resp == nil {
+			return nil, fmt.Errorf("unexpected response when upgrading defined entity [%s(%s)] from EntityType Version [%s] to EntityType Version [%s]; obtained nil response",
+				srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion)
+		} else {
+			if resp.StatusCode == http.StatusPreconditionFailed {
+				klog.V(5).Infof("wrong etag [%s] while upgrading the defined entity [%s(%s)] from EntityType Version [%s] to EntityType Version [%s]. Retries remaining: [%d]",
+					etag, srcRde.Name, srcRde.Id, srcRdeTypeVersion, MaxUpdateRetries-retries-1)
+				continue
+			} else if resp.StatusCode != http.StatusOK {
+				klog.Errorf("unexpected response status code when upgrading defined entity [%s(%s)] from EntityType Version [%s] to EntityType Version [%s]. Expected response [%d] obtained [%d]",
+					srcRde.Name, srcRde.Id, srcRdeTypeVersion, http.StatusOK, resp.StatusCode)
+				continue
+			}
+		}
+		klog.V(4).Infof("successfully upgraded RDE [%s(%s)] from EntityType Version [%s] to EntityType Version [%s]", srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion)
+		return &updatedRde, nil
+	}
+	return nil, fmt.Errorf("failed to upgrade RDE [%s(%s)] from EntityType Version [%s] to EntityType Version [%s] after [%d] retries",
+		srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion, MaxUpdateRetries)
+}
 func (capvcdRdeManager *CapvcdRdeManager) convertFrom100Format(ctx context.Context, srcRde *swagger.DefinedEntity, srcRdeTypeVersion string) (*swagger.DefinedEntity, error) {
 	if srcRdeTypeVersion == rdeType.CapvcdRDETypeVersion {
 		klog.V(4).Infof("RDE [%s] is already upgraded to version [%s]", srcRde.Id, rdeType.CapvcdRDETypeVersion)
@@ -458,6 +582,7 @@ func (capvcdRdeManager *CapvcdRdeManager) convertFrom100Format(ctx context.Conte
 
 // ConvertToLatestRDEVersionFormat updates the RDE version. The upgraded RDE will only contain minimal information related to the cluster after upgrade.
 //  CAPVCD will reconcile the RDE eventually with proper data by CAPVCD.
+// Invokes the right converter to convert the srcRDE into the format of latest RDE version in use
 //  The function attempts upgrade multiple times as defined by MaxUpdateRetries to avoid failures due to incorrect ETag.
 // 	"entity.status.persistentVolumes" and "entity.status.virtualIPs" in the existing RDE will be retained in the upgraded RDE.
 func (capvcdRdeManager *CapvcdRdeManager) ConvertToLatestRDEVersionFormat(ctx context.Context, rdeID string) (*swagger.DefinedEntity, error) {
@@ -468,13 +593,22 @@ func (capvcdRdeManager *CapvcdRdeManager) ConvertToLatestRDEVersionFormat(ctx co
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch RDE type version for RDE [%s]", rdeID)
 	}
-
+	entityTypeSemVer, err := semver.New(srcRdeTypeVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing entityType version [%s] of RDE [%s(%s)]: [%v]",
+			srcRdeTypeVersion, srcRde.Name, srcRde.Id, err)
+	}
 	var dstRde *swagger.DefinedEntity
+	if strconv.Itoa(int(entityTypeSemVer.Major)) != CAPVCDEntityTypeDefaultMajorVersion {
+		return nil, fmt.Errorf("failed to upgrade RDE [%s(%s)] to version [%s]; invalid source RDE version [%s]", srcRde.Name, srcRde.Id, rdeType.CapvcdRDETypeVersion, srcRdeTypeVersion)
+	}
 	switch srcRdeTypeVersion {
 	case rde_type_1_0_0.CapvcdRDETypeVersion:
 		dstRde, err = capvcdRdeManager.convertFrom100Format(ctx, srcRde, srcRdeTypeVersion)
+	case rde_type_1_1_0.CapvcdRDETypeVersion:
+		dstRde, err = capvcdRdeManager.convertFrom110Format(ctx, srcRde, srcRdeTypeVersion)
 	default:
-		err = fmt.Errorf("failed to upgrade RDE [%s]; invalid source RDE version [%s]", rdeID, srcRdeTypeVersion)
+		klog.V(3).Infof("CAPVCD does not support RDE [%s(%s)] upgrade from source version [%s] to version [%s]", srcRde.Name, srcRde.Id, srcRdeTypeVersion, rdeType.CapvcdRDETypeVersion)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert RDE [%s] from source version [%s] to destination version [%s]",

--- a/pkg/util/defined_entity_utils.go
+++ b/pkg/util/defined_entity_utils.go
@@ -3,7 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
+	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_2_0"
 )
 
 func ConvertMapToCAPVCDEntity(entityMap map[string]interface{}) (*rdeType.CAPVCDEntity, error) {
@@ -30,4 +30,29 @@ func ConvertCAPVCDEntityToMap(capvcdEntity *rdeType.CAPVCDEntity) (map[string]in
 		return nil, fmt.Errorf("failed to marshal CAPVCD entity data to a map: [%v]", err)
 	}
 	return entityMap, nil
+}
+
+func ConvertMapToCAPVCDStatus(capvcdStatusMap map[string]interface{}) (*rdeType.CAPVCDStatus, error) {
+	var capvcdStatus rdeType.CAPVCDStatus
+	entityByteArr, err := json.Marshal(&capvcdStatusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal entity map: [%v]", err)
+	}
+	err = json.Unmarshal(entityByteArr, &capvcdStatus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal entity byte array to capvcd entity: [%v]", err)
+	}
+	return &capvcdStatus, nil
+}
+func ConvertCAPVCDStatusToMap(capvcdStatus *rdeType.CAPVCDStatus) (map[string]interface{}, error) {
+	var capvcdStatusMap map[string]interface{}
+	entityByteArr, err := json.Marshal(&capvcdStatus)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CAPVCD entity to byte array: [%v]", err)
+	}
+	err = json.Unmarshal(entityByteArr, &capvcdStatusMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal CAPVCD entity data to a map: [%v]", err)
+	}
+	return capvcdStatusMap, nil
 }

--- a/pkg/vcdtypes/rde_type_1_2_0/types_1_2_0.go
+++ b/pkg/vcdtypes/rde_type_1_2_0/types_1_2_0.go
@@ -1,0 +1,169 @@
+package rde_type_1_2_0
+
+import "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+
+const (
+	CapvcdRDETypeVersion = "1.2.0"
+)
+
+type Metadata struct {
+	Name string `json:"name,omitempty"`
+	Vdc  string `json:"virtualDataCenterName,omitempty"`
+	Org  string `json:"orgName,omitempty"`
+	Site string `json:"site,omitempty"`
+}
+
+type ControlPlane struct {
+	SizingClass  string `json:"sizingClass,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	TemplateName string `json:"templateName,omitempty"`
+}
+
+type Workers struct {
+	SizingClass  string `json:"sizingClass,omitempty"`
+	Count        int32  `json:"count,omitempty"`
+	TemplateName string `json:"templateName,omitempty"`
+}
+
+type Distribution struct {
+	Version string `json:"version,omitempty"`
+}
+
+type Topology struct {
+	ControlPlane []ControlPlane `json:"controlPlane,omitempty"`
+	Workers      []Workers      `json:"workers,omitempty"`
+}
+
+type Cni struct {
+	Name string `json:"name,omitempty"`
+}
+
+type Pods struct {
+	CidrBlocks []string `json:"cidrBlocks,omitempty"`
+}
+
+type Services struct {
+	CidrBlocks []string `json:"cidrBlocks,omitempty"`
+}
+
+type Ovdc struct {
+	Name        string `json:"name,omitempty"`
+	ID          string `json:"id,omitempty"`
+	OvdcNetwork string `json:"ovdcNetworkName,omitempty"`
+}
+
+type Org struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+type VCDProperties struct {
+	Site string `json:"site,omitempty"`
+	Ovdc []Ovdc `json:"orgVdcs,omitempty"`
+	Org  []Org  `json:"organizations,omitempty"`
+}
+
+type ApiEndpoints struct {
+	Host string `json:"host,omitempty"`
+	Port int32  `json:"port,omitempty"`
+}
+
+type ClusterApiStatus struct {
+	Phase        string         `json:"phase,omitempty"`
+	ApiEndpoints []ApiEndpoints `json:"apiEndpoints,omitempty"`
+}
+
+type VersionedAddon struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type PrivateSection struct {
+	KubeConfig string `json:"kubeConfig,omitempty"`
+}
+
+type K8sNetwork struct {
+	Pods     Pods     `json:"pods,omitempty"`
+	Services Services `json:"services,omitempty"`
+}
+
+type ClusterResource struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type VCDResource struct {
+	Type              string                 `json:"type,omitempty"`
+	ID                string                 `json:"id,omitempty"`
+	Name              string                 `json:"name,omitempty"`
+	AdditionalDetails map[string]interface{} `json:"additionalDetails,omitempty"`
+}
+
+type NodePool struct {
+	Name              string            `json:"name,omitempty"`
+	SizingPolicy      string            `json:"sizingPolicy,omitempty"`
+	PlacementPolicy   string            `json:"placementPolicy,omitempty"`
+	DiskSizeMb        int32             `json:"diskSizeMb,omitempty"`
+	NvidiaGpuEnabled  bool              `json:"nvidiaGpuEnabled,omitempty"`
+	StorageProfile    string            `json:"storageProfile,omitempty"`
+	DesiredReplicas   int32             `json:"desiredReplicas"`
+	AvailableReplicas int32             `json:"availableReplicas"`
+	NodeStatus        map[string]string `json:"nodeStatus,omitempty"`
+}
+
+type ClusterResourceSetBinding struct {
+	ClusterResourceSetName string `json:"clusterResourceSetName,omitempty"`
+	Kind                   string `json:"kind,omitempty"`
+	Name                   string `json:"name,omitempty"`
+	Applied                bool   `json:"applied,omitempty"`
+	LastAppliedTime        string `json:"lastAppliedTime,omitempty"`
+}
+
+type K8sInfo struct {
+	TkgVersion string `json:"tkgVersion,omitempty"`
+	K8sVersion string `json:"kubernetesVersion,omitempty"`
+}
+
+type Upgrade struct {
+	Current  *K8sInfo `json:"current"`
+	Previous *K8sInfo `json:"previous"`
+	Ready    bool     `json:"ready"`
+}
+
+type CAPVCDStatus struct {
+	Phase                      string                      `json:"phase,omitempty"`
+	Kubernetes                 string                      `json:"kubernetes,omitempty"`
+	Uid                        string                      `json:"uid,omitempty"`
+	ClusterAPIStatus           ClusterApiStatus            `json:"clusterApiStatus,omitempty"`
+	NodePool                   []NodePool                  `json:"nodePool,omitempty"`
+	CapvcdVersion              string                      `json:"capvcdVersion,omitempty"`
+	UseAsManagementCluster     bool                        `json:"useAsManagementCluster,omitempty"`
+	ErrorSet                   []vcdsdk.BackendError       `json:"errorSet,omitempty"`
+	EventSet                   []vcdsdk.BackendEvent       `json:"eventSet,omitempty"`
+	K8sNetwork                 K8sNetwork                  `json:"k8sNetwork,omitempty"`
+	ParentUID                  string                      `json:"parentUid,omitempty"`
+	ClusterResourceSet         []ClusterResource           `json:"clusterResourceSet,omitempty"`
+	VcdProperties              VCDProperties               `json:"vcdProperties,omitempty"`
+	Private                    PrivateSection              `json:"private,omitempty"`
+	VCDResourceSet             []VCDResource               `json:"vcdResourceSet,omitempty"`
+	CapiStatusYaml             string                      `json:"capiStatusYaml,omitempty"`
+	ClusterResourceSetBindings []ClusterResourceSetBinding `json:"clusterResourceSetBindings,omitempty"`
+	CreatedByVersion           string                      `json:"createdByVersion"`
+	Upgrade                    Upgrade                     `json:"upgrade,omitempty"`
+}
+
+type Status struct {
+	CAPVCDStatus CAPVCDStatus `json:"capvcd,omitempty"`
+}
+
+type CAPVCDSpec struct {
+	CapiYaml string `json:"capiYaml"`
+}
+
+type CAPVCDEntity struct {
+	Metadata   Metadata   `json:"metadata"`
+	Spec       CAPVCDSpec `json:"spec"`
+	ApiVersion string     `json:"apiVersion"`
+	Status     Status     `json:"status"`
+	Kind       string     `json:"kind"`
+}


### PR DESCRIPTION
Signed-off-by: ymo24 <ymo@vmware.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add `convertFrom110Format` for CAPVCD: RDE 1.2 Upgrade.
- Modify function `ConvertToLatestRDEVersionFormat`. RDE with 1.y.z version will not return error

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/380)
<!-- Reviewable:end -->
