### PR TITLE
[CAFV-142] Reverse the release order of the tables in README.md (#385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,26 @@ The version of Cluster API Provider Cloud Director and Installation that are com
 
 |                                  CAPVCD Version                                   | VMware Cloud Director API | VMware Cloud Director Installation | CoreCAPI/Clusterctl CLI version | Kubernetes Versions |
 |:---------------------------------------------------------------------------------:| :-----------------------: | :--------------------------------: | :---: | :------------------ |
-| [0.5.0](https://github.com/vmware/cluster-api-provider-cloud-director/tree/0.5.0) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [0.4.7](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.4.7) |<ul><li>1.21</li><li>1.20</li></ul>|
-| [0.5.1](https://github.com/vmware/cluster-api-provider-cloud-director/tree/0.5.1) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [0.4.7](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.4.7) |<ul><li>1.21</li><li>1.20</li></ul>|
-| [1.0.0](https://github.com/vmware/cluster-api-provider-cloud-director/tree/1.0.0) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [1.1.3](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.1.3) |<ul><li>1.22</li><li>1.21</li><li>1.20</li></ul>|
 |  [main](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main)  | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [1.1.3](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.1.3) |<ul><li>1.22</li><li>1.21</li><li>1.20</li></ul>|
+| [1.0.0](https://github.com/vmware/cluster-api-provider-cloud-director/tree/1.0.0) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [1.1.3](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.1.3) |<ul><li>1.22</li><li>1.21</li><li>1.20</li></ul>|
+| [0.5.1](https://github.com/vmware/cluster-api-provider-cloud-director/tree/0.5.1) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [0.4.7](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.4.7) |<ul><li>1.21</li><li>1.20</li></ul>|
+| [0.5.0](https://github.com/vmware/cluster-api-provider-cloud-director/tree/0.5.0) | 36.0+ | 10.3.1+ <br/>(10.3.1 needs hot-patch to prevent VCD cell crashes in multi-cell environments) | [0.4.7](https://github.com/kubernetes-sigs/cluster-api/releases/tag/v0.4.7) |<ul><li>1.21</li><li>1.20</li></ul>|
 
 Cluster API versions:
 
 |                          | v1alpha4 (v1.0) | v1beta1 (v1.1) |
 |--------------------------| --------------  |----------------|
-| CAPVCD v1alpha4 (v0.5)   |     ✓           | Not supported  |
-| CAPVCD v1beta1 (v1.0)    |     ✓           | ✓              |
 | CAPVCD v1beta1 (main)    |     ✓           | ✓              |
+| CAPVCD v1beta1 (v1.0)    |     ✓           | ✓              |
+| CAPVCD v1alpha4 (v0.5)   |     ✓           | Not supported  |
 
 TKG versions:
 
 |                        | TKG versions |
 | -----------------------| ------------ | 
-| CAPVCD v1alpha4 (v0.5) | 1.4.0, 1.3.1 | 
-| CAPVCD v1beta1  (v1.0) | 1.5.4, 1.4.3 | 
 | CAPVCD v1beta1  (main) | 1.5.4, 1.4.3 | 
+| CAPVCD v1beta1  (v1.0) | 1.5.4, 1.4.3 | 
+| CAPVCD v1alpha4 (v0.5) | 1.4.0, 1.3.1 |
 
 ## Troubleshooting
 [Collect CAPI log bundle for Cloud Director](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/scripts).


### PR DESCRIPTION
(cherry picked from commit ea515ac2ac425246515b7f389ffd9fb143f0982b)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Reverse the release order of the tables in README.md

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/386)
<!-- Reviewable:end -->
