### PR TITLE
[CAFV-256] Port `workload` cluster label to `1.0.z` branch

### DIFF
--- a/templates/crs/tanzu/v1.6.1/v1.6.1.yaml.template
+++ b/templates/crs/tanzu/v1.6.1/v1.6.1.yaml.template
@@ -2459,13 +2459,13 @@ stringData:
       metadata.yaml: |
         cluster:
           name: __CLUSTER_NAME__
-          type: management
+          type: workload
           plan: prod
           kubernetesProvider: VMware Tanzu Kubernetes Grid
           tkgVersion: v1.6.1
           edition: tkg
           infrastructure:
-            provider: vsphere
+            provider: cloud-director
         bom:
           configmapRef:
             name: tkg-bom
@@ -4108,82 +4108,16 @@ stringData:
     CLUSTER_NAME: __CLUSTER_NAME__
     CLUSTER_PLAN: prod
     NAMESPACE: tkg-system
-    INFRASTRUCTURE_PROVIDER: vsphere
+    INFRASTRUCTURE_PROVIDER: cloud-director
     IS_WINDOWS_WORKLOAD_CLUSTER: false
     SIZE: null
     CONTROLPLANE_SIZE: null
     WORKER_SIZE: null
     ENABLE_CEIP_PARTICIPATION: false
-    DEPLOY_TKG_ON_VSPHERE7: null
-    ENABLE_TKGS_ON_VSPHERE7: null
-    VSPHERE_NUM_CPUS: 2
-    VSPHERE_DISK_GIB: 40
-    VSPHERE_MEM_MIB: 4096
-    VSPHERE_CONTROL_PLANE_NUM_CPUS: 2
-    VSPHERE_CONTROL_PLANE_DISK_GIB: 20
-    VSPHERE_CONTROL_PLANE_MEM_MIB: 4096
-    VSPHERE_WORKER_NUM_CPUS: 2
-    VSPHERE_WORKER_DISK_GIB: 20
-    VSPHERE_WORKER_MEM_MIB: 4096
-    VSPHERE_CLONE_MODE: fullClone
-    VSPHERE_NETWORK: /DC1/network/Avi Management Segment
-    VSPHERE_TEMPLATE: /DC1/vm/crs123template
     VIP_NETWORK_INTERFACE: eth0
