### PR TITLE
[CAFV-285] Refractor CAPVCD test automation AND use server side apply to do Kubernetes operations

### DIFF
--- a/tests/e2e/doc.md
+++ b/tests/e2e/doc.md
@@ -28,14 +28,14 @@ Note: **You can also use [setup script](setup_kind_cluster.sh) to set up the kin
     - Apply the CRS of CNI/CPI/CSI
     - Wait for all the machine states become `running`
   - Resize the workload cluster
-    - increase the worker pool node of the workload cluster
+    - increase the worker pool node count of the workload cluster
     - monitor the new machine show up and then become running
-    - decrease the worker pool node of the workload cluster
+    - decrease the worker pool node count of the workload cluster
     - monitor the replicas of machines become correct
   - delete the workload cluster
     - delete all the objects from capiYaml except `secret`
     - Ensure the workload cluster is deleted
-    - Delete the cluster name space
+    - Delete the cluster name space (Secret - capi-user-credentials is deleted at the same time)
 
 ## Tests to be added
 * test the upgrade on an existing workload cluster

--- a/tests/e2e/doc.md
+++ b/tests/e2e/doc.md
@@ -1,0 +1,43 @@
+# CAPVCD automation tests
+
+## Workload cluster CRUD based on the completed management Cluster
+- Test Prerequisites
+  - The management cluster can be accessible.
+  - The management cluster has CAPI controller and CAPVCD controller.
+  - User prepares the completed cluster yaml. See [clusterctl template flavors](../../docs/CLUSTERCTL.md#template_flavors) for the details.
+  
+Note: **You can also use [setup script](setup_kind_cluster.sh) to set up the kind cluster**. 
+1. The script only works for mac OS. 
+2. The script is expected to export the `GOROOT`already.
+
+
+- Test input
+  - PathToKubeconfigOfManagementCluster (absolute path to find the file)
+  - PathToCapiYamlOfWorkloadCluster (absolute path to find the file)
+  
+
+
+- Test Workflow
+  - use kubeConfigPath and capiYamlPath to get kubeConfig and capiYaml.
+  - Create the workload cluster
+    - Get the clusterName and clusterNameSpace from capiYaml
+    - Create the namespace when necessary
+    - Apply the objects from capiYaml
+    - Wait for the cluster becomes `provisioned` and all the machine states become `provisioned`
+    - Validate the kubeConfig of the workload cluster
+    - Apply the CRS of CNI/CPI/CSI
+    - Wait for all the machine states become `running`
+  - Resize the workload cluster
+    - increase the worker pool node of the workload cluster
+    - monitor the new machine show up and then become running
+    - decrease the worker pool node of the workload cluster
+    - monitor the replicas of machines become correct
+  - delete the workload cluster
+    - delete all the objects from capiYaml except `secret`
+    - Ensure the workload cluster is deleted
+    - Delete the cluster name space
+
+## Tests to be added
+* test the upgrade on an existing workload cluster
+* automate the management cluster creation. Test the management cluster creation and workload cluster creation together.
+* test the VCD resource name change and validate CAPVCD to fallback and use the correct VCD name change.

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -1,0 +1,29 @@
+package e2e
+
+import (
+	"flag"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+var (
+	PathToMngmntClusterKubecfg    string
+	PathToWorkloadClusterCapiYaml string
+)
+
+func init() {
+	flag.StringVar(&PathToMngmntClusterKubecfg, "PathToMngmntClusterKubecfg", "", "path to find the Kubeconfig. It is used to retrieve the cluster")
+	flag.StringVar(&PathToWorkloadClusterCapiYaml, "PathToWorkloadClusterCapiYaml", "", "path to find the capi Yaml. It is used to generate the vcd cluster")
+}
+
+var _ = BeforeSuite(func() {
+
+	Expect(PathToMngmntClusterKubecfg).NotTo(BeZero(), "Please make sure --PathToMngmntClusterKubecfg is set correctly.")
+	Expect(PathToWorkloadClusterCapiYaml).NotTo(BeZero(), "Please make sure --PathToWorkloadClusterCapiYaml is set correctly.")
+})
+
+func TestCAPVCDAutomation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CAPVCD Testing Suite")
+}

--- a/tests/e2e/setup_kind_cluster.sh
+++ b/tests/e2e/setup_kind_cluster.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Expect the GOROOT is already exported
+export PATH=$PATH:$GOROOT/bin/
+
+# Install kind
+GO111MODULE="on" go install sigs.k8s.io/kind@v0.20.0
+
+# Install clusterctl on Mac
+# Note: clusterctl-darwin-amd64 is only for MAC. If you are using the different OS, please find the corresponding binary file
+curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.0/clusterctl-darwin-amd64 -o clusterctl
+chmod +x ./clusterctl
+sudo mv ./clusterctl /usr/local/bin/clusterctl
+
+# Check clusterctl version
+clusterctl version
+
+# Create kind cluster configuration file
+cat > kind-cluster-with-extramounts.yaml <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
+EOF
+
+# Create a local cluster using kind
+kind create cluster --config kind-cluster-with-extramounts.yaml
+
+# Set the context to the created cluster
+kubectl cluster-info --context kind-kind
+kubectl config set-context kind-kind
+
+# Verify the cluster is up and running
+kubectl get po -A -owide
+
+# Initialize clusterctl with required providers
+clusterctl init --core cluster-api:v1.4.0 -b kubeadm:v1.4.0 -c kubeadm:v1.4.0 -i vcd:v1.1.0

--- a/tests/e2e/utils/cluster_util.go
+++ b/tests/e2e/utils/cluster_util.go
@@ -1,0 +1,247 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk"
+	"github.com/vmware/cluster-api-provider-cloud-director/api/v1beta2"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"strings"
+)
+
+func ValidateKubeConfig(ctx context.Context, kubeConfigBytes []byte) (*kubernetes.Clientset, error) {
+	workloadRestConfig, csConfig, err := CreateClientConfig(kubeConfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client configuration: %v", err)
+	}
+
+	if workloadRestConfig == nil {
+		return nil, fmt.Errorf("failed to create REST configuration from kubeconfig")
+	}
+
+	if csConfig == nil {
+		return nil, fmt.Errorf("failed to create clientset from REST configuration")
+	}
+
+	fmt.Println("checking pods of the cluster from all the namespaces")
+	podList, err := csConfig.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return csConfig, fmt.Errorf("failed to list pods: %v", err)
+	}
+
+	if podList == nil || len(podList.Items) == 0 {
+		return csConfig, fmt.Errorf("kubeConfig is invalid as the workload cluster should have more than 1 pod")
+	}
+
+	return csConfig, nil
+}
+
+func CreateClientConfig(kubeConfigBytes []byte) (*rest.Config, *kubernetes.Clientset, error) {
+	workloadRestConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
+	}
+
+	csConfig, err := kubernetes.NewForConfig(workloadRestConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create clientset from REST config: %w", err)
+	}
+
+	return workloadRestConfig, csConfig, nil
+}
+
+func GetVCDClusterFromCluster(ctx context.Context, cs *kubernetes.Clientset, namespace string, name string) (*v1beta2.VCDCluster, error) {
+	vcdCluster, err := getVCDCluster(ctx, cs, namespace, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VCDCluster: %w", err)
+	}
+
+	if vcdCluster == nil {
+		return nil, fmt.Errorf("VCDCluster is nil")
+	}
+
+	return vcdCluster, nil
+}
+
+func GetClusterNameAndNamespaceFromCAPIYaml(yamlContent []byte) (string, string, error) {
+	var err error
+	var resourceName string
+	var namespace string
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(yamlContent)))
+	hundredKB := 100 * 1024
+	for err == nil {
+		yamlBytes, readErr := yamlReader.Read()
+		if readErr == io.EOF {
+			break
+		}
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+		unstructuredObj := unstructured.Unstructured{}
+		err = yamlDecoder.Decode(&unstructuredObj)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to decode YAML object: %w", err)
+		}
+
+		kind := unstructuredObj.GetKind()
+		resourceName = unstructuredObj.GetName()
+		namespace = unstructuredObj.GetNamespace()
+		switch kind {
+		case Cluster:
+			if resourceName == "" || namespace == "" {
+				return resourceName, namespace, fmt.Errorf("please examine the format of capi yaml. The clustername and namespace should not be empty")
+			}
+			return resourceName, namespace, nil
+		}
+
+		if err != nil {
+			return resourceName, namespace, fmt.Errorf("failed to get clustername and namespace: %v", err)
+		}
+	}
+	return resourceName, namespace, nil
+}
+
+func GetUserOrgAndName(_ context.Context, org, username string) (string, string) {
+	parts := strings.Split(username, "/")
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+
+	return org, username
+}
+
+func ConstructCAPVCDTestClient(ctx context.Context, vcdCluster *v1beta2.VCDCluster, workloadClientSet *kubernetes.Clientset, capiYaml, clusterNameSpace, clusterName, rdeId string, getVdcClient bool) (*testingsdk.TestClient, error) {
+	var refreshToken, username string
+	secret, err := GetSecret(ctx, capiYaml)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get Secret from CapiYaml: [%v]", err)
+	}
+	if b, exists := secret.Data["username"]; exists {
+		username = strings.TrimRight(string(b), "\n")
+	}
+	if b, exists := secret.Data["refreshToken"]; exists {
+		refreshToken = strings.TrimRight(string(b), "\n")
+	}
+
+	userOrgName, userName := GetUserOrgAndName(ctx, vcdCluster.Status.Org, username)
+
+	testClient, err := NewTestClient(vcdCluster.Status.Site, vcdCluster.Status.Org, userOrgName, vcdCluster.Status.Ovdc, userName, refreshToken, rdeId, getVdcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct testing client: [%v]", err)
+	}
+	// Using workload client as the Kubernetes client of testClient
+	testClient.Cs = workloadClientSet
+	return testClient, nil
+}
+
+func CreateWorkloadClusterResources(ctx context.Context, workloadClientSet *kubernetes.Clientset, capiYaml, rdeID string, vcdcluster *v1beta2.VCDCluster) error {
+	var refreshToken string
+	namespace := "kube-system"
+	secret, err := GetSecret(ctx, capiYaml)
+	if err != nil {
+		return fmt.Errorf("unable to get Secret from CapiYaml: [%v]", err)
+	}
+
+	if b, exists := secret.Data["refreshToken"]; exists {
+		refreshToken = strings.TrimRight(string(b), "\n")
+	}
+
+	err = CreateClusterIDSecret(ctx, workloadClientSet, namespace, rdeID)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster ID secret: %w", err)
+	}
+
+	err = CreateAuthSecret(ctx, workloadClientSet, namespace, refreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to create auth secret: %w", err)
+	}
+
+	host := vcdcluster.Status.Site
+
+	org := vcdcluster.Status.Org
+
+	clusterName := vcdcluster.Name
+
+	ovdc := vcdcluster.Status.Ovdc
+
+	ovdcNetwork := vcdcluster.Status.OvdcNetwork
+
+	if host == "" {
+		return fmt.Errorf("host is empty in the cluster %s", rdeID)
+	}
+
+	if org == "" {
+		return fmt.Errorf("org is empty in the cluster %s", rdeID)
+	}
+
+	if clusterName == "" {
+		return fmt.Errorf("clusterName is empty in the cluster %s", rdeID)
+	}
+
+	if ovdc == "" {
+		return fmt.Errorf("ovdc is empty in the cluster %s", rdeID)
+	}
+
+	if ovdcNetwork == "" {
+		return fmt.Errorf("ovdcNetwork is empty in the cluster %s", rdeID)
+	}
+
+	err = CreateCCMConfigMap(ctx, workloadClientSet, namespace, host, org, ovdc, rdeID, clusterName, ovdcNetwork)
+	if err != nil {
+		return fmt.Errorf("failed to create CCM config map: %w", err)
+	}
+
+	err = CreateCSIConfigMap(ctx, workloadClientSet, namespace, host, org, ovdc, rdeID, clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to create CSI config map: %w", err)
+	}
+	return nil
+}
+
+func GetSecret(_ context.Context, capiYaml string) (*corev1.Secret, error) {
+	hundredKB := 100 * 1024
+	var err error = nil
+	var secret *corev1.Secret
+
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader([]byte(capiYaml))))
+
+	for err == nil {
+		yamlBytes, err := yamlReader.Read()
+		if err == io.EOF {
+			break
+		}
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+		unstructuredObj := unstructured.Unstructured{}
+		err = yamlDecoder.Decode(&unstructuredObj)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse yaml segment: [%v]\n", err)
+		}
+
+		kind := unstructuredObj.GetKind()
+		name := unstructuredObj.GetName()
+		switch kind {
+		case SECRET:
+			secret = &corev1.Secret{}
+			yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+			if err = yamlDecoder.Decode(secret); err != nil {
+				return nil, fmt.Errorf("unable to parse object of kind [%s] and name [%s]: [%v]\n",
+					kind, name, err)
+			}
+			break
+		}
+	}
+
+	err = nil
+	if secret == nil {
+		err = fmt.Errorf("unexpected empty secret in yaml")
+	}
+
+	return secret, err
+}

