### PR TITLE
[CAFV-159] update v1beta2 capvcd objects in template files and example files

### DIFF
--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -20,7 +20,7 @@ spec:
     name: capi-cluster-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: default # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: capi-cluster # name of the VCDCluster object associated with the cluster.
     namespace: default # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object

--- a/templates/cluster-class-template.yaml
+++ b/templates/cluster-class-template.yaml
@@ -96,7 +96,7 @@ spec:
         httpsProxy: ${HTTPS_PROXY}
         noProxy: ${NO_PROXY}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-control-plane-template
@@ -173,7 +173,7 @@ spec:
             eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
             cloud-provider: external
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_CLASS_NAME}-worker-template

--- a/templates/cluster-class-template.yaml
+++ b/templates/cluster-class-template.yaml
@@ -38,7 +38,7 @@ spec:
     machineInfrastructure:
       ref:
         kind: VCDMachineTemplate
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         name: ${CLUSTER_CLASS_NAME}-control-plane-template
   infrastructure:
     ref:
@@ -56,7 +56,7 @@ spec:
               name: ${CLUSTER_CLASS_NAME}-worker-template
           infrastructure:
             ref:
-              apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+              apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
               kind: VCDMachineTemplate
               name: ${CLUSTER_CLASS_NAME}-worker-template
 ---

--- a/templates/cluster-template-v1.20.8-crs.yaml
+++ b/templates/cluster-template-v1.20.8-crs.yaml
@@ -22,7 +22,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -38,7 +38,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -56,7 +56,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -113,14 +113,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.20.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.20.8+vmware.1
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -175,7 +175,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.20.8.yaml
+++ b/templates/cluster-template-v1.20.8.yaml
@@ -18,7 +18,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -34,7 +34,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -52,7 +52,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -109,14 +109,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.20.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -171,7 +171,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.21.8-crs.yaml
+++ b/templates/cluster-template-v1.21.8-crs.yaml
@@ -22,7 +22,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -38,7 +38,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -56,7 +56,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -113,14 +113,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.21.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.21.8+vmware.1-tkg.2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -175,7 +175,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.21.8.yaml
+++ b/templates/cluster-template-v1.21.8.yaml
@@ -18,7 +18,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -34,7 +34,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -52,7 +52,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -109,14 +109,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.21.8+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.21.8+vmware.1-tkg.2
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -171,7 +171,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.22.9-crs.yaml
+++ b/templates/cluster-template-v1.22.9-crs.yaml
@@ -22,7 +22,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -38,7 +38,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -56,7 +56,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -113,14 +113,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.22.9+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.22.9+vmware.1-tkg.1
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -175,7 +175,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.22.9.yaml
+++ b/templates/cluster-template-v1.22.9.yaml
@@ -18,7 +18,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -34,7 +34,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -52,7 +52,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -109,14 +109,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.22.9+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.22.9+vmware.1-tkg.1
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -171,7 +171,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.23.10-crs.yaml
+++ b/templates/cluster-template-v1.23.10-crs.yaml
@@ -22,7 +22,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -38,7 +38,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -56,7 +56,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -113,14 +113,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.23.10+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.23.10+vmware.1-tkg.1.
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -175,7 +175,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template-v1.23.10.yaml
+++ b/templates/cluster-template-v1.23.10.yaml
@@ -18,7 +18,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -34,7 +34,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # B64 encoded password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # B64 encoded refresh token of the client registered with VCD for creating clusters. password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -52,7 +52,7 @@ spec:
   loadBalancerConfigSpec:
     vipSubnet: "" # Virtual IP CIDR for the external network
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -109,14 +109,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: v1.23.10+vmware.1 # Kubernetes version to be used to create (or) upgrade the control plane nodes. Default version for this flavor is v1.23.10+vmware.1-tkg.1.
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -171,7 +171,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-md-0 # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -22,7 +22,7 @@ spec:
     name: ${CLUSTER_NAME}-control-plane # name of the KubeadmControlPlane object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the KubeadmControlPlane object reside. Should be the same namespace as that of the Cluster object
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
     kind: VCDCluster
     name: ${CLUSTER_NAME} # name of the VCDCluster object associated with the cluster.
     namespace: ${TARGET_NAMESPACE} # kubernetes namespace in which the VCDCluster object resides. Should be the same namespace as that of the Cluster object
@@ -38,7 +38,7 @@ data:
   password: "${VCD_PASSWORD_B64}" # password associated with the user creating the cluster
   refreshToken: "${VCD_REFRESH_TOKEN_B64}" # refresh token of the client registered with VCD for creating clusters. username and password can be left blank if refresh token is provided
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -61,7 +61,7 @@ spec:
     httpsProxy: ${HTTPS_PROXY}
     noProxy: ${NO_PROXY}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
@@ -118,14 +118,14 @@ spec:
           cloud-provider: external
   machineTemplate:
     infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: VCDMachineTemplate
       name: ${CLUSTER_NAME}-control-plane # name of the VCDMachineTemplate object used to deploy control plane VMs. Should be the same name as that of KubeadmControlPlane object
       namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object. Should be the same namespace as that of the Cluster object
   replicas: ${CONTROL_PLANE_MACHINE_COUNT} # desired number of control plane nodes for the cluster
   version: ${KUBERNETES_VERSION} # Kubernetes version to be used to create (or) upgrade the control plane nodes. The value needs to be retrieved from the respective TKGm ova BOM. Refer to the documentation.
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: VCDMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-${WORKER_POOL_NAME}
@@ -180,7 +180,7 @@ spec:
           namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the KubeadmConfigTemplate object. Should be the same namespace as that of the Cluster object
       clusterName: ${CLUSTER_NAME} # name of the Cluster object
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: VCDMachineTemplate
         name: ${CLUSTER_NAME}-${WORKER_POOL_NAME} # name of the VCDMachineTemplate object used to deploy worker nodes
         namespace: ${TARGET_NAMESPACE} # kubernetes namespace of the VCDMachineTemplate object used to deploy worker nodes


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- update v1beta2 capvcd objects in template files and example files
- Only examine the capvcd object API version.
- Will validate all the template files during E2E testing

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/417)
<!-- Reviewable:end -->
