### PR TITLE
[CAFV-181] Testfest - Add omitempty for extraOvdcNetworks to avoid null when empty

### DIFF
--- a/api/v1beta2/vcdmachine_types.go
+++ b/api/v1beta2/vcdmachine_types.go
@@ -76,7 +76,7 @@ type VCDMachineSpec struct {
 	// ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
 	// VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
 	// +optional
-	ExtraOvdcNetworks *[]string `json:"extraOvdcNetworks,omitempty"`
+	ExtraOvdcNetworks []string `json:"extraOvdcNetworks,omitempty"`
 
 	// VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
 	// Functions of Sprig library are supported. See https://github.com/Masterminds/sprig

--- a/api/v1beta2/vcdmachine_types.go
+++ b/api/v1beta2/vcdmachine_types.go
@@ -76,7 +76,7 @@ type VCDMachineSpec struct {
 	// ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
 	// VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
 	// +optional
-	ExtraOvdcNetworks *[]string `json:"extraOvdcNetworks"`
+	ExtraOvdcNetworks *[]string `json:"extraOvdcNetworks,omitempty"`
 
 	// VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
 	// Functions of Sprig library are supported. See https://github.com/Masterminds/sprig

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -571,7 +571,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	desiredNetworks := []string{vcdCluster.Spec.OvdcNetwork}
 	if vcdMachine.Spec.ExtraOvdcNetworks != nil {
-		desiredNetworks = append([]string{vcdCluster.Spec.OvdcNetwork}, *vcdMachine.Spec.ExtraOvdcNetworks...)
+		desiredNetworks = append([]string{vcdCluster.Spec.OvdcNetwork}, vcdMachine.Spec.ExtraOvdcNetworks...)
 	}
 	if err = r.reconcileVMNetworks(vdcManager, vApp, vm, desiredNetworks); err != nil {
 		log.Error(err, fmt.Sprintf("Error while attaching networks to vApp and VMs"))


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Add omitempty to extraOvdcNetworks field to ensure null doesn't get used when field is empty

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/405)
<!-- Reviewable:end -->
