### PR TITLE
Log cloud-init scripts only for debug mode

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -517,7 +517,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	cloudInit := string(mergedCloudInitBytes)
 
 	// nothing is redacted in the cloud init script - please ensure no secrets are present
-	log.Info(fmt.Sprintf("Cloud init Script: [%s]", cloudInit))
+	log.V(2).Info(fmt.Sprintf("Cloud init Script: [%s]", cloudInit))
 	err = capvcdRdeManager.AddToEventSet(ctx, capisdk.CloudInitScriptGenerated, "", machine.Name, "", skipRDEEventUpdates)
 	if err != nil {
 		log.Error(err, "failed to add CloudInitScriptGenerated event into RDE", "rdeID", vcdCluster.Status.InfraId)
@@ -1069,7 +1069,7 @@ func (r *VCDMachineReconciler) getBootstrapData(ctx context.Context, machine *cl
 		return "", errors.New("error retrieving bootstrap data: secret value key is missing")
 	}
 
-	log.Info(fmt.Sprintf("Auto-generated bootstrap script: [%s]", string(value)))
+	log.V(2).Info(fmt.Sprintf("Auto-generated bootstrap script: [%s]", string(value)))
 
 	return string(value), nil
 }


### PR DESCRIPTION
## Description

Currently, it always dumps cloud-init scripts, which makes logs of operator dirty. Also, cloud-init script contain sensitive data coming from kubeadmconfig. For example, join tokens, files to mount node via k8s secrets etc.

It is enough to set -zap-log-level=2 to print cloud-init scripts to logs.


## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/484)
<!-- Reviewable:end -->
