### PR TITLE
CAFV-281: Use same version methodology as other components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test: manifests generate fmt vet ## Run tests.
 
 build-within-docker: vendor
 	mkdir -p /build/cluster-api-provider-cloud-director
-	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/$(CAPVCD_IMG)/version.Version=${VERSION}" -o /build/vcloud/cluster-api-provider-cloud-director main.go
+	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/vmware/$(CAPVCD_IMG)/release.Version=${VERSION}" -o /build/vcloud/cluster-api-provider-cloud-director main.go
 
 generate-capvcd-image: generate fmt vet vendor 
 	docker build -f Dockerfile . -t $(CAPVCD_IMG):$(VERSION) --build-arg VERSION=$(VERSION)

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -359,7 +359,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 					ApiEndpoints: []rdeType.ApiEndpoints{},
 				},
 				NodePool:               nil,
-				CapvcdVersion:          release.CAPVCDVersion,
+				CapvcdVersion:          release.Version,
 				UseAsManagementCluster: vcdCluster.Spec.UseAsManagementCluster,
 				K8sNetwork: rdeType.K8sNetwork{
 					Pods: rdeType.Pods{
@@ -377,7 +377,7 @@ func (r *VCDClusterReconciler) constructCapvcdRDE(ctx context.Context, cluster *
 				},
 				CapiStatusYaml:             "",
 				ClusterResourceSetBindings: nil,
-				CreatedByVersion:           release.CAPVCDVersion,
+				CreatedByVersion:           release.Version,
 				Upgrade: rdeType.Upgrade{
 					Current: &rdeType.K8sInfo{
 						K8sVersion: kubernetesVersion,
@@ -670,8 +670,8 @@ func (r *VCDClusterReconciler) reconcileRDE(ctx context.Context, cluster *cluste
 			capvcdStatusPatch["Private.KubeConfig"] = string(kubeConfigBytes)
 		}
 	}
-	if release.CAPVCDVersion != capvcdStatus.CapvcdVersion {
-		capvcdStatusPatch["CapvcdVersion"] = release.CAPVCDVersion
+	if release.Version != capvcdStatus.CapvcdVersion {
+		capvcdStatusPatch["CapvcdVersion"] = release.Version
 	}
 
 	updatedRDE, err := capvcdRdeManager.PatchRDE(ctx, specPatch, metadataPatch, capvcdStatusPatch, vcdCluster.Status.InfraId, vappID, updateExternalID)
@@ -936,7 +936,7 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	vcdCluster.Spec.RDEId = infraID
 
 	rdeManager := vcdsdk.NewRDEManager(workloadVCDClient, vcdCluster.Status.InfraId,
-		capisdk.StatusComponentNameCAPVCD, release.CAPVCDVersion)
+		capisdk.StatusComponentNameCAPVCD, release.Version)
 	// After InfraId has been set, we can update site, org, ovdcNetwork, parentUid, useAsManagementCluster
 	// proxyConfigSpec loadBalancerConfigSpec for vcdCluster status
 	vcdCluster.Status.Site = vcdCluster.Spec.Site
@@ -1366,7 +1366,7 @@ func (r *VCDClusterReconciler) reconcileDelete(ctx context.Context,
 	}
 	// Remove vapp from VCDResourceSet in the RDE
 	rdeManager := vcdsdk.NewRDEManager(workloadVCDClient, vcdCluster.Status.InfraId,
-		capisdk.StatusComponentNameCAPVCD, release.CAPVCDVersion)
+		capisdk.StatusComponentNameCAPVCD, release.Version)
 	err = rdeManager.RemoveFromVCDResourceSet(ctx, vcdsdk.ComponentCAPVCD, VCDResourceVApp, vcdCluster.Name)
 	if err != nil {
 		updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.RdeError, "", vcdCluster.Name,

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -1333,7 +1333,7 @@ func (r *VCDMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 		}
 	}
 	// Remove VM from VCDResourceSet of RDE
-	rdeManager := vcdsdk.NewRDEManager(workloadVCDClient, vcdCluster.Status.InfraId, capisdk.StatusComponentNameCAPVCD, release.CAPVCDVersion)
+	rdeManager := vcdsdk.NewRDEManager(workloadVCDClient, vcdCluster.Status.InfraId, capisdk.StatusComponentNameCAPVCD, release.Version)
 	err = rdeManager.RemoveFromVCDResourceSet(ctx, vcdsdk.ComponentCAPVCD, VcdResourceTypeVM, machine.Name)
 	if err != nil {
 		updatedErr := capvcdRdeManager.AddToErrorSet(ctx, capisdk.RdeError, "", machine.Name,

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	_ "embed"
 	"flag"
+	"fmt"
+	"github.com/vmware/cluster-api-provider-cloud-director/release"
 	"os"
 	"time"
 
@@ -35,9 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
-
-//go:embed release/version
-var capVCDVersion string
 
 var (
 	myscheme = runtime.NewScheme()
@@ -87,6 +86,10 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	if release.Version == "" {
+		setupLog.Error(fmt.Errorf("release.Version variable should not be empty"), "")
+	}
+	setupLog.Info("CAPVCD version", "version", release.Version)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 myscheme,

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -107,7 +107,7 @@ func NewCapvcdRdeManager(client *vcdsdk.Client, clusterID string) *CapvcdRdeMana
 		RdeManager: &vcdsdk.RDEManager{
 			Client:                 client,
 			StatusComponentName:    StatusComponentNameCAPVCD,
-			StatusComponentVersion: release.CAPVCDVersion,
+			StatusComponentVersion: release.Version,
 			ClusterID:              clusterID,
 		},
 	}
@@ -698,7 +698,7 @@ func (capvcdRdeManager *CapvcdRdeManager) ConvertToLatestRDEVersionFormat(ctx co
 func (capvcdRdeManager *CapvcdRdeManager) CheckForEmptyRDEAndUpdateCreatedByVersions(ctx context.Context, infraId string) error {
 
 	if capvcdRdeManager.RdeManager == nil {
-		return fmt.Errorf("nil rdeManager found while updating RDE [%s] with createdBy version [%s]", infraId, release.CAPVCDVersion)
+		return fmt.Errorf("nil rdeManager found while updating RDE [%s] with createdBy version [%s]", infraId, release.Version)
 	}
 
 	client := capvcdRdeManager.Client
@@ -733,12 +733,12 @@ func (capvcdRdeManager *CapvcdRdeManager) CheckForEmptyRDEAndUpdateCreatedByVers
 		}
 	}
 	capvcdStatusPatch := make(map[string]interface{})
-	capvcdStatusPatch["CreatedByVersion"] = release.CAPVCDVersion
+	capvcdStatusPatch["CreatedByVersion"] = release.Version
 	_, err = capvcdRdeManager.PatchRDE(ctx, nil, nil, capvcdStatusPatch, infraId, "", false)
 	if err != nil {
-		return fmt.Errorf("failed to update CAPVCD status with created by version [%s] for RDE [%s]", release.CAPVCDVersion, infraId)
+		return fmt.Errorf("failed to update CAPVCD status with created by version [%s] for RDE [%s]", release.Version, infraId)
 	}
-	klog.V(4).Infof("successfully updated CAPVCD status with created by version [%s] for RDE [%s]", release.CAPVCDVersion, infraId)
+	klog.V(4).Infof("successfully updated CAPVCD status with created by version [%s] for RDE [%s]", release.Version, infraId)
 	return nil
 }
 

--- a/release/release.go
+++ b/release/release.go
@@ -1,8 +1,0 @@
-package release
-
-import (
-	_ "embed" // this needs go 1.16+
-)
-
-//go:embed version
-var CAPVCDVersion string

--- a/release/version.go
+++ b/release/version.go
@@ -1,0 +1,9 @@
+/*
+   Copyright 2021 VMware, Inc.
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package release
+
+// Version is to be set in the build process. Empty version will cause a panic.
+var Version string = ""

--- a/release/version.go
+++ b/release/version.go
@@ -6,4 +6,4 @@
 package release
 
 // Version is to be set in the build process. Empty version will cause a panic.
-var Version string = ""
+var Version string = "unset"


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Change version to be in line with other components, so that the git-sha is also embedded in it

## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/465)
<!-- Reviewable:end -->