--- a/tests/e2e/utils/cluster_util.go
+++ b/tests/e2e/utils/cluster_util.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 )
 
@@ -65,8 +66,8 @@ func CreateClientConfig(kubeConfigBytes []byte) (*rest.Config, *kubernetes.Clien
 	return workloadRestConfig, csConfig, nil
 }
 
-func GetVCDClusterFromCluster(ctx context.Context, cs *kubernetes.Clientset, namespace string, name string) (*v1beta2.VCDCluster, error) {
-	vcdCluster, err := getVCDCluster(ctx, cs, namespace, name)
+func GetVCDClusterFromCluster(ctx context.Context, client runtimeclient.Client, namespace string, name string) (*v1beta2.VCDCluster, error) {
+	vcdCluster, err := getVCDCluster(ctx, client, namespace, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get VCDCluster: %w", err)
 	}

--- a/tests/e2e/utils/config_map_files/vcloud-ccm-config.yaml
+++ b/tests/e2e/utils/config_map_files/vcloud-ccm-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vcloud-ccm-configmap
+  namespace: kube-system
+data:
+  vcloud-ccm-config.yaml: |+
+    vcd:
+      host: {{.VcdHost}}
+      org: {{.ORG}}
+      vdc: {{.OVDC}}
+    loadbalancer:
+      oneArm:
+        startIP: "192.168.8.2"
+        endIP: "192.168.8.100"
+      ports:
+        http: 80
+        https: 443
+      network: {{.Network}}
+      vipSubnet: ""
+      certAlias: {{.ClusterID}}-cert
+      enableVirtualServiceSharedIP: false # supported for VCD >= 10.4
+    clusterid: {{.ClusterID}}
+    vAppName: {{.VAPP}}
+immutable: true

--- a/tests/e2e/utils/config_map_files/vcloud-csi-config.yaml
+++ b/tests/e2e/utils/config_map_files/vcloud-csi-config.yaml
@@ -1,25 +1,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vcloud-ccm-configmap
+  name: vcloud-csi-configmap
   namespace: kube-system
 data:
-  vcloud-ccm-config.yaml: |+
+  vcloud-csi-config.yaml: |+
     vcd:
       host: {{.VcdHost}}
       org: {{.ORG}}
       vdc: {{.OVDC}}
-    loadbalancer:
-      oneArm:
-        startIP: "192.168.8.2"
-        endIP: "192.168.8.100"
-      ports:
-        http: 80
-        https: 443
-      network: {{.Network}}
-      vipSubnet: ""
-      certAlias: {{.ClusterID}}-cert
-      enableVirtualServiceSharedIP: false # supported for VCD >= 10.4
     clusterid: {{.ClusterID}}
     vAppName: {{.VAPP}}
 immutable: true

--- a/tests/e2e/utils/config_map_files/vcloud-csi-config.yaml
+++ b/tests/e2e/utils/config_map_files/vcloud-csi-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vcloud-ccm-configmap
+  namespace: kube-system
+data:
+  vcloud-ccm-config.yaml: |+
+    vcd:
+      host: {{.VcdHost}}
+      org: {{.ORG}}
+      vdc: {{.OVDC}}
+    loadbalancer:
+      oneArm:
+        startIP: "192.168.8.2"
+        endIP: "192.168.8.100"
+      ports:
+        http: 80
+        https: 443
+      network: {{.Network}}
+      vipSubnet: ""
+      certAlias: {{.ClusterID}}-cert
+      enableVirtualServiceSharedIP: false # supported for VCD >= 10.4
+    clusterid: {{.ClusterID}}
+    vAppName: {{.VAPP}}
+immutable: true

--- a/tests/e2e/utils/k8s_util.go
+++ b/tests/e2e/utils/k8s_util.go
@@ -1,0 +1,265 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	_ "embed" // this needs go 1.16+
+	"fmt"
+	infrav2 "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta2"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"text/template"
+)
+
+const (
+	CAPIObjectVersion   = "v1beta1"
+	CAPVCDObjectVersion = "v1beta2"
+	FieldManager        = "rdeProjector"
+)
+
+//go:embed config_map_files/vcloud-ccm-config.yaml
+var ccmConfigMapYamlTemplate string
+
+//go:embed config_map_files/vcloud-csi-config.yaml
+var csiConfigMapYamlTemplate string
+
+// ApplyCAPIYaml applies the Kubernetes YAML content to create objects using the provided runtime client.
+// It reads the YAML content, decodes each object, and creates them in the cluster using the runtime client.
+// If an error occurs during decoding or creation, it returns the error.
+func ApplyCAPIYaml(ctx context.Context, r runtimeclient.Client, yamlContent []byte) error {
+
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(yamlContent)))
+	hundredKB := 100 * 1024
+
+	for {
+		yamlBytes, err := yamlReader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+		unstructuredObj := unstructured.Unstructured{}
+		if err = yamlDecoder.Decode(&unstructuredObj); err != nil {
+			fmt.Println(err)
+			continue
+		}
+		err = r.Create(ctx, &unstructuredObj, &runtimeclient.CreateOptions{
+			FieldManager: FieldManager,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func DeleteCAPIYaml(ctx context.Context, r runtimeclient.Client, yamlContent []byte) error {
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(yamlContent)))
+
+	for {
+		yamlBytes, err := yamlReader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return fmt.Errorf("error reading YAML: %w", err)
+		}
+
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), 0)
+		unstructuredObj := unstructured.Unstructured{}
+		if err = yamlDecoder.Decode(&unstructuredObj); err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		// Check if the object is a secret
+		if unstructuredObj.GetKind() == SECRET {
+			fmt.Printf("Skipping deletion of secret: %s/%s\n", unstructuredObj.GetNamespace(), unstructuredObj.GetName())
+			continue
+		}
+
+		objKey := runtimeclient.ObjectKey{
+			Namespace: unstructuredObj.GetNamespace(),
+			Name:      unstructuredObj.GetName(),
+		}
+		if err := r.Get(ctx, objKey, &unstructuredObj); err != nil {
+			if !errors.IsNotFound(err) {
+				fmt.Printf("Failed to get object: %s/%s\n", unstructuredObj.GetNamespace(), unstructuredObj.GetName())
+				return fmt.Errorf("failed to get object: %s/%s: %w", unstructuredObj.GetNamespace(), unstructuredObj.GetName(), err)
+			}
+			continue
+		}
+
+		fmt.Printf("Deleting object: %s/%s\n", unstructuredObj.GetNamespace(), unstructuredObj.GetName())
+		err = r.Delete(ctx, &unstructuredObj, &runtimeclient.DeleteOptions{})
+		if err != nil {
+			fmt.Printf("Failed to delete object: %s/%s\n", unstructuredObj.GetNamespace(), unstructuredObj.GetName())
+			return fmt.Errorf("failed to delete object: %s/%s: %w", unstructuredObj.GetNamespace(), unstructuredObj.GetName(), err)
+		}
+	}
+
+	return nil
+}
+
+func CreateOrGetNameSpace(ctx context.Context, cs *kubernetes.Clientset, namespace string) error {
+	_, err := cs.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			nsInstance := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			_, createErr := cs.CoreV1().Namespaces().Create(ctx, nsInstance, metav1.CreateOptions{})
+			if createErr != nil {
+				return fmt.Errorf("error occurred when creating the namespace [%s]: [%v]", namespace, createErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("error occurred when getting the namespace [%s]: [%v]", namespace, err)
+	}
+	return nil
+}
+
+func CreateAuthSecret(ctx context.Context, cs *kubernetes.Clientset, namespace string, refreshToken string) error {
+	secretName := "vcloud-basic-auth"
+	username := ""
+	password := ""
+
+	// Create the secret object
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			"refreshToken": refreshToken,
+			"username":     username,
+			"password":     password,
+		},
+	}
+	return createSecret(ctx, cs, secret, namespace)
+}
+
+func CreateClusterIDSecret(ctx context.Context, cs *kubernetes.Clientset, namespace string, clusterID string) error {
+	secretName := "vcloud-clusterid-secret"
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		StringData: map[string]string{
+			"clusterid": clusterID,
+		},
+	}
+	return createSecret(ctx, cs, secret, namespace)
+}
+
+func CreateCCMConfigMap(ctx context.Context, cs *kubernetes.Clientset, namespace, host, org, vdcName, clusterID, clusterName, ovdcNetwork string) error {
+	var err error
+	hundredKB := 100 * 1024
+	cpiConfigMapTemplate := template.New("cpi_config_map")
+
+	if cpiConfigMapTemplate, err = cpiConfigMapTemplate.Parse(ccmConfigMapYamlTemplate); err != nil {
+		return fmt.Errorf("failed to parse cpi_config_map template: %v", err)
+	}
+	configMapInput := ConfigMapInput{
+		VcdHost:   host,
+		OVDC:      vdcName,
+		ClusterID: clusterID,
+		ORG:       org,
+		Network:   ovdcNetwork,
+		VAPP:      clusterName,
+	}
+	buff := bytes.Buffer{}
+
+	if err = cpiConfigMapTemplate.Execute(&buff, configMapInput); err != nil {
+		return fmt.Errorf("failed to render cpi_config_map template: %v", err)
+	}
+	configMap := &corev1.ConfigMap{}
+	yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(buff.Bytes()), hundredKB)
+	if err = yamlDecoder.Decode(configMap); err != nil {
+		return fmt.Errorf("failed to decode ConfigMap: %v", err)
+	}
+
+	return createConfigMap(ctx, cs, configMap, namespace)
+}
+
+func CreateCSIConfigMap(ctx context.Context, cs *kubernetes.Clientset, namespace, host, org, vdcName, clusterID, vAppName string) error {
+	hundredKB := 100 * 1024
+	var err error
+	configMap := &corev1.ConfigMap{}
+	buff := bytes.Buffer{}
+
+	configMapInput := ConfigMapInput{
+		VcdHost:   host,
+		OVDC:      vdcName,
+		ClusterID: clusterID,
+		ORG:       org,
+		VAPP:      vAppName,
+	}
+
+	csiConfigMapTemplate := template.New("csi_config_map")
+
+	if csiConfigMapTemplate, err = csiConfigMapTemplate.Parse(csiConfigMapYamlTemplate); err != nil {
+		return fmt.Errorf("failed to parse csi_config_map template: %v", err)
+	}
+	if err = csiConfigMapTemplate.Execute(&buff, configMapInput); err != nil {
+		return fmt.Errorf("failed to render csi_config_map template: %v", err)
+	}
+
+	yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(buff.Bytes()), hundredKB)
+	if err = yamlDecoder.Decode(configMap); err != nil {
+		return fmt.Errorf("failed to decode ConfigMap: %v", err)
+	}
+	return createConfigMap(ctx, cs, configMap, namespace)
+}
+
+func getVCDCluster(ctx context.Context, cs *kubernetes.Clientset, namespace string, name string) (*infrav2.VCDCluster, error) {
+	hundredKB := 100 * 1024
+	vcdCluster := &infrav2.VCDCluster{}
+	resp, err := cs.RESTClient().Get().
+		AbsPath(fmt.Sprintf("/apis/infrastructure.cluster.x-k8s.io/%s", CAPVCDObjectVersion)).
+		Resource("vcdclusters").
+		Namespace(namespace).
+		Name(name).
+		DoRaw(ctx)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to get vcdcluster: %v", err)
+	}
+	yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(resp), hundredKB)
+	if err = yamlDecoder.Decode(vcdCluster); err != nil {
+		return vcdCluster, fmt.Errorf("error occurred when decoding vcdcluster: %v", err)
+	}
+	return vcdCluster, nil
+}
+
+func createConfigMap(ctx context.Context, cs *kubernetes.Clientset, configMap *corev1.ConfigMap, namespace string) error {
+	_, err := cs.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create ConfigMap: %v", err)
+	}
+	return nil
+}
+
+func createSecret(ctx context.Context, cs *kubernetes.Clientset, secret *corev1.Secret, namespace string) error {
+	_, err := cs.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create secret: %v", err)
+	}
+	return nil
+}

