### PR TITLE
[CAFV-166] Fix wire log commands in the doc

### DIFF
--- a/docs/WIRE_LOGS.md
+++ b/docs/WIRE_LOGS.md
@@ -2,14 +2,14 @@
 
 Execute the following command to log HTTP requests to VCD and HTTP responses from VCD -
 
-`kubectl set env -n kube-system deployment/vmware-cloud-director-ccm GOVCD_LOG_ON_SCREEN=true -oyaml`
+`kubectl set env -n capvcd-system deployment/capvcd-controller-manager GOVCD_LOG_ON_SCREEN=true -oyaml`
 
 Once the above command is executed, CAPVCD will start logging the HTTP requests and HTTP responses made via 
 go-vcloud-director SDK. The container logs can be obtained using the command `kubectl logs -n capvcd-system <CAPVCD Pod>`
 
 To stop logging the HTTP requests and responses from VCD, the following command can be executed -
 
-`kubectl set env -n kube-system deployment/vmware-cloud-director-ccm GOVCD_LOG_ON_SCREEN-`
+`kubectl set env -n capvcd-system deployment/capvcd-controller-manager GOVCD_LOG_ON_SCREEN-`
 
 NOTE: Please make sure to collect the logs before and after enabling the wire log. The above commands update the CAPVCD
 deployment, which creates a new CAPVCD pod. The logs present in the old pod will be lost.


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Fix commands to enable / disable wire logs in CAPVCD pods.

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/384)
<!-- Reviewable:end -->
