### PR TITLE
Fix deepy copy for in.ExtraOvdcNetworks

### DIFF
--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -369,12 +369,8 @@ func (in *VCDMachineSpec) DeepCopyInto(out *VCDMachineSpec) {
 	out.DiskSize = in.DiskSize.DeepCopy()
 	if in.ExtraOvdcNetworks != nil {
 		in, out := &in.ExtraOvdcNetworks, &out.ExtraOvdcNetworks
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 


### PR DESCRIPTION
Adds missing changes in #405

```
go build -ldflags "-X github.com/vmware/cluster-api-provider-cloud-director/version.Version=main-branch" -o /build/vcloud/cluster-api-provider-cloud-director main.go
# github.com/vmware/cluster-api-provider-cloud-director/api/v1beta2
api/v1beta2/zz_generated.deepcopy.go:372:8: cannot use new([]string) (type *[]string) as type []string in assignment
api/v1beta2/zz_generated.deepcopy.go:373:6: invalid indirect of *in (type []string)
api/v1beta2/zz_generated.deepcopy.go:375:4: invalid indirect of out (type []string)
api/v1beta2/zz_generated.deepcopy.go:375:30: invalid indirect of in (type []string)
api/v1beta2/zz_generated.deepcopy.go:376:9: invalid indirect of out (type []string)
api/v1beta2/zz_generated.deep copy.go:376:15: invalid indirect of in (type []string
```

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/406)
<!-- Reviewable:end -->