--- a/tests/e2e/utils/node_pool_scaling_utils.go
+++ b/tests/e2e/utils/node_pool_scaling_utils.go
@@ -1,0 +1,214 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk"
+	"io"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"time"
+)
+
+func ScaleNodePool(ctx context.Context, r runtimeclient.Client, desiredNodePoolSize int64, yamlContent []byte) error {
+	fmt.Printf("Scaling node pool to %d\n", desiredNodePoolSize)
+
+	// Initialize variables
+	var err error = nil
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(yamlContent)))
+	hundredKB := 100 * 1024
+
+	// Iterate through YAML documents
+	for err == nil {
+		yamlBytes, err := yamlReader.Read()
+		if err == io.EOF {
+			break
+		}
+
+		// Decode YAML into unstructured object
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+		unstructuredObj := unstructured.Unstructured{}
+		err = yamlDecoder.Decode(&unstructuredObj)
+		if err != nil {
+			return fmt.Errorf("unable to parse yaml segment: [%v]\n", err)
+		}
+
+		// Extract kind and name from unstructured object
+		kind := unstructuredObj.GetKind()
+		name := unstructuredObj.GetName()
+
+		switch kind {
+		case MachineDeployment:
+			// If the kind is MachineDeployment, update the replicas field
+			specMap, err := GetMapBySpecName(unstructuredObj.Object, "spec", VCDCluster)
+			if err != nil {
+				return err
+			}
+
+			specMap["replicas"] = desiredNodePoolSize
+
+			// Patch the unstructured object with the updated MachineDeployment
+			force := true
+			executedErr := r.Patch(ctx, &unstructuredObj, runtimeclient.Apply, &runtimeclient.PatchOptions{
+				Force:        &force,
+				FieldManager: FieldManager,
+			})
+			if executedErr != nil {
+				return fmt.Errorf("failed to patch object of kind [%s] and name [%s]: %w", kind, name, executedErr)
+			}
+			break
+		}
+	}
+
+	fmt.Println("Node pool scaling completed successfully")
+	return nil
+}
+
+func MonitorK8sNodePools(testClient *testingsdk.TestClient, runtimeClient runtimeclient.Client, expectedWorkNodeCount int64) error {
+	fmt.Println("Monitoring Kubernetes to confirm changes")
+
+	timeout := timeoutMinutes * time.Minute
+	pollInterval := pollIntervalSeconds * time.Second
+
+	return wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		// Get all worker nodes
+		nodeList, err := testClient.GetWorkerNodes(context.Background())
+		if err != nil {
+			if testingsdk.IsRetryableError(err) {
+				fmt.Printf("Retryable error occurred while getting worker nodes: [%v]\n", err)
+				fmt.Println("Retrying monitor")
+				return false, nil
+			} else {
+				return true, fmt.Errorf("error getting worker nodes: [%v]", err)
+			}
+		}
+
+		// Check if the expected number of nodes exist for each worker pool
+		if len(nodeList) != int(expectedWorkNodeCount) {
+			fmt.Println("Cluster does not have the right number of nodes yet")
+			fmt.Println("Retrying monitor")
+			return false, nil
+		}
+
+		// Wait for all nodes to be spun up
+		machineList := &clusterv1.MachineList{}
+		err = runtimeClient.List(context.Background(), machineList)
+		if err != nil {
+			return true, fmt.Errorf("error getting machine list: [%v]", err)
+		}
+
+		for _, machine := range machineList.Items {
+			if machine.Status.Phase != machinePhaseRunning && machine.Status.Phase != machinePhaseProvisioned {
+				fmt.Printf("Machine %s : Phase: %s\n", machine.Name, machine.Status.Phase)
+				fmt.Println("Retrying monitor")
+				return false, nil
+			}
+		}
+
+		fmt.Println("Node pool monitoring completed successfully")
+		return true, nil
+	})
+}
+
+func WaitForClusterProvisioned(ctx context.Context, client runtimeclient.Client, clusterName, clusterNameSpace string) error {
+	timeout := timeoutMinutes * time.Minute
+	pollInterval := pollIntervalSeconds * time.Second
+	cluster := &clusterv1.Cluster{}
+
+	// Check the cluster readiness using wait.PollImmediate
+	if err := wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		if err := client.Get(ctx, runtimeclient.ObjectKey{Namespace: clusterNameSpace, Name: clusterName}, cluster); err != nil {
+			return false, fmt.Errorf("failed to get cluster: %w", err)
+		}
+		return cluster.Status.InfrastructureReady, nil
+	}); err != nil {
+		return fmt.Errorf("cluster readiness check failed: %w", err)
+	}
+
+	// Check the readiness of all machines
+	machineList := &clusterv1.MachineList{}
+
+	if err := client.List(ctx, machineList, runtimeclient.InNamespace(cluster.Namespace), runtimeclient.MatchingLabels{
+		clusterv1.ClusterNameLabel: cluster.Name,
+	}); err != nil {
+		return fmt.Errorf("failed to list machines: %w", err)
+	}
+
+	if err := wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		for _, machine := range machineList.Items {
+			if !controllerutil.ContainsFinalizer(&machine, clusterv1.MachineFinalizer) {
+				// Machine is being deleted, so skip it
+				continue
+			}
+
+			if machine.Status.Phase == machinePhaseProvisioning {
+				fmt.Printf("machine %s : phase: %s\n", machine.Name, machine.Status.Phase)
+				fmt.Println("retrying monitor")
+				return false, nil
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("machine readiness check failed: %w", err)
+	}
+
+	return nil
+}
+
+func WaitForMachinesRunning(ctx context.Context, client runtimeclient.Client, clusterName, clusterNameSpace string) error {
+	timeout := timeoutMinutes * time.Minute
+	pollInterval := pollIntervalSeconds * time.Second
+	machineList := &clusterv1.MachineList{}
+
+	if err := client.List(ctx, machineList, runtimeclient.InNamespace(clusterNameSpace), runtimeclient.MatchingLabels{
+		clusterv1.ClusterNameLabel: clusterName,
+	}); err != nil {
+		return fmt.Errorf("failed to list machines: %w", err)
+	}
+
+	if err := wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		for _, machine := range machineList.Items {
+			if !controllerutil.ContainsFinalizer(&machine, clusterv1.MachineFinalizer) {
+				// Machine is being deleted, so skip it
+				continue
+			}
+
+			if machine.Status.Phase != machinePhaseRunning {
+				fmt.Printf("machine %s : phase: %s\n", machine.Name, machine.Status.Phase)
+				fmt.Println("retrying monitor")
+				return false, nil
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("machine readiness check failed: %w", err)
+	}
+
+	return nil
+}
+
+func WaitForClusterDelete(ctx context.Context, client runtimeclient.Client, clusterName, clusterNameSpace string) error {
+	timeout := timeoutMinutes * time.Minute
+	pollInterval := pollIntervalSeconds * time.Second
+	cluster := &clusterv1.Cluster{}
+	// Check the cluster deletion using wait.PollImmediate
+	if err := wait.PollImmediate(pollInterval, timeout, func() (bool, error) {
+		err := client.Get(ctx, runtimeclient.ObjectKey{Namespace: clusterNameSpace, Name: clusterName}, cluster)
+		if err != nil && errors.IsNotFound(err) {
+			// Cluster is deleted
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
+		return fmt.Errorf("cluster deletion check failed: %w", err)
+	}
+
+	return nil
+}

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk"
+)
+
+const (
+	timeoutMinutes           = 40
+	pollIntervalSeconds      = 120
+	machinePhaseProvisioned  = "Provisioned"
+	machinePhaseProvisioning = "Provisioning"
+	machinePhaseRunning      = "Running"
+	VCDCluster               = "VCDCluster"
+	Cluster                  = "Cluster"
+	SECRET                   = "Secret"
+	MachineDeployment        = "MachineDeployment"
+)
+
+type ConfigMapInput struct {
+	VcdHost   string
+	ORG       string
+	OVDC      string
+	Network   string
+	ClusterID string
+	VAPP      string
+}
+
+func NewTestClient(host, org, userOrg, vdcName, username, token, clusterId string, getVdcClient bool) (*testingsdk.TestClient, error) {
+	vcdAuthParams := &testingsdk.VCDAuthParams{
+		Host:         host,
+		OrgName:      org,
+		UserOrg:      userOrg,
+		OvdcName:     vdcName,
+		Username:     username,
+		RefreshToken: token,
+		GetVdcClient: getVdcClient,
+	}
+	return testingsdk.NewTestClient(vcdAuthParams, clusterId)
+}
+
+func GetMapBySpecName(specMap map[string]interface{}, specName string, sectionName string) (map[string]interface{}, error) {
+	entity, ok := specMap[specName]
+	if !ok {
+		return nil, fmt.Errorf("unable to get map: [%s] from %s in capiYaml String\n", specName, sectionName)
+	}
+	updatedSpecMap, ok := entity.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert [%T] to map[string]interface{}", entity)
+	}
+	return updatedSpecMap, nil
+}

--- a/tests/e2e/workload_cluster_test.go
+++ b/tests/e2e/workload_cluster_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Workload Cluster Life cycle management", func() {
 			ExpectWithOffset(1, workloadClientSet).NotTo(BeNil(), "Workload client set is nil")
 
 			By("Getting the vcdcluster of the CAPVCD cluster - management cluster")
-			vcdCluster, err = utils.GetVCDClusterFromCluster(ctx, cs, clusterNameSpace, clusterName)
+			vcdCluster, err = utils.GetVCDClusterFromCluster(ctx, runtimeClient, clusterNameSpace, clusterName)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get VCDCluster from the cluster")
 			ExpectWithOffset(1, vcdCluster).NotTo(BeNil(), "VCDCluster is nil")
 
@@ -129,7 +129,7 @@ var _ = Describe("Workload Cluster Life cycle management", func() {
 			desiredWorkerNodeCount = int64(initialNodeCount + 2)
 
 			By("Resizing the node pool in the workload cluster")
-			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, capiYaml)
+			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, clusterName, clusterNameSpace)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to scale node pool")
 
 			By(fmt.Sprintf("Monitoring the status of machines inside the CAPVCD cluster after increasing the node pool from %d to %d", initialNodeCount, len(workerPoolNodes)))
@@ -145,7 +145,7 @@ var _ = Describe("Workload Cluster Life cycle management", func() {
 			desiredWorkerNodeCount = int64(len(workerPoolNodes) - 2)
 
 			By("Resizing the node pool in the workload cluster")
-			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, capiYaml)
+			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, clusterName, clusterNameSpace)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to scale node pool")
 
 			By(fmt.Sprintf("Monitoring the status of machines inside the CAPVCD cluster after decreasing the node pool from %d to %d", initialNodeCount, desiredWorkerNodeCount))

--- a/tests/e2e/workload_cluster_test.go
+++ b/tests/e2e/workload_cluster_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Workload Cluster Life cycle management", func() {
 
 			By("Getting the rdeID from the vcdCluster")
 			rdeID = vcdCluster.Status.InfraId
-			ExpectWithOffset(1, rdeID).NotTo(BeNil(), "rdeID is empty")
+			ExpectWithOffset(1, rdeID).NotTo(BeZero(), "rdeID is empty")
 
 			By("Creating the cluster resource sets")
 			err = utils.CreateWorkloadClusterResources(ctx, workloadClientSet, string(capiYaml), rdeID, vcdCluster)
@@ -168,6 +168,9 @@ var _ = Describe("Workload Cluster Life cycle management", func() {
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to monitor cluster deletion")
 			err = testClient.DeleteNameSpace(ctx, clusterName)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to delete cluster namespace")
+			By("Checking the RDE entity of the cluster is already deleted")
+			err = utils.CheckRdeEntityNonExisted(ctx, testClient.VcdClient, rdeID, clusterName)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to delete the cluster RDE entity")
 		})
 	})
 })

