### PR TITLE
[CAFV-195] Updates the capvcdCluster schema apiVersion to 1.1

### DIFF
--- a/schema/schema_1_1_0.json
+++ b/schema/schema_1_1_0.json
@@ -308,7 +308,7 @@
     },
     "apiVersion": {
       "type": "string",
-      "default": "capvcd.vmware.com/v1.0",
+      "default": "capvcd.vmware.com/v1.1",
       "description": "The version of the payload format"
     }
   }


### PR DESCRIPTION
## Description
Updates the capvcdCluster schema apiVersion to 1.1

- 

## Checklist
- [ ] tested locally
- [x ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/413)
<!-- Reviewable:end -->