-    VSPHERE_SSH_AUTHORIZED_KEY: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC6w6uijkfNj8bhvzO3FusP5aN/731KrMAteqNQZfOfhLyVE/aVfpRYzjFIC4yvrl8LkSMZz7XY6RGhaMUPPjpB+/Xyqfc8qPAnzJ3K3UuHkNH2dHPngF+ffN0ZNZXoRBOzWHnCPOvD0iz0XC73/CK18Yd0wmq16PVexYHnpy1X+t16s7zyay32YwEaa+vjs0/Wvxreq9wT148WFMP+9Czjm5vB/5yvH/g24zav7LiF0ytyarEn5+X0oGgkC9EJrrvEzym/tacChnGw/aXs7NmQxJMG8jKm+gAe/oLAE+qK37bFyCm39LsMdHyYsKf+iRjwDu4pI1x+6dO6++HPW1SYMaRNIQROHb71COVW9rp5XFmmP8KJc4bzSuLUYJmvxJKJ22Zn7TqYPGee7ZSOoZ4kmGH27T0AxrgVok/wazNiNTAyGCF88hwSd1kQNSrFyFdbEZUXN3VUfEvcVILMQF/+nVH70/MO/u9wJBHUYNjK73hmG+zu8F5CwEu/B6Q/tIKEeqqaU+XUSRDHpf3D8Khrtr1WwuF0PWa7fRuOa4QfwkEnnF88nYpDLnZUcsnNaTcXJuM3Zzr3eiV3eOj2MOrI+BYDU4IWBHimcaNk9hrM3RCNSnTHkt9reoUCz2q7lTcmMk+HcebKQ+32jdoFI79xlxbfgFxxfw0sxyYSB1cetw==
-    VSPHERE_USERNAME: administrator@vsphere.local
-    VSPHERE_REGION: null
-    VSPHERE_ZONE: null
-    VSPHERE_SERVER: atl1-vcd-static-132-236.eng.vmware.com
-    VSPHERE_DATACENTER: /DC1
-    VSPHERE_RESOURCE_POOL: /DC1/host/TestbedCluster2/Resources
-    VSPHERE_DATASTORE: /DC1/datastore/local-datastore-4
-    VSPHERE_FOLDER: /DC1/vm/cassini/cluster-org (8f69d43f-c12b-4088-8aec-b1e8c82cd8ae)
-    VSPHERE_STORAGE_POLICY_ID: ""
-    VSPHERE_TLS_THUMBPRINT: ""
-    VSPHERE_INSECURE: true
-    VSPHERE_CONTROL_PLANE_ENDPOINT: 1.2.3.4
-    VSPHERE_CONTROL_PLANE_ENDPOINT_PORT: 6443
-    NSXT_POD_ROUTING_ENABLED: false
-    NSXT_ROUTER_PATH: ""
-    NSXT_USERNAME: ""
-    NSXT_MANAGER_HOST: ""
-    NSXT_ALLOW_UNVERIFIED_SSL: "false"
-    NSXT_REMOTE_AUTH: "false"
-    NSXT_VMC_ACCESS_TOKEN: ""
-    NSXT_VMC_AUTH_HOST: ""
-    NSXT_CLIENT_CERT_KEY_DATA: ""
-    NSXT_CLIENT_CERT_DATA: ""
-    NSXT_ROOT_CA_DATA_B64: ""
-    NSXT_SECRET_NAME: cloud-provider-vsphere-nsxt-credentials
-    NSXT_SECRET_NAMESPACE: kube-system
-    ENABLE_OIDC: false
-    OIDC_ISSUER_URL: null
-    OIDC_USERNAME_CLAIM: null
-    OIDC_GROUPS_CLAIM: null
-    OIDC_DEX_CA: null
-    ENABLE_MHC: false
-    ENABLE_MHC_WORKER_NODE: true
-    ENABLE_MHC_CONTROL_PLANE: true
-    MHC_UNKNOWN_STATUS_TIMEOUT: 5m
-    MHC_FALSE_STATUS_TIMEOUT: 12m
-    TKG_CUSTOM_IMAGE_REPOSITORY: ""
-    TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: false
-    TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE: ""
-    TKG_HTTP_PROXY: ""
-    TKG_HTTPS_PROXY: ""
-    TKG_NO_PROXY: ""
-    TKG_PROXY_CA_CERT: ""
-    TKG_IP_FAMILY: null
     ENABLE_AUDIT_LOGGING: false
     ENABLE_DEFAULT_STORAGE_CLASS: true
-    CLUSTER_CIDR: 100.96.0.0/11
-    SERVICE_CIDR: 100.64.0.0/13
     NODE_STARTUP_TIMEOUT: 20m
-    CONTROL_PLANE_MACHINE_COUNT: 3
-    WORKER_MACHINE_COUNT: 1
-    WORKER_MACHINE_COUNT_0: 1
-    WORKER_MACHINE_COUNT_1: 1
-    WORKER_MACHINE_COUNT_2: 1
     OS_NAME: ubuntu
     OS_VERSION: 20.04
     OS_ARCH: amd64
@@ -4257,9 +4191,8 @@ stringData:
     ANTREA_EGRESS: true
     ANTREA_FLOWEXPORTER: false
     ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD: false
-    PROVIDER_TYPE: vsphere
+    PROVIDER_TYPE: cloud-director
     TKG_CLUSTER_ROLE: management
     TKG_VERSION: v1.6.1
     CNI: antrea
-    VSPHERE_VERSION: 7.0.2
 type: addons.cluster.x-k8s.io/resource-set


### PR DESCRIPTION
This is a cherry-pick of [CAFV-182] Remove unneeded config values and management label (#408) from `main` branch
----
* removed vsphere and management references and other unneded values

* reverted antrea

* removed oidc, nsxt, and tkg values

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/447)
<!-- Reviewable:end -->
