### PR TITLE
[CAFV-200] Update manifests generated to point to projects.registry.vmware.com

### DIFF
--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -16,7 +16,7 @@
 			{
 				"name":"cluster-api-provider-cloud-director",
 				"version":"__VERSION__",
-				"imageRepository":"__REGISTRY__"
+				"imageRepository":"projects.registry.vmware.com/vmware-cloud-director"
 			}
 		]
 	}

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,1 +1,1 @@
-__REGISTRY__ cluster-api-provider-cloud-director __VERSION__
+projects.registry.vmware.com/vmware-cloud-director cluster-api-provider-cloud-director __VERSION__

--- a/config/manager/manager.yaml.template
+++ b/config/manager/manager.yaml.template
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:__VERSION__
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:__VERSION__
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Update manifests generated to point to projects.registry.vmware.com

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Update manifests generated to point to projects.registry.vmware.com/vmware-cloud-director
  - Since `clusterctl init` can override which repository to pull from, we can ensure that all of our manifests will point to a reachable location (projects.registry.vmware.com)

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/422)
<!-- Reviewable:end -->
