### PR TITLE
Image updates to reduce image size, move to golang static binary and scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /go/src/github.com/vmware/cluster-api-provider-cloud-director
 
 ENV GOPATH /go
 ARG VERSION
-RUN make build-within-docker VERSION=$VERSION
+RUN make build-within-docker VERSION=$VERSION && \
+    chmod +x /build/vcloud/cluster-api-provider-cloud-director
 
 ########################################################
 
@@ -21,8 +22,6 @@ FROM photon:4.0-20210910
 WORKDIR /opt/vcloud/bin
 
 COPY --from=builder /build/vcloud/cluster-api-provider-cloud-director .
-
-RUN chmod +x /opt/vcloud/bin/cluster-api-provider-cloud-director
 
 USER nobody
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN make build-within-docker VERSION=$VERSION && \
 
 ########################################################
 
-FROM photon:4.0-20210910
+FROM scratch
 
 WORKDIR /opt/vcloud/bin
 
 COPY --from=builder /build/vcloud/cluster-api-provider-cloud-director .
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-USER nobody
-ENTRYPOINT ["/bin/bash", "-l", "-c"]
+# nobody user ID
+USER 65534
+ENTRYPOINT ["/opt/vcloud/bin/cluster-api-provider-cloud-director"]

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test: manifests generate fmt vet ## Run tests.
 
 build-within-docker: vendor
 	mkdir -p /build/cluster-api-provider-cloud-director
-	go build -ldflags "-X github.com/vmware/$(CAPVCD_IMG)/version.Version=${VERSION}" -o /build/vcloud/cluster-api-provider-cloud-director main.go
+	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/$(CAPVCD_IMG)/version.Version=${VERSION}" -o /build/vcloud/cluster-api-provider-cloud-director main.go
 
 generate-capvcd-image: generate fmt vet vendor 
 	docker build -f Dockerfile . -t $(CAPVCD_IMG):$(VERSION) --build-arg VERSION=$(VERSION)


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

Multiple fixes to move from a photon base to a scratch image.

- fix image layers to prevent unneeded layer. By moving the `chmod +x` to before the copy, we don't have to include that layer in the changes
```bash
vcloud2          latest            32186ae3133f   35 minutes ago   93.8MB
vcloud           latest            af43cf4b9444   35 minutes ago   151MB
```

If we inspect the layers we can see the copy layer is 57MB and the chmod layer is also 57MB because it has to modify the permissions on that binary in the docker layer.
```bash
57 MB  COPY /build/vcloud/cluster-api-provider-cloud-director . # buildkit
57 MB  RUN /bin/sh -c chmod +x /opt/vcloud/bin/cluster-api-provider-cloud-director # buildkit
```

after the change we don't have the 2nd layer
```bash
57 MB  COPY /build/vcloud/cluster-api-provider-cloud-director . # buildkit
```

- remove the debugging symbols and gdb information from binary and change to a static binary. This reduces the binary size by 17MB (`CGO_ENABLED=0` and `-s -w` in the ldflags)

```bash
57 MB  COPY /build/vcloud/cluster-api-provider-cloud-director . # buildkit
```
```bash
40 MB  COPY /build/vcloud/cluster-api-provider-cloud-director . # buildkit
```

Then finally, we can move from photon to a scratch image and get rid of any additional files we don't need and greatly reduce the image size

before
```bash
vcloud      latest            af43cf4b9444   3 hours ago    151MB
```
after
```bash
vcloud4     latest            2c364a3ae915   2 hours ago    40.3MB
```


## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [X] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [X] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [X] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [X] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [X] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [X] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

Signed-off-by: slimm609 <dbrian@vmware.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/446)
<!-- Reviewable:end -->
