### PR TITLE
[CAFV-298] Cherrypick commit 81031e5: Downgrade kustomize to 4.5.7, controller-gen 0.4.1 (#490)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-CONTROLLER_GEN_VERSION := 0.8.0
+CONTROLLER_GEN_VERSION := 0.4.1
 CONVERSION_GEN_VERSION := 0.23.1
 LINT_VERSION := 1.51.2
 GOSEC_VERSION := "v2.16.0"
+KUSTOMIZE_VERSION := 4.5.7
 
 GOLANGCI_EXIT_CODE ?= 1
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -251,7 +252,10 @@ bin/testbin:
 $(KUSTOMIZE): bin
 	@cd bin && \
 		set -ex -o pipefail && \
-		wget -q -O - "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash;
+		wget "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"; \
+		chmod +x ./install_kustomize.sh; \
+		./install_kustomize.sh $(KUSTOMIZE_VERSION) .; \
+		rm -f ./install_kustomize.sh;
 
 $(CONTROLLER_GEN): bin
 	@GOBIN=$(GITROOT)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v${CONTROLLER_GEN_VERSION}


### PR DESCRIPTION
* Downgrade kustomize to 4.5.7, controller-gen 0.4.1

Signed-off-by: lzichong <lzichong@vmware.com>

* Address Adnan CR: Use constant for kustomize version

Signed-off-by: lzichong <lzichong@vmware.com>

---------

Signed-off-by: lzichong <lzichong@vmware.com>
(cherry picked from commit 81031e51818863fef435252d4185cdda83e26e0e)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Cherrypick commit 81031e5 from main to 1.1.z

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/491)
<!-- Reviewable:end -->
