### PR TITLE
[CAFV-206] add clusterctl config suppport for ClusterClass yaml file

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -1,30 +1,4 @@
 apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  labels:
-    cni: antrea
-  name: ${CLUSTER_NAME}
-  namespace: ${TARGET_NAMESPACE}
-spec:
-  clusterNetwork:
-    pods:
-      cidrBlocks:
-      - ${POD_CIDR} # pod CIDR for the cluster
-    services:
-      cidrBlocks:
-      - ${SERVICE_CIDR} # service CIDR for the cluster
-  topology:
-    class: ${CLUSTER_CLASS_NAME}
-    controlPlane:
-      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-    version: ${KUBERNETES_VERSION}
-    workers:
-      machineDeployments:
-      - class: default-worker
-        name: worker
-        replicas: ${WORKER_MACHINE_COUNT}
----
-apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: ${CLUSTER_CLASS_NAME}
@@ -59,6 +33,32 @@ spec:
               apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
               kind: VCDMachineTemplate
               name: ${CLUSTER_CLASS_NAME}-worker-template
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cni: antrea
+  name: ${CLUSTER_NAME}
+  namespace: ${TARGET_NAMESPACE}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR} # pod CIDR for the cluster
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR} # service CIDR for the cluster
+  topology:
+    class: ${CLUSTER_CLASS_NAME}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machineDeployments:
+        - class: default-worker
+          name: worker
+          replicas: ${WORKER_MACHINE_COUNT}
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -24,6 +24,7 @@ providers:
 
 
 EXP_CLUSTER_RESOURCE_SET: true
+# CLUSTER_TOPOLOGY: true # Enable/Disable the feature gate for ClusterClass support.
 
 # Mandatory VCD specific properties
 VCD_SITE: "https://VCD_FQDN"
@@ -49,6 +50,7 @@ VCD_VIP_CIDR: ""
 
 # Kubernetes cluster properties
 CLUSTER_NAME: "myCluster"
+CLUSTER_CLASS_NAME: "myClusterClass"
 TARGET_NAMESPACE: default
 CONTROL_PLANE_MACHINE_COUNT: 1
 WORKER_MACHINE_COUNT: 1


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- add clusterctl config suppport for ClusterClass yaml file

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