--- a/tests/e2e/workload_cluster_test.go
+++ b/tests/e2e/workload_cluster_test.go
@@ -1,0 +1,173 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk"
+	infrav2 "github.com/vmware/cluster-api-provider-cloud-director/api/v1beta2"
+	"github.com/vmware/cluster-api-provider-cloud-director/tests/e2e/utils"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"os"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	kcfg "sigs.k8s.io/cluster-api/util/kubeconfig"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Workload Cluster Life cycle management", func() {
+	When("create, resize, and delete the workload cluster", func() {
+		var (
+			runtimeClient          runtimeclient.Client
+			testClient             *testingsdk.TestClient
+			ctx                    context.Context
+			kubeConfig             []byte
+			capiYaml               []byte
+			cs                     *kubernetes.Clientset
+			workloadClientSet      *kubernetes.Clientset
+			desiredWorkerNodeCount int64
+			clusterName            string
+			clusterNameSpace       string
+			vcdCluster             *infrav2.VCDCluster
+			rdeID                  string
+		)
+
+		BeforeEach(func() {
+			var err error
+			var restConfig *rest.Config
+			testScheme := runtime.NewScheme() // new scheme required for client, to add our v1beta1 Infra resources
+
+			fmt.Println("Setting up!")
+			ctx = context.TODO()
+
+			fmt.Println("Getting the CAPI YAML!")
+			capiYaml, err = os.ReadFile(PathToWorkloadClusterCapiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to read CAPI YAML")
+			ExpectWithOffset(1, capiYaml).NotTo(BeEmpty(), "CAPI YAML is empty")
+
+			fmt.Println("Getting the Kubernetes Config!")
+			kubeConfig, err = os.ReadFile(PathToMngmntClusterKubecfg)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to read Kubernetes Config")
+			ExpectWithOffset(1, kubeConfig).NotTo(BeEmpty(), "Kubernetes Config is empty")
+
+			restConfig, cs, err = utils.CreateClientConfig(kubeConfig)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create client config")
+
+			utilruntime.Must(scheme.AddToScheme(testScheme))
+			utilruntime.Must(clusterv1beta1.AddToScheme(testScheme))
+			runtimeClient, err = runtimeclient.New(restConfig, runtimeclient.Options{Scheme: testScheme})
+			ExpectWithOffset(1, runtimeClient).NotTo(BeNil(), "Failed to create runtime client")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create runtime client")
+		})
+
+		It("CAPVCD should be able to create the workload cluster", func() {
+			var err error
+			By("Getting the clusterName and namespace")
+			clusterName, clusterNameSpace, err = utils.GetClusterNameAndNamespaceFromCAPIYaml(capiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get cluster name and namespace")
+			ExpectWithOffset(1, clusterName).NotTo(BeEmpty(), "Cluster name is empty")
+			ExpectWithOffset(1, clusterNameSpace).NotTo(BeEmpty(), "Cluster namespace is empty")
+
+			By("Creating the namespace when necessary")
+			err = utils.CreateOrGetNameSpace(ctx, cs, clusterNameSpace)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create or get namespace")
+
+			By("Applying the CAPI YAML in the CAPVCD mgmt cluster")
+			err = utils.ApplyCAPIYaml(ctx, runtimeClient, capiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to apply CAPI YAML")
+
+			err = utils.WaitForClusterProvisioned(ctx, runtimeClient, clusterName, clusterNameSpace)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to wait for cluster provisioned")
+
+			By("Retrieving the kube config of the workload cluster")
+			kubeConfigBytes, err := kcfg.FromSecret(ctx, runtimeClient, runtimeclient.ObjectKey{
+				Namespace: clusterNameSpace,
+				Name:      clusterName,
+			})
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to retrieve kube config")
+			ExpectWithOffset(1, kubeConfigBytes).NotTo(BeNil(), "Kube config is nil")
+
+			By("Validating the kube config of the workload cluster")
+			workloadClientSet, err = utils.ValidateKubeConfig(ctx, kubeConfigBytes)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to validate kube config")
+			ExpectWithOffset(1, workloadClientSet).NotTo(BeNil(), "Workload client set is nil")
+
+			By("Getting the vcdcluster of the CAPVCD cluster - management cluster")
+			vcdCluster, err = utils.GetVCDClusterFromCluster(ctx, cs, clusterNameSpace, clusterName)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get VCDCluster from the cluster")
+			ExpectWithOffset(1, vcdCluster).NotTo(BeNil(), "VCDCluster is nil")
+
+			By("Getting the rdeID from the vcdCluster")
+			rdeID = vcdCluster.Status.InfraId
+			ExpectWithOffset(1, rdeID).NotTo(BeNil(), "rdeID is empty")
+
+			By("Creating the cluster resource sets")
+			err = utils.CreateWorkloadClusterResources(ctx, workloadClientSet, string(capiYaml), rdeID, vcdCluster)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create cluster Resource Set")
+
+			By("Waiting for the cluster machines to become running state")
+			err = utils.WaitForMachinesRunning(ctx, runtimeClient, clusterName, clusterNameSpace)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to wait for machines running")
+		})
+
+		It("CAPVCD should be able to resize the cluster", func() {
+			var err error
+			testClient, err = utils.ConstructCAPVCDTestClient(ctx, vcdCluster, workloadClientSet, string(capiYaml), clusterNameSpace, clusterName, rdeID, true)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to construct CAPVCD test client")
+			ExpectWithOffset(1, testClient).NotTo(BeNil(), "Test client is nil")
+
+			By("Setting desired worker pool node account")
+			workerPoolNodes, err := testClient.GetWorkerNodes(context.Background())
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get worker nodes")
+			ExpectWithOffset(1, workerPoolNodes).NotTo(BeNil(), "Worker nodes are nil")
+
+			initialNodeCount := len(workerPoolNodes)
+			desiredWorkerNodeCount = int64(initialNodeCount + 2)
+
+			By("Resizing the node pool in the workload cluster")
+			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, capiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to scale node pool")
+
+			By(fmt.Sprintf("Monitoring the status of machines inside the CAPVCD cluster after increasing the node pool from %d to %d", initialNodeCount, len(workerPoolNodes)))
+			err = utils.MonitorK8sNodePools(testClient, runtimeClient, desiredWorkerNodeCount)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to monitor K8s node pools")
+
+			By(fmt.Sprintf("Verifying the final number of worker nodes after increasing the node pool to %d", len(workerPoolNodes)))
+			workerPoolNodes, err = testClient.GetWorkerNodes(context.Background())
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get worker nodes after resizing")
+			ExpectWithOffset(1, len(workerPoolNodes)).To(Equal(int(desiredWorkerNodeCount)), "Unexpected number of worker nodes after resizing")
+
+			initialNodeCount = int(desiredWorkerNodeCount)
+			desiredWorkerNodeCount = int64(len(workerPoolNodes) - 2)
+
+			By("Resizing the node pool in the workload cluster")
+			err = utils.ScaleNodePool(ctx, runtimeClient, desiredWorkerNodeCount, capiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to scale node pool")
+
+			By(fmt.Sprintf("Monitoring the status of machines inside the CAPVCD cluster after decreasing the node pool from %d to %d", initialNodeCount, desiredWorkerNodeCount))
+			err = utils.MonitorK8sNodePools(testClient, runtimeClient, desiredWorkerNodeCount)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to monitor K8s node pools")
+
+			By(fmt.Sprintf("Verifying the final number of worker nodes after decreasing the node pool to %d", len(workerPoolNodes)))
+			workerPoolNodes, err = testClient.GetWorkerNodes(context.Background())
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to get worker nodes after resizing")
+			ExpectWithOffset(1, len(workerPoolNodes)).To(Equal(int(desiredWorkerNodeCount)), "Unexpected number of worker nodes after resizing")
+		})
+
+		It("CAPVCD should be able to delete the workload cluster", func() {
+			By("Deleting the workload cluster")
+			err := utils.DeleteCAPIYaml(ctx, runtimeClient, capiYaml)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to delete CAPI YAML")
+
+			By("Monitoring the cluster get deleted")
+			err = utils.WaitForClusterDelete(ctx, runtimeClient, clusterName, clusterNameSpace)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to monitor cluster deletion")
+			err = testClient.DeleteNameSpace(ctx, clusterName)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to delete cluster namespace")
+		})
+	})
+})

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/capiyaml_utils.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/capiyaml_utils.go
@@ -1,0 +1,213 @@
+package testingsdk
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
+	"io"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const (
+	MachineDeployment     = "MachineDeployment"
+	KubeadmConfigTemplate = "KubeadmConfigTemplate"
+	VCDMachineTemplate    = "VCDMachineTemplate"
+)
+
+func GetCapvcdYamlFromRde(capvcdRDE swagger.DefinedEntity) (string, error) {
+	specIf, ok := capvcdRDE.Entity["spec"]
+	if !ok {
+		return "", fmt.Errorf("unable to get spec field from capvcd RDE [%s]", capvcdRDE.Id)
+	}
+
+	spec, ok := specIf.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unable to convert spec of capvcd rde [%s] from type [%T] to map[string]interface{}",
+			capvcdRDE.Id, specIf)
+	}
+
+	capiYamlIf, ok := spec["capiYaml"]
+	if !ok {
+		return "", fmt.Errorf("`capiYaml` field not found in spec for capvcd RDE [%s]", capvcdRDE.Id)
+	}
+
+	capiYaml, ok := capiYamlIf.(string)
+	if !ok {
+		return "", fmt.Errorf("unable to convert `capiYaml` of capvcd rde [%s] from type [%T] to string",
+			capvcdRDE.Id, specIf)
+	}
+
+	return capiYaml, nil
+}
+
+func GetMapBySpecName(specMap map[string]interface{}, specName string, sectionName string) (map[string]interface{}, error) {
+	entity, ok := specMap[specName]
+	if !ok {
+		return nil, fmt.Errorf("unable to get map: [%s] from %s in capiYaml String\n", specName, sectionName)
+	}
+	updatedSpecMap, ok := entity.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert [%T] to map[string]interface{}", entity)
+	}
+	return updatedSpecMap, nil
+}
+
+func getWorkerNodePoolObjectBase(ctx context.Context, client *vcdsdk.Client, clusterId string, objectType string) (map[string]interface{}, error) {
+	rde, err := getRdeById(ctx, client, clusterId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get defined entity by clusterId [%s]: [%v]", clusterId, err)
+	}
+
+	capiYaml, err := GetCapvcdYamlFromRde(*rde)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get capiyaml from RDE: [%v]", err)
+	}
+
+	hundredKB := 100 * 1024
+	err = nil
+	yamlReader := k8syaml.NewYAMLReader(bufio.NewReader(bytes.NewReader([]byte(capiYaml))))
+
+	for err == nil {
+		yamlBytes, err := yamlReader.Read()
+		if err == io.EOF {
+			break
+		}
+		yamlDecoder := k8syaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlBytes), hundredKB)
+		unstructuredObj := unstructured.Unstructured{}
+		err = yamlDecoder.Decode(&unstructuredObj)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse yaml segment: [%v]\n", err)
+		}
+		kind := unstructuredObj.GetKind()
+		switch kind {
+		case objectType:
+			return unstructuredObj.Object, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find any [%s] entities in capiyaml", objectType)
+}
+
+func CreateNewVCDMachineTemplate(ctx context.Context, client *vcdsdk.Client, clusterId string, nodePoolName string) (map[string]interface{}, error) {
+	newVcdMachineTemplate, err := getWorkerNodePoolObjectBase(ctx, client, clusterId, VCDMachineTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get VCDMachineTemplateBase: [%v]", err)
+	}
+
+	metadataIf, ok := newVcdMachineTemplate["metadata"]
+	if !ok {
+		return nil, fmt.Errorf("VcdMachineTemplate base has no metadata attribute")
+	}
+	metadata, ok := metadataIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not convert %s.metadata to map", VCDMachineTemplate)
+	}
+	metadata["name"] = nodePoolName
+
+	newVcdMachineTemplate["metadata"] = metadata
+	return newVcdMachineTemplate, nil
+}
+
+func CreateNewKubeadmConfigTemplate(ctx context.Context, client *vcdsdk.Client, clusterId string, nodePoolName string) (map[string]interface{}, error) {
+	newKubeadmConfigTemplate, err := getWorkerNodePoolObjectBase(ctx, client, clusterId, KubeadmConfigTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get KubeadmConfigTemplate: [%v]", err)
+	}
+
+	metadataIf, ok := newKubeadmConfigTemplate["metadata"]
+	if !ok {
+		return nil, fmt.Errorf("KubeadmConfigTemplate base has no metadata attribute")
+	}
+	metadata, ok := metadataIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not convert %s.metadata to map", VCDMachineTemplate)
+	}
+	metadata["name"] = nodePoolName
+	newKubeadmConfigTemplate["metadata"] = metadata
+	return newKubeadmConfigTemplate, nil
+}
+
+func CreateNewMachineDeployment(ctx context.Context, client *vcdsdk.Client, clusterId string, nodePoolName string, nodePoolSize int64) (map[string]interface{}, error) {
+	newMachineDeployment, err := getWorkerNodePoolObjectBase(ctx, client, clusterId, MachineDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get MachineDeployment: [%v]", err)
+	}
+
+	// change node pool name in metadata
+	metadataIf, ok := newMachineDeployment["metadata"]
+	if !ok {
+		return nil, fmt.Errorf("MachineDeployment base has no metadata attribute")
+	}
+	metadata, ok := metadataIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("could not convert %s.metadata to map", VCDMachineTemplate)
+	}
+	metadata["name"] = nodePoolName
+	newMachineDeployment["metadata"] = metadata
+
+	// change node pool name in spec.template.spec.bootstrap.configRef.name
+	specMap, err := GetMapBySpecName(newMachineDeployment, "spec", MachineDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("error converting %s.spec to map: [%v]", MachineDeployment, err)
+	}
+
+	templateIf, ok := specMap["template"]
+	if !ok {
+		return nil, fmt.Errorf("specMap has no template attribute")
+	}
+	template, ok := templateIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert spec.template to map")
+	}
+	spec2If, ok := template["spec"]
+	if !ok {
+		return nil, fmt.Errorf("spec.template has no spec attribute")
+	}
+	spec2, ok := spec2If.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert spec.template.spec to map")
+	}
+	bootstrapIf, ok := spec2["bootstrap"]
+	if !ok {
+		return nil, fmt.Errorf("spec.template.spec has no bootstrap attribute")
+	}
+	bootstrap, ok := bootstrapIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert spec.template.spec.bootstrap to map")
+	}
+	configRefIf, ok := bootstrap["configRef"]
+	if !ok {
+		return nil, fmt.Errorf("spec.template.spec.bootstrap has no configRef attribute")
+	}
+	configRef, ok := configRefIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert spec.template.spec.bootstrap.configRef to map")
+	}
+	configRef["name"] = nodePoolName
+
+	// change node pool name in spec.template.spec.infrastructureRef.name
+	infrastructureRefIf, ok := spec2["infrastructureRef"]
+	if !ok {
+		return nil, fmt.Errorf("spec.template.spec has no infrastructureRef attribute")
+	}
+	infrastructureRef, ok := infrastructureRefIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unable to convert spec.template.spec.infrastructureRef to map")
+	}
+	infrastructureRef["name"] = nodePoolName
+
+	// propagating changes up
+	// also change spec.replicas to nodePoolSize
+	bootstrap["configRef"] = configRef
+	spec2["bootstrap"] = bootstrap
+	spec2["infrastructureRef"] = infrastructureRef
+	template["spec"] = spec2
+	specMap["template"] = template
+	specMap["replicas"] = nodePoolSize
+	newMachineDeployment["spec"] = specMap
+
+	return newMachineDeployment, nil
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/client.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/client.go
@@ -1,0 +1,342 @@
+package testingsdk
+
+import (
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	"gopkg.in/yaml.v3"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type TestClient struct {
+	VcdClient   *vcdsdk.Client
+	Cs          kubernetes.Interface
+	ClusterId   string
+	ClusterName string
+	Config      *restclient.Config
+}
+
+type VCDAuthParams struct {
+	Host         string
+	OvdcName     string
+	OrgName      string
+	Username     string
+	RefreshToken string
+	UserOrg      string
+	GetVdcClient bool // This will need to be set to true as it's needed for CSI, but may not be needed for other use cases
+}
+
+type DeployParams struct {
+	Name            string
+	Labels          map[string]string
+	VolumeParams    VolumeParams
+	ContainerParams ContainerParams
+}
+type VolumeParams struct {
+	VolumeName string
+	PvcRef     string
+	MountPath  string
+}
+
+type ContainerParams struct {
+	ContainerName  string
+	ContainerImage string
+	ContainerPort  int32
+	Args           []string
+}
+
+func NewTestClient(params *VCDAuthParams, clusterId string) (*TestClient, error) {
+	client, err := getTestVCDClient(params)
+	if err != nil {
+		return nil, fmt.Errorf("error occured while generating client using [%s:%s] for cluster [%s]: [%v]", params.Username, params.UserOrg, clusterId, err)
+	}
+
+	kubeConfig, err := GetKubeconfigFromRDEId(context.TODO(), client, clusterId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubeconfig from RDE [%s]: [%v]", clusterId, err)
+	}
+	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfig))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create RESTConfig using kubeconfig from RDE: [%v]", err)
+	}
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create clientset using RESTConfig generated from kubeconfig for cluster [%s]: [%v]", clusterId, err)
+	}
+
+	clusterName, err := getClusterNameById(context.TODO(), client, clusterId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get Cluster Name by Cluster Id [%s]: [%v]", clusterId, err)
+	}
+	return &TestClient{
+		VcdClient:   client,
+		Cs:          cs,
+		ClusterId:   clusterId,
+		ClusterName: clusterName,
+		Config:      config,
+	}, nil
+}
+
+func createKubeClient(kubeConfig string) (kubernetes.Interface, error) {
+	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeConfig))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create RESTConfig using kubeconfig from RDE: [%v]", err)
+	}
+	return kubernetes.NewForConfig(config)
+}
+
+func (tc *TestClient) CreateNameSpace(ctx context.Context, nsName string) (*apiv1.Namespace, error) {
+	ns, err := createNameSpace(ctx, nsName, tc.Cs.(*kubernetes.Clientset))
+	if err != nil {
+		return nil, fmt.Errorf("error creating NameSpace [%s] for cluster [%s(%s)]: [%v]", nsName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return ns, nil
+}
+
+func (tc *TestClient) CreateDeployment(ctx context.Context, params *DeployParams, nameSpace string) (*appsv1.Deployment, error) {
+	deployment, err := createDeployment(ctx, tc.Cs.(*kubernetes.Clientset), params, nameSpace)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Deployment [%s] for cluster [%s(%s)]: [%v]", params.Name, tc.ClusterName, tc.ClusterId, err)
+	}
+	return deployment, nil
+}
+
+func (tc *TestClient) CreateLoadBalancerService(ctx context.Context, nameSpace string, serviceName string, annotations map[string]string, labels map[string]string, servicePort []apiv1.ServicePort, loadBalancerIP string) (*apiv1.Service, error) {
+	lbService, err := createLoadBalancerService(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, serviceName, annotations, labels, servicePort, loadBalancerIP)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LoadBalancer Service [%s] for cluster [%s(%s)]: [%v]", serviceName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return lbService, nil
+}
+
+func (tc *TestClient) DeleteDeployment(ctx context.Context, nameSpace string, deploymentName string) error {
+	err := deleteDeployment(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, deploymentName)
+	if err != nil {
+		return fmt.Errorf("error deleting Deployment [%s] for cluster [%s(%s)]: [%v]", deploymentName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+
+}
+
+func (tc *TestClient) DeleteNameSpace(ctx context.Context, nameSpace string) error {
+	err := deleteNameSpace(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace)
+	if err != nil {
+		return fmt.Errorf("error deleting NameSpace [%s] for cluster [%s(%s)]: [%v]", nameSpace, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+func (tc *TestClient) DeleteService(ctx context.Context, nameSpace string, serviceName string) error {
+	err := deleteService(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, serviceName)
+	if err != nil {
+		return fmt.Errorf("error deleting Service [%s] for cluster [%s(%s)]: [%v]", serviceName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+func (tc *TestClient) GetWorkerNodes(ctx context.Context) ([]apiv1.Node, error) {
+	wnPool, err := getWorkerNodes(ctx, tc.Cs.(*kubernetes.Clientset))
+	if err != nil {
+		if err == ResourceNotFound {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting Worker Node Pool for cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+	}
+	return wnPool, nil
+}
+
+func (tc *TestClient) GetNodes(ctx context.Context) ([]apiv1.Node, error) {
+	nPool, err := getNodes(ctx, tc.Cs.(*kubernetes.Clientset))
+	if err != nil {
+		if err == ResourceNotFound {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting Node Pool for cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+	}
+	return nPool, nil
+}
+
+func (tc *TestClient) GetDeployment(ctx context.Context, nameSpace string, deployName string) (*appsv1.Deployment, error) {
+	deployment, err := getDeployment(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, deployName)
+	if err != nil {
+		if err == ResourceNotFound {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting Deployment [%s] for cluster [%s(%s)]: [%v]", deployName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return deployment, nil
+}
+
+func (tc *TestClient) GetService(ctx context.Context, nameSpace string, serviceName string) (*apiv1.Service, error) {
+	svc, err := getService(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, serviceName)
+	if err != nil {
+		if err == ResourceNotFound {
+			return nil, err
+		}
+		return nil, fmt.Errorf("error getting Service [%s] for cluster [%s(%s)]: [%v]", serviceName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return svc, nil
+}
+
+func (tc *TestClient) GetConfigMap(namespace, name string) (*apiv1.ConfigMap, error) {
+	return tc.Cs.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (tc *TestClient) GetK8sVersion() (*version.Info, error) {
+	return tc.Cs.(*kubernetes.Clientset).Discovery().ServerVersion()
+}
+
+func (tc *TestClient) GetIpamSubnetFromConfigMap(cm *apiv1.ConfigMap) (string, error) {
+	data := cm.Data
+	ccmYaml, ok := data["vcloud-ccm-config.yaml"]
+	if !ok {
+		return "", fmt.Errorf("no data present")
+	}
+
+	var ccmCfgMap map[string]interface{}
+	err := yaml.Unmarshal([]byte(ccmYaml), &ccmCfgMap)
+	if err != nil {
+		return "", fmt.Errorf("err occurred: [%v]", err)
+	}
+
+	for key, val := range ccmCfgMap {
+		if key == "loadbalancer" {
+			lbDataMap, ok := val.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("unable to convert loadbalancer content to data map")
+			}
+			for k, v := range lbDataMap {
+				if k == "vipSubnet" {
+					return v.(string), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("unable to find vipSubnet from ConfigMap [%s]", cm.Name)
+}
+
+func (tc *TestClient) GetNetworkNameFromConfigMap(cm *apiv1.ConfigMap) (string, error) {
+	data := cm.Data
+	ccmYaml, ok := data["vcloud-ccm-config.yaml"]
+	if !ok {
+		return "", fmt.Errorf("no data present")
+	}
+
+	var result map[string]interface{}
+	err := yaml.Unmarshal([]byte(ccmYaml), &result)
+	if err != nil {
+		return "", fmt.Errorf("err occurred: [%v]", err)
+	}
+
+	for key, val := range result {
+		if key == "loadbalancer" {
+			lbDataMap, ok := val.(map[string]interface{})
+			if !ok {
+				return "", fmt.Errorf("unable to convert loadbalancer content to data map")
+			}
+			for k, v := range lbDataMap {
+				if k == "network" {
+					return v.(string), nil
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+func (tc *TestClient) WaitForDeploymentReady(ctx context.Context, nameSpace string, deployName string) error {
+	err := waitForDeploymentReady(ctx, tc.Cs.(*kubernetes.Clientset), nameSpace, deployName)
+	if err != nil {
+		return fmt.Errorf("error querying Deployment [%s] status for cluster [%s(%s)]: [%v]", deployName, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+func (tc *TestClient) WaitForWorkerNodeReady(ctx context.Context, workerNode *apiv1.Node) error {
+	err := wait.PollImmediate(defaultNodeInterval, defaultNodeReadyTimeout, func() (bool, error) {
+		nodes, err := tc.GetWorkerNodes(ctx)
+		if err != nil {
+			return false, fmt.Errorf("error getting a list of nodes from cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+		}
+
+		for _, node := range nodes {
+			if node.Name == workerNode.Name {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == apiv1.NodeReady && condition.Status == apiv1.ConditionTrue {
+						return true, nil
+					}
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error querying node [%s] status for cluster [%s(%s)]: [%v]", workerNode.Name, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+func (tc *TestClient) WaitForWorkerNodePhaseRunning(ctx context.Context, workerNode *apiv1.Node) error {
+	err := wait.PollImmediate(defaultNodeInterval, defaultNodeReadyTimeout, func() (bool, error) {
+		nodes, err := tc.GetWorkerNodes(ctx)
+		if err != nil {
+			return false, fmt.Errorf("error getting a list of nodes from cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+		}
+
+		for _, node := range nodes {
+			if node.Name == workerNode.Name && node.Status.Phase == apiv1.NodeRunning {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error querying node [%s] status for cluster [%s(%s)]: [%v]", workerNode.Name, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+// WaitForWorkerNodeNotReady we cannot use negate result from WaitForWorkerNodeReady() Set different RetryTimeInterval and avoid timeout error
+func (tc *TestClient) WaitForWorkerNodeNotReady(ctx context.Context, workerNode *apiv1.Node) error {
+	err := wait.PollImmediate(defaultNodeInterval, defaultNodeNotReadyTimeout, func() (bool, error) {
+		nodes, err := tc.GetWorkerNodes(ctx)
+		if err != nil {
+			return false, fmt.Errorf("error getting a list of nodes from cluster [%s(%s)]: [%v]", tc.ClusterName, tc.ClusterId, err)
+		}
+
+		for _, node := range nodes {
+			if node.Name == workerNode.Name {
+				for _, condition := range node.Status.Conditions {
+					if condition.Type == apiv1.NodeReady && condition.Status != apiv1.ConditionTrue {
+						return true, nil
+					}
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("error querying node [%s] status for cluster [%s(%s)]: [%v]", workerNode.Name, tc.ClusterName, tc.ClusterId, err)
+	}
+	return nil
+}
+
+func (tc *TestClient) WaitForExtIP(namespace string, name string) (string, error) {
+	svc, err := waitForServiceExposure(tc.Cs, namespace, name)
+	if err != nil {
+		return "", err
+	}
+
+	if svc == nil {
+		return "", fmt.Errorf("the service is nil")
+	}
+	// We can safely return below as we handled the len(IngressList) check in waitServiceExposure()
+	return svc.Status.LoadBalancer.Ingress[0].IP, nil
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/k8sclient.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/k8sclient.go
@@ -1,0 +1,386 @@
+package testingsdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+	"time"
+)
+
+var (
+	ResourceExisted             = errors.New("[REX] resource is already existed")
+	ResourceNotFound            = errors.New("[RNF] resource is not found")
+	ResourceNameNull            = errors.New("[RNN] resource name is null")
+	ControlPlaneLabel           = "node-role.kubernetes.io/control-plane"
+	defaultRetryInterval        = 10 * time.Second
+	defaultRetryTimeout         = 160 * time.Second
+	defaultLongRetryInterval    = 20 * time.Second
+	defaultLongRetryTimeout     = 300 * time.Second
+	defaultNodeInterval         = 2 * time.Second
+	defaultNodeReadyTimeout     = 20 * time.Minute
+	defaultNodeNotReadyTimeout  = 8 * time.Minute
+	defaultServiceRetryInterval = 10 * time.Second
+	defaultServiceRetryTimeout  = 5 * time.Minute
+)
+
+func waitForServiceExposure(cs kubernetes.Interface, namespace string, name string) (*apiv1.Service, error) {
+	var svc *apiv1.Service
+	var err error
+
+	err = wait.PollImmediate(defaultServiceRetryInterval, defaultServiceRetryTimeout, func() (bool, error) {
+		svc, err = cs.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			// If our error is retryable, it's not a major error. So we do not need to return it as an error.
+			if IsRetryableError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+
+		IngressList := svc.Status.LoadBalancer.Ingress
+		if len(IngressList) == 0 {
+			// we'll store an error here and continue to retry until timeout, if this was where we time out eventually, we will return an error at the end
+			err = fmt.Errorf("cannot find Ingress components after duration: [%d] minutes", defaultServiceRetryTimeout/time.Minute)
+			return false, nil
+		}
+
+		ip := svc.Status.LoadBalancer.Ingress[0].IP
+		return ip != "", nil // Once we have our IP, we can terminate the condition for polling and return the service
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func waitForDeploymentReady(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, deployName string) error {
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		options := metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("app=%s", deployName),
+		}
+		podList, err := k8sClient.CoreV1().Pods(nameSpace).List(ctx, options)
+		if err != nil {
+			if IsRetryableError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("unexpected error occurred while getting deployment [%s]", deployName)
+		}
+		podCount := len(podList.Items)
+
+		ready := 0
+		for _, pod := range (*podList).Items {
+			if pod.Status.Phase == apiv1.PodRunning {
+				ready++
+			}
+		}
+		if ready < podCount {
+			fmt.Printf("running pods: %v < %v\n", ready, podCount)
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}
+
+func waitForDeploymentDeleted(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, deployName string) (bool, error) {
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		_, err := getDeployment(ctx, k8sClient, nameSpace, deployName)
+		if err != nil {
+			if err == ResourceNotFound {
+				return true, nil
+			}
+			if IsRetryableError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("unexpected error occurred while getting deployment [%s]", deployName)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("error occurred while checking deployment status: %v", err)
+	}
+	return true, nil
+}
+
+func waitForServiceDeleted(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, serviceName string) (bool, error) {
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		_, err := getService(ctx, k8sClient, nameSpace, serviceName)
+		if err != nil {
+			if err == ResourceNotFound {
+				return true, nil
+			}
+			if IsRetryableError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("unexpected error occurred while getting service [%s]", serviceName)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("error occurred while checking serviceName status: %v", err)
+	}
+	return true, nil
+}
+
+func waitForNameSpaceDeleted(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string) (bool, error) {
+	err := wait.PollImmediate(defaultLongRetryInterval, defaultLongRetryTimeout, func() (bool, error) {
+		_, err := k8sClient.CoreV1().Namespaces().Get(ctx, nameSpace, metav1.GetOptions{})
+		if err != nil {
+			if apierrs.IsNotFound(err) {
+				return true, nil
+			}
+			if IsRetryableError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("unexpected error occurred while getting namespace [%s]", nameSpace)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("error occurred while checking namespace status: %v", err)
+	}
+	return true, nil
+}
+
+func IsRetryableError(err error) bool {
+	if apierrs.IsInternalError(err) || apierrs.IsTimeout(err) || apierrs.IsServerTimeout(err) ||
+		apierrs.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) {
+		return true
+	}
+	return false
+}
+
+func getDeployment(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, deployName string) (*appsv1.Deployment, error) {
+	if deployName == "" {
+		return nil, ResourceNameNull
+	}
+	deployment, err := k8sClient.AppsV1().Deployments(nameSpace).Get(ctx, deployName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil, ResourceNotFound
+		}
+		return nil, err
+	}
+	return deployment, nil
+}
+
+func getService(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, serviceName string) (*apiv1.Service, error) {
+	if serviceName == "" {
+		return nil, ResourceNameNull
+	}
+	svc, err := k8sClient.CoreV1().Services(nameSpace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil, ResourceNotFound
+		}
+		return nil, err
+	}
+	return svc, nil
+}
+
+func getWorkerNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]apiv1.Node, error) {
+	var workerNodes []apiv1.Node
+	nodes, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return workerNodes, fmt.Errorf("error occurred while getting nodes: [%v]", err)
+	}
+	for _, node := range nodes.Items {
+		_, ok := node.Labels[ControlPlaneLabel]
+		if !ok {
+			workerNodes = append(workerNodes, node)
+		}
+	}
+	return workerNodes, nil
+}
+
+func getNodes(ctx context.Context, k8sClient *kubernetes.Clientset) ([]apiv1.Node, error) {
+	var allNodes []apiv1.Node
+	nodes, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return allNodes, fmt.Errorf("error occurred while getting nodes: [%v]", err)
+	}
+	for _, node := range nodes.Items {
+		allNodes = append(allNodes, node)
+	}
+	return allNodes, nil
+}
+
+func createNameSpace(ctx context.Context, nsName string, k8sClient *kubernetes.Clientset) (*apiv1.Namespace, error) {
+	if nsName == "" {
+		return nil, ResourceNameNull
+	}
+	namespace := &apiv1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}
+	ns, err := k8sClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating namespace [%s]: [%v]", nsName, err)
+	}
+	return ns, nil
+}
+
+func createDeployment(ctx context.Context, k8sClient *kubernetes.Clientset, params *DeployParams, nameSpace string) (*appsv1.Deployment, error) {
+	if params.Name == "" {
+		return nil, ResourceNameNull
+	}
+	if nameSpace == "" {
+		nameSpace = apiv1.NamespaceDefault
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: nameSpace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: params.Labels,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: params.Labels,
+				},
+				Spec: apiv1.PodSpec{
+					Containers: []apiv1.Container{
+						{
+							Image:           params.ContainerParams.ContainerImage,
+							ImagePullPolicy: apiv1.PullAlways,
+							Name:            params.ContainerParams.ContainerName,
+							Args:            params.ContainerParams.Args,
+							Ports: []apiv1.ContainerPort{
+								{
+									ContainerPort: params.ContainerParams.ContainerPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if params.VolumeParams.VolumeName != "" && params.VolumeParams.PvcRef != "" && params.VolumeParams.MountPath != "" {
+		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = []apiv1.VolumeMount{
+			{
+				Name:      params.VolumeParams.VolumeName,
+				MountPath: params.VolumeParams.MountPath,
+			},
+		}
+		deployment.Spec.Template.Spec.Volumes = []apiv1.Volume{
+			{
+				Name: params.VolumeParams.VolumeName,
+				VolumeSource: apiv1.VolumeSource{
+					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: params.VolumeParams.PvcRef,
+					},
+				},
+			},
+		}
+	}
+
+	newDeployment, err := k8sClient.AppsV1().Deployments(nameSpace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating deployment [%s]: [%v]", params.Name, err)
+	}
+	return newDeployment, nil
+}
+
+func createLoadBalancerService(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, serviceName string, annotations map[string]string, labels map[string]string, servicePort []apiv1.ServicePort, loadBalancerIP string) (*apiv1.Service, error) {
+	if serviceName == "" {
+		return nil, ResourceNameNull
+	}
+	if nameSpace == "" {
+		nameSpace = apiv1.NamespaceDefault
+	}
+	svc := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Namespace:   nameSpace,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: apiv1.ServiceSpec{
+			Ports:          servicePort,
+			Selector:       labels,
+			Type:           "LoadBalancer",
+			LoadBalancerIP: loadBalancerIP,
+		},
+	}
+	newSVC, err := k8sClient.CoreV1().Services(nameSpace).Create(ctx, svc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error occurred while creating service [%s]: [%v]", serviceName, err)
+	}
+	return newSVC, nil
+}
+
+func deleteDeployment(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, deploymentName string) error {
+	_, err := getDeployment(ctx, k8sClient, nameSpace, deploymentName)
+	if err != nil {
+		if err == ResourceNotFound {
+			return fmt.Errorf("the deployment [%s] does not exist", deploymentName)
+		}
+		klog.Info("error occurred while getting deployment [%s]: [%v]", deploymentName, err)
+	}
+	err = k8sClient.AppsV1().Deployments(nameSpace).Delete(ctx, deploymentName, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete deployment [%s]", deploymentName)
+	}
+	deploymentDeleted, err := waitForDeploymentDeleted(ctx, k8sClient, nameSpace, deploymentName)
+	if err != nil {
+		return fmt.Errorf("error occurred while deleting deployment [%s]: [%v]", deploymentName, err)
+	}
+	if !deploymentDeleted {
+		return fmt.Errorf("deployment [%s] still exists", deploymentName)
+	}
+	return nil
+}
+
+func deleteNameSpace(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string) error {
+	err := k8sClient.CoreV1().Namespaces().Delete(ctx, nameSpace, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete namespace [%s]", nameSpace)
+	}
+	namespaceDeleted, err := waitForNameSpaceDeleted(ctx, k8sClient, nameSpace)
+	if err != nil {
+		return fmt.Errorf("error occurred while deleting namespace [%s]: [%v]", nameSpace, err)
+	}
+	if !namespaceDeleted {
+		return fmt.Errorf("namespace [%s] still exists", nameSpace)
+	}
+	return nil
+}
+
+func deleteService(ctx context.Context, k8sClient *kubernetes.Clientset, nameSpace string, serviceName string) error {
+	_, err := getService(ctx, k8sClient, nameSpace, serviceName)
+	if err != nil {
+		if err == ResourceNotFound {
+			return fmt.Errorf("the service [%s] does not exist", serviceName)
+		}
+		klog.Info("error occurred while getting service [%s]: [%v]", serviceName, err)
+	}
+	err = k8sClient.CoreV1().Services(nameSpace).Delete(ctx, serviceName, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to delete service [%s]", serviceName)
+	}
+	serviceDeleted, err := waitForServiceDeleted(ctx, k8sClient, nameSpace, serviceName)
+	if err != nil {
+		return fmt.Errorf("error occurred while deleting service [%s]: [%v]", serviceName, err)
+	}
+	if !serviceDeleted {
+		return fmt.Errorf("service [%s] still exists", serviceName)
+	}
+	return nil
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/rde_utils.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/rde_utils.go
@@ -1,0 +1,109 @@
+package testingsdk
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+)
+
+// TODO: In the future, we will need to consider how to handle different versions of RDE. Currently these functions are not resilient to RDE version changes.
+
+func GetVCDResourceSet(ctx context.Context, client *vcdsdk.Client, clusterId, componentName string) ([]vcdsdk.VCDResource, error) {
+	vcdResourceSetMap, err := getVcdResourceSetComponentMapFromRDEId(ctx, client, clusterId, componentName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving vcd resource set array from RDE [%s]: [%v]", clusterId, err)
+	}
+	return convertVcdResourceSetMapToVcdResourceArr(vcdResourceSetMap)
+}
+
+// Returns status.component as map[string]interface{}, this will help us narrow down to specific fields such as nodepools, vcdresources, etc
+// Components: vcdKe, projector, csi, cpi, capvcd
+func GetComponentMapInStatus(ctx context.Context, client *vcdsdk.Client, clusterId, componentName string) (map[string]interface{}, error) {
+	rde, err := getRdeById(ctx, client, clusterId)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get defined entity [%s]: [%v]", clusterId, err)
+	}
+
+	entityStatusIf, ok := rde.Entity["status"]
+	if !ok {
+		return nil, fmt.Errorf("status field not found in RDE [%s]", rde.Id)
+	}
+
+	entityStatus, ok := entityStatusIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert capvcd RDE [%s] status field from [%T] to map[string]interface{}",
+			rde.Id, entityStatusIf)
+	}
+
+	componentStatusIf, ok := entityStatus[componentName]
+	if !ok {
+		return nil, fmt.Errorf("[%s] field not found in status field of RDE [%s]", componentName, rde.Id)
+	}
+
+	componentStatus, ok := componentStatusIf.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert [%s] status from [%T] to map[string]interface{} for RDE [%s]",
+			componentName, componentStatusIf, clusterId)
+	}
+	return componentStatus, nil
+}
+
+func GetKubeconfigFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
+	capvcdStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, vcdsdk.ComponentCAPVCD)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving [%s] field in status field of RDE [%s]: [%v]", vcdsdk.ComponentCAPVCD, clusterId, err)
+	}
+
+	privateStatusIf, ok := capvcdStatusMap["private"]
+	if !ok {
+		return "", fmt.Errorf("private field not found in status->capvcd of RDE [%s]", clusterId)
+	}
+
+	capvcdPrivateStatusMap, ok := privateStatusIf.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed to convert RDE [%s]  status->capvcd->private from [%T] to map[string]interface{}", clusterId, privateStatusIf)
+	}
+
+	kubeConfig, ok := capvcdPrivateStatusMap["kubeConfig"]
+	if !ok {
+		return "", fmt.Errorf("kubeConfig field not found in status->capvcd->private of RDE [%s]", clusterId)
+	}
+	return kubeConfig.(string), nil
+}
+
+func getVcdResourceSetComponentMapFromRDEId(ctx context.Context, client *vcdsdk.Client, clusterId, componentName string) (interface{}, error) {
+	componentStatusMap, err := GetComponentMapInStatus(ctx, client, clusterId, componentName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving field [%s] in status from RDE [%s]: [%v]", componentName, clusterId, err)
+	}
+
+	// Inferred type is interface{} for both key and values. So we cannot directly type assert into []vcdsdk.VCDResource.
+	vcdResourceSetArr, ok := componentStatusMap[vcdsdk.ComponentStatusFieldVCDResourceSet]
+	if !ok {
+		return nil, fmt.Errorf("vcdResourceSet field not found in status->[%s] of RDE [%s]", componentName, clusterId)
+	}
+	return vcdResourceSetArr, nil
+}
+
+// This step is required because the type inferred is []interface{}, and we cannot do type assertion here, so we must marshal and unmarshal
+func convertVcdResourceSetMapToVcdResourceArr(vcdResourceSetArr interface{}) ([]vcdsdk.VCDResource, error) {
+	data, err := json.Marshal(vcdResourceSetArr)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling VCDResourceSet [%T]: [%v]", vcdResourceSetArr, err)
+	}
+	var vcdResourceSet []vcdsdk.VCDResource
+	err = json.Unmarshal(data, &vcdResourceSet)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling data to [%T]: [%v]", vcdResourceSet, err)
+	}
+	return vcdResourceSet, nil
+}
+
+func getClusterNameById(ctx context.Context, client *vcdsdk.Client, clusterId string) (string, error) {
+	rde, err := getRdeById(ctx, client, clusterId)
+	if err != nil {
+		return "", fmt.Errorf("unable to get defined entity by clusterId [%s]: [%v]", clusterId, err)
+	}
+	return rde.Name, nil
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/set_utils.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/set_utils.go
@@ -1,0 +1,24 @@
+package testingsdk
+
+type Set struct {
+	m map[interface{}]bool
+}
+
+func NewSet() *Set {
+	s := &Set{}
+	s.m = make(map[interface{}]bool)
+	return s
+}
+
+func (s *Set) Add(value interface{}) {
+	s.m[value] = true
+}
+
+func (s *Set) Contains(value interface{}) bool {
+	_, c := s.m[value]
+	return c
+}
+
+func (s *Set) Size() int {
+	return len(s.m)
+}

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/vcd_utils.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/vcd_utils.go
@@ -1,0 +1,69 @@
+package testingsdk
+
+import (
+	"context"
+	"fmt"
+	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
+	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func getTestVCDClient(params *VCDAuthParams) (*vcdsdk.Client, error) {
+	return vcdsdk.NewVCDClientFromSecrets(
+		params.Host,
+		params.OrgName,
+		params.OvdcName,
+		params.UserOrg,
+		params.Username,
+		"",
+		params.RefreshToken,
+		true,
+		params.GetVdcClient)
+}
+
+func getRdeById(ctx context.Context, client *vcdsdk.Client, rdeId string) (*swagger.DefinedEntity, error) {
+	clusterOrg, err := client.VCDClient.GetOrgByName(client.ClusterOrgName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving org [%s]: [%v]", client.ClusterOrgName, err)
+	}
+	if clusterOrg == nil || clusterOrg.Org == nil {
+		return nil, fmt.Errorf("retrieved org is nil for [%s]", client.ClusterOrgName)
+	}
+	rde, _, _, err := client.APIClient.DefinedEntityApi.GetDefinedEntity(ctx, rdeId, clusterOrg.Org.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDE [%s]: [%v]", rdeId, err)
+	}
+	return &rde, nil
+}
+
+func GetVappTemplates(client *vcdsdk.Client) ([]*types.QueryResultVappTemplateType, error) {
+	var allVappTemplates []*types.QueryResultVappTemplateType
+
+	clusterOrg, err := client.VCDClient.GetOrgByName(client.ClusterOrgName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving org [%s]: [%v]", client.ClusterOrgName, err)
+	}
+	catalogRecords, err := clusterOrg.QueryCatalogList()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving catalog records from org: [%s]: [%v]", clusterOrg.Org.Name, err)
+	}
+	for _, catalogRecord := range catalogRecords {
+		catalog, err := clusterOrg.GetCatalogByName(catalogRecord.Name, true)
+		if err != nil {
+			return nil, fmt.Errorf("error retreiving catalog [%s] from org [%s]: [%v]", catalogRecord.Name, clusterOrg.Org.Name, err)
+		}
+
+		vappTemplates, err := catalog.QueryVappTemplateList()
+		if err != nil {
+			return nil, fmt.Errorf("error retreiving vApp templates from catalog [%s] from org [%s]: [%v]", catalogRecord.Name, clusterOrg.Org.Name, err)
+		}
+
+		// It is possible that users have uploaded the same vApp templates to
+		// multiple catalogs, so it is possible that there are duplicate vApp
+		// templates in `allVappTemplates`
+		for _, vappTemplate := range vappTemplates {
+			allVappTemplates = append(allVappTemplates, vappTemplate)
+		}
+	}
+	return allVappTemplates, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# github.com/BurntSushi/toml v1.0.0
+## explicit; go 1.16
 # github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
@@ -7,6 +9,8 @@ github.com/Masterminds/semver/v3
 # github.com/Masterminds/sprig/v3 v3.2.3
 ## explicit; go 1.13
 github.com/Masterminds/sprig/v3
+# github.com/alessio/shellescape v1.4.1
+## explicit; go 1.14
 # github.com/antihax/optional v1.0.0
 ## explicit; go 1.13
 github.com/antihax/optional
@@ -113,6 +117,8 @@ github.com/google/gofuzz/bytesource
 # github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38
 ## explicit; go 1.14
 github.com/google/pprof/profile
+# github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2
+## explicit; go 1.19
 # github.com/google/uuid v1.3.0
 ## explicit
 github.com/google/uuid
@@ -125,6 +131,8 @@ github.com/huandu/xstrings
 # github.com/imdario/mergo v0.3.13
 ## explicit; go 1.13
 github.com/imdario/mergo
+# github.com/inconshreveable/mousetrap v1.0.1
+## explicit; go 1.18
 # github.com/josharian/intern v1.0.0
 ## explicit; go 1.5
 github.com/josharian/intern
@@ -142,6 +150,8 @@ github.com/kr/text
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/mattn/go-isatty v0.0.17
+## explicit; go 1.15
 # github.com/matttproud/golang_protobuf_extensions v1.0.2
 ## explicit; go 1.9
 github.com/matttproud/golang_protobuf_extensions/pbutil
@@ -226,6 +236,8 @@ github.com/onsi/gomega/types
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
+# github.com/pelletier/go-toml v1.9.4
+## explicit; go 1.12
 # github.com/peterhellberg/link v1.1.0
 ## explicit
 github.com/peterhellberg/link
@@ -260,11 +272,14 @@ github.com/shopspring/decimal
 # github.com/spf13/cast v1.5.0
 ## explicit; go 1.18
 github.com/spf13/cast
+# github.com/spf13/cobra v1.6.1
+## explicit; go 1.15
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
 # github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20230420174123-f285168de9e5
 ## explicit; go 1.17
+github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk
 github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient
@@ -785,6 +800,8 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
+# sigs.k8s.io/kind v0.20.0
+## explicit; go 1.16
 # sigs.k8s.io/structured-merge-diff/v4 v4.2.3
 ## explicit; go 1.13
 sigs.k8s.io/structured-merge-diff/v4/fieldpath


### PR DESCRIPTION
## Description

- Use `Server Side Apply` to apply and delete objects of `capiYaml`.
- Update the instruction documents for `CAPVCD` test automation.
- 


## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/467)
<!-- Reviewable:end -->
