### PR TITLE
CAFV-261: Use projects-stg as build registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 MANIFEST_DIR = templates
 
-REGISTRY ?= harbor-repo.vmware.com/vcloud
+REGISTRY ?= "projects-stg.registry.vmware.com/vmware-cloud-director"
 VERSION ?= $(shell cat ${GITROOT}/release/version)
 CAPVCD_IMG := cluster-api-provider-cloud-director
 CAPVCD_ARTIFACT_IMG := capvcd-manifest-airgapped

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.6409b2b
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-a647055
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-efdd678
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-05911c8
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-a647055
+        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-efdd678
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml.template
+++ b/config/manager/manager.yaml.template
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:__VERSION__
+        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:__VERSION__
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/config/manager/manager.yaml.template
+++ b/config/manager/manager.yaml.template
@@ -22,7 +22,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:__VERSION__
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:__VERSION__
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1560,7 +1560,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: harbor-repo.vmware.com/vcloud/cluster-api-provider-cloud-director:main-branch.6409b2b
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-a647055
         livenessProbe:
           httpGet:
             path: /healthz

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1560,7 +1560,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-05911c8
+        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-05911c8
         livenessProbe:
           httpGet:
             path: /healthz

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1560,7 +1560,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-a647055
+        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-efdd678
         livenessProbe:
           httpGet:
             path: /healthz

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1560,7 +1560,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects-stg.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-efdd678
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:main-branch-05911c8
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Use projects-stg as internal registry

## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [NA] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
NA

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/449)
<!-- Reviewable:end -->
