### PR TITLE
[CAFV-298] Downgrade kustomize to 4.5.7, controller-gen 0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CONTROLLER_GEN_VERSION := 0.4.1
 CONVERSION_GEN_VERSION := 0.23.1
 LINT_VERSION := 1.51.2
 GOSEC_VERSION := "v2.16.0"
+KUSTOMIZE_VERSION := 4.5.7
 
 GOLANGCI_EXIT_CODE ?= 1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -253,7 +254,7 @@ $(KUSTOMIZE): bin
 		set -ex -o pipefail && \
 		wget "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"; \
 		chmod +x ./install_kustomize.sh; \
-		./install_kustomize.sh 4.5.7 .; \
+		./install_kustomize.sh $(KUSTOMIZE_VERSION) .; \
 		rm -f ./install_kustomize.sh;
 
 $(CONTROLLER_GEN): bin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONTROLLER_GEN_VERSION := 0.8.0
+CONTROLLER_GEN_VERSION := 0.4.1
 CONVERSION_GEN_VERSION := 0.23.1
 LINT_VERSION := 1.51.2
 GOSEC_VERSION := "v2.16.0"
@@ -251,7 +251,10 @@ bin/testbin:
 $(KUSTOMIZE): bin
 	@cd bin && \
 		set -ex -o pipefail && \
-		wget -q -O - "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash;
+		wget "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"; \
+		chmod +x ./install_kustomize.sh; \
+		./install_kustomize.sh 4.5.7 .; \
+		rm -f ./install_kustomize.sh;
 
 $(CONTROLLER_GEN): bin
 	@GOBIN=$(GITROOT)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v${CONTROLLER_GEN_VERSION}


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Downgrade kustomize to 4.5.7, controller-gen to 0.4.1

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/490)
<!-- Reviewable:end -->
