### PR TITLE
[CAFV-77] Update cloud init script to read kubeadm failure reason (#439)

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -68,6 +68,11 @@ write_files:
       vmtoolsd --cmd "info-set guestinfo.post_customization_script_execution_status $?"
       ERROR_MESSAGE="$(date) $(caller): $BASH_COMMAND"
       echo "$ERROR_MESSAGE" &>> /var/log/capvcd/customization/error.log
+      if [[ -s /root/kubeadm.err ]]
+      then
+        KUBEADM_FAILURE=$(cat /root/kubeadm.err)
+        ERROR_MESSAGE="$ERROR_MESSAGE $KUBEADM_FAILURE"
+      fi
       vmtoolsd --cmd "info-set guestinfo.post_customization_script_execution_failure_reason $ERROR_MESSAGE"
 
       CLOUD_INIT_OUTPUT=""
@@ -79,7 +84,7 @@ write_files:
     }
     mkdir -p /var/log/capvcd/customization
     trap 'catch $? $LINENO' ERR EXIT
-    set -ex
+    set -eEx
 
     echo "$(date) Post Customization script execution in progress" &>> /var/log/capvcd/customization/status.log {{- if .ControlPlane }}
 
@@ -141,11 +146,15 @@ write_files:
       NEW_TAG_VERSION=$(echo $IMAGE_REF | sed 's/.*://' | sed 's/_/-/')
       ctr -n=k8s.io image tag $IMAGE_REF $REF_PATH:$NEW_TAG_VERSION
     done
-    {{ .BootstrapRunCmd }}
+    set +x
+    {
+      {{ .BootstrapRunCmd }}
+    } 2> /root/kubeadm.err
+    set -x
     if [[ ! -f /run/cluster-api/bootstrap-success.complete ]]
     then
       echo "file /run/cluster-api/bootstrap-success.complete not found" &>> /var/log/capvcd/customization/error.log
-    exit 1
+      exit 1
     fi
     vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} successful"
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>
(cherry picked from commit a85687652b923d04578eef238e62597e56d31636)

Please provide a brief description of the changes proposed in this Pull Request

BootstrapRunCmd generated from CAPI is a compound command. The BootstrapRunCmd will be of the following format
```
kubeadm join --config /run/kubeadm/kubeadm-join-config.yaml  && echo success > /run/cluster-api/bootstrap-success.complete
```
`trap` cannot be used to catch the error if the executed command is part of an && or ||
> The ERR trap is not executed if the failed command is part of the command list immediately following a [while](https://ss64.com/bash/while.html) or until keyword, part of the test in an if statement, part of a && or || list, or if the command's return value is being inverted via !.
These are the same conditions obeyed by the errexit option.

This PR uses stderr redirection to catch the error from kubeadm cli.

Example error in RDE:

<img width="1426" alt="Screen Shot 2023-04-20 at 3 35 18 PM" src="https://user-images.githubusercontent.com/16699642/233502458-b067a3fc-59aa-4b8e-ba80-dae0eed0ee93.png">



## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/441)
<!-- Reviewable:end -->
