### PR TITLE
Improve post customization phases

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -102,7 +102,7 @@ write_files:
 
     vmtoolsd --cmd "info-set guestinfo.metering.status in_progress"
     systemctl enable --now metering
-    vmtoolsd --cmd "info-set guestinfo.metering.status successful"
+    vmtoolsd --cmd "info-set guestinfo.metering.status successful" {{- if or .HTTPProxy .HTTPSProxy }}
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status in_progress"
     export HTTP_PROXY="{{.HTTPProxy}}"
@@ -122,7 +122,7 @@ write_files:
     END
     systemctl daemon-reload
     systemctl restart containerd
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- if .NvidiaGPU }}
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- end }} {{- if .NvidiaGPU }}
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.nvidia.runtime.install.status in_progress"
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID)

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -213,17 +213,11 @@ const (
 	PostCustomizationScriptFailureReason   = "guestinfo.post_customization_script_execution_failure_reason"
 )
 
-var controlPlanePostCustPhases = []string{
+var postCustPhases = []string{
 	NetworkConfiguration,
 	MeteringConfiguration,
 	ProxyConfiguration,
-	KubeadmInit,
-}
-
-var joinPostCustPhases = []string{
-	NetworkConfiguration,
-	MeteringConfiguration,
-	KubeadmNodeJoin,
+	NvidiaRuntimeInstall,
 }
 
 func removeFromSlice(remove string, arr []string) []string {
@@ -821,16 +815,23 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	if err != nil {
 		log.Error(err, "failed to remove VCDMachineCreationError from RDE", "rdeID", vcdCluster.Status.InfraId)
 	}
-	//Todo: add remove here
-	// wait for each vm phase
-	phases := controlPlanePostCustPhases
-	if !useControlPlaneScript {
-		if vcdMachine.Spec.EnableNvidiaGPU {
-			phases = []string{joinPostCustPhases[0], joinPostCustPhases[1], NvidiaRuntimeInstall}
-		} else {
-			phases = joinPostCustPhases
-		}
+
+	phases := postCustPhases
+	if useControlPlaneScript {
+		phases = append(phases, KubeadmInit)
+	} else {
+		phases = append(phases, KubeadmNodeJoin)
 	}
+
+	if !vcdMachine.Spec.EnableNvidiaGPU {
+		phases = removeFromSlice(NvidiaRuntimeInstall, phases)
+	}
+
+	if vcdCluster.Spec.ProxyConfigSpec.HTTPSProxy == "" &&
+		vcdCluster.Spec.ProxyConfigSpec.HTTPProxy == "" {
+		phases = removeFromSlice(ProxyConfiguration, phases)
+	}
+
 	for _, phase := range phases {
 		if err = vApp.Refresh(); err != nil {
 			err1 := capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDMachineScriptExecutionError, "", machine.Name, fmt.Sprintf("%v", err))


### PR DESCRIPTION
## Description

- PostCustomization phases are a bit complicated now. They have to be ordered in cloud_init and `phases` arrays. Removing phases conditionally is easier than adding. 

- Now, `NvidiaRuntimeInstall` is not applied for the first CP node but there is no such restriction in the VCDMachine level. This PR adds `NvidiaRuntimeInstall` regardless of `useControlPlaneScript`.

- Now, the proxy configuration for containerd is rendered in cloud_init.tmpl regardless of their content. `/etc/systemd/system/containerd.service.d/http-proxy.conf` should be rendered only when `HttpProxy` or `HttpsProxy` has a value.  This will allow users to use their own proxy settings for containerd without using built-in features. 


## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [x] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [x] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [x] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [x] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [x] No
   - [ ] N/A


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/395)
<!-- Reviewable:end -->
