### PR TITLE
[CAFV-223] [common-core] sync with CPI common-core for the latest testing common code - remove PVC related k8s functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230420174123-f285168de9e5
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	go.uber.org/zap v1.19.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,9 @@ require (
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4ddc9292
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	go.uber.org/zap v1.19.1
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
@@ -92,6 +91,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -547,6 +547,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4ddc9292 h1:Uh7EE1UjpBBfyKQEiPMgXEP3rpcojsUDvMyzEkGUxXA=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4ddc9292/go.mod h1:B7LWK1eIP4gYf5grYWNCwMuMkaGqXJ3BJj+ZNe1Gbpw=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138 h1:CPmJ54U6rFzedOAXgYAeZqTJrtga9I8+1spBghS1mrQ=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138/go.mod h1:B7LWK1eIP4gYf5grYWNCwMuMkaGqXJ3BJj+ZNe1Gbpw=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/go.sum
+++ b/go.sum
@@ -549,6 +549,8 @@ github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4d
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4ddc9292/go.mod h1:B7LWK1eIP4gYf5grYWNCwMuMkaGqXJ3BJj+ZNe1Gbpw=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138 h1:CPmJ54U6rFzedOAXgYAeZqTJrtga9I8+1spBghS1mrQ=
 github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138/go.mod h1:B7LWK1eIP4gYf5grYWNCwMuMkaGqXJ3BJj+ZNe1Gbpw=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230420174123-f285168de9e5 h1:Ech3c2JxElUoXy3Rj77NivBZT8+7uB+bcyRSwgLLfL0=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230420174123-f285168de9e5/go.mod h1:B7LWK1eIP4gYf5grYWNCwMuMkaGqXJ3BJj+ZNe1Gbpw=
 github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -277,7 +277,7 @@ github.com/spf13/cast
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.2
 ## explicit; go 1.13
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230316164812-df9d4ddc9292
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -277,7 +277,7 @@ github.com/spf13/cast
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.2
 ## explicit; go 1.13
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230417202714-aa24a76e6138
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230420174123-f285168de9e5
 ## explicit; go 1.17
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

-  [common-core] sync with CPI common-core for the latest testing common code - remove PVC related k8s functions

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/436)
<!-- Reviewable:end -->
