### PR TITLE
Skip RDE upgrades if VCDKECluster is True

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -812,10 +812,9 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		if !strings.Contains(infraID, NoRdePrefix) && vcdCluster.Status.RdeVersionInUse != "" &&
 			vcdCluster.Status.RdeVersionInUse != rdeType.CapvcdRDETypeVersion {
 			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
-			isVCDKECluster := capvcdRdeManager.IsVCDKECluster(ctx, infraID)
 			// 4. Skip the RDE upgrade process if the VCDKECluster flag is set to true
 			//    and current_rde_version < standard_rde_version
-			if !isVCDKECluster && capisdk.CheckIfRdeVersionNeedsUpgraded(vcdCluster.Status.RdeVersionInUse, rdeType.CapvcdRDETypeVersion) {
+			if !capvcdRdeManager.IsVCDKECluster(ctx, infraID) && capisdk.CheckIfRdeVersionNeedsUpgraded(vcdCluster.Status.RdeVersionInUse, rdeType.CapvcdRDETypeVersion) {
 				log.Info("Upgrading RDE", "rdeID", infraID,
 					"targetRDEVersion", rdeType.CapvcdRDETypeVersion)
 				_, err = capvcdRdeManager.ConvertToLatestRDEVersionFormat(ctx, infraID)

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -806,16 +806,13 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			}
 		}
 
-		//1. If infraID indicates that there is no RDE (Resource Definition Entity), skip the RDE upgrade process.
+		//1. If infraID indicates that there is no RDE (Runtime Defined Entity), skip the RDE upgrade process.
 		//2. If vcdCluster.Status.RdeVersionInUse is empty, skip the RDE upgrade process.
 		//3. If version outdated is detected, proceed with the RDE upgrade process.
 		if !strings.Contains(infraID, NoRdePrefix) && vcdCluster.Status.RdeVersionInUse != "" &&
 			vcdCluster.Status.RdeVersionInUse != rdeType.CapvcdRDETypeVersion {
 			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, infraID)
-			isVCDKECluster, err := capvcdRdeManager.IsVCDKECluster(ctx, infraID)
-			if err != nil {
-				return ctrl.Result{}, errors.Wrapf(err, "error occurred when checking whether the RDE is vcdKE Cluster [%s]", infraID)
-			}
+			isVCDKECluster := capvcdRdeManager.IsVCDKECluster(ctx, infraID)
 			// 4. Skip the RDE upgrade process if the VCDKECluster flag is set to true
 			//    and current_rde_version < standard_rde_version
 			if !isVCDKECluster && capisdk.CheckIfRdeVersionNeedsUpgraded(vcdCluster.Status.RdeVersionInUse, rdeType.CapvcdRDETypeVersion) {

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -125,15 +125,15 @@ func convertToMap(obj interface{}) (map[string]interface{}, error) {
 	return parsedMap, nil
 }
 
-func CheckIfRdeVersionNeedsUpgraded(srcRdeTypeVersion string, tgtRdeTypeVersion string) bool {
+func CheckIfClusterRdeNeedsUpgrade(srcRdeTypeVersion string, tgtRdeTypeVersion string) bool {
 	entityTypeSemVer, err := semver.New(srcRdeTypeVersion)
 	if err != nil {
-		klog.Errorf("fail to convert [%s] into a standard version: [%v]", srcRdeTypeVersion, err)
+		klog.Errorf("fail to convert [%s] into a semantic version: [%v]", srcRdeTypeVersion, err)
 		return false
 	}
 	tgtRdeTypeVersionSemVer, err := semver.New(tgtRdeTypeVersion)
 	if err != nil {
-		klog.Errorf("fail to convert [%s] into a standard version: [%v]", srcRdeTypeVersion, err)
+		klog.Errorf("fail to convert [%s] into a semantic version: [%v]", srcRdeTypeVersion, err)
 		return false
 	}
 	return entityTypeSemVer.LT(*tgtRdeTypeVersionSemVer)
@@ -373,7 +373,7 @@ func (capvcdRdeManager *CapvcdRdeManager) IsVCDKECluster(ctx context.Context, rd
 		klog.Errorf("unable to convert [%T] to map in the defined entity [%s]", specMap, rdeID)
 		return false
 	}
-	// if the vcdKeSpec section is present, then the cluster is not managed by CSE
+	// if the vcdKeSpec section is present, then the cluster is not managed by standalone CAPVCD.
 	vcdKESpecEntry, ok := specMap["vcdKe"]
 	if !ok {
 		return false

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -347,7 +347,7 @@ func (capvcdRdeManager *CapvcdRdeManager) IsVCDKECluster(ctx context.Context, rd
 	}
 
 	if org == nil || org.Org == nil {
-		klog.Errorf("obtained nil org when getting org by name [%s] in the defined entity [%s]", client.ClusterOrgName, rdeID, err)
+		klog.Errorf("obtained nil org when getting org by name [%s] in the defined entity [%s]", client.ClusterOrgName, rdeID)
 		return false
 	}
 
@@ -358,7 +358,7 @@ func (capvcdRdeManager *CapvcdRdeManager) IsVCDKECluster(ctx context.Context, rd
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		klog.Errorf("error getting defined entity with ID [%s]: [%v]", rdeID, err)
+		klog.Errorf("obtained unexpected http status [%d] when getting the defined entity with ID [%s]", resp.StatusCode, rdeID)
 		return false
 	}
 
@@ -373,7 +373,7 @@ func (capvcdRdeManager *CapvcdRdeManager) IsVCDKECluster(ctx context.Context, rd
 		klog.Errorf("unable to convert [%T] to map in the defined entity [%s]", specMap, rdeID)
 		return false
 	}
-
+	// if the vcdKeSpec section is present, then the cluster is not managed by CSE
 	vcdKESpecEntry, ok := specMap["vcdKe"]
 	if !ok {
 		return false


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Skip RDE upgrades if VCDKECluster is True
- Standalone capvcd cluster - RDE upgrades should happen and status updates must happen.
- VCD-KE cluster - RDE upgrades should not happen and but status updates must happen

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/454)
<!-- Reviewable:end -->
