### PR TITLE
disable host path provisioner for clusters

### DIFF
--- a/examples/capi-quickstart.yaml
+++ b/examples/capi-quickstart.yaml
@@ -89,9 +89,6 @@ spec:
         certSANs:
         - localhost
         - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.7.0_vmware.12 # DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM. Refer to the github documentation for more details

--- a/templates/cluster-class-template.yaml
+++ b/templates/cluster-class-template.yaml
@@ -126,9 +126,6 @@ spec:
             certSANs:
               - localhost
               - 127.0.0.1
-          controllerManager:
-            extraArgs:
-              enable-hostpath-provisioner: "true"
           dns:
             imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
             imageTag: v1.8.4_vmware.9 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.22.9

--- a/templates/cluster-template-v1.20.8-crs.yaml
+++ b/templates/cluster-template-v1.20.8-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.7.0_vmware.12 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.20.8.

--- a/templates/cluster-template-v1.20.8.yaml
+++ b/templates/cluster-template-v1.20.8.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.7.0_vmware.12 # DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM. Refer to the github documentation for more details

--- a/templates/cluster-template-v1.21.8-crs.yaml
+++ b/templates/cluster-template-v1.21.8-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.0_vmware.11 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.21.8.

--- a/templates/cluster-template-v1.21.8.yaml
+++ b/templates/cluster-template-v1.21.8.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.0_vmware.11 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.21.8.

--- a/templates/cluster-template-v1.22.9-crs.yaml
+++ b/templates/cluster-template-v1.22.9-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.4_vmware.9 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.22.9

--- a/templates/cluster-template-v1.22.9.yaml
+++ b/templates/cluster-template-v1.22.9.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.4_vmware.9 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.22.9

--- a/templates/cluster-template-v1.23.10-crs.yaml
+++ b/templates/cluster-template-v1.23.10-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.6_vmware.11 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.23.10.

--- a/templates/cluster-template-v1.23.10.yaml
+++ b/templates/cluster-template-v1.23.10.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.6_vmware.11 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.23.10.

--- a/templates/cluster-template-v1.24.10-crs.yaml
+++ b/templates/cluster-template-v1.24.10-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.6_vmware.17 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.24.10.

--- a/templates/cluster-template-v1.24.10.yaml
+++ b/templates/cluster-template-v1.24.10.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.8.6_vmware.17 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.24.10.

--- a/templates/cluster-template-v1.25.7-crs.yaml
+++ b/templates/cluster-template-v1.25.7-crs.yaml
@@ -84,9 +84,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.9.3_vmware.8 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.25.7.

--- a/templates/cluster-template-v1.25.7.yaml
+++ b/templates/cluster-template-v1.25.7.yaml
@@ -80,9 +80,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: v1.9.3_vmware.8 # DNS image tag associated with the TKGm OVA used. This dns version is associated with TKG OVA using Kubernetes version v1.25.7.

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -89,9 +89,6 @@ spec:
         certSANs:
           - localhost
           - 127.0.0.1
-      controllerManager:
-        extraArgs:
-          enable-hostpath-provisioner: "true"
       dns:
         imageRepository: projects.registry.vmware.com/tkg # image repository to pull the DNS image from
         imageTag: ${DNS_VERSION} # DNS image tag associated with the TKGm OVA used. The values must be retrieved from the TKGm ova BOM. Refer to the github documentation for more details


### PR DESCRIPTION
- disable host path provisioned for cluster templates

## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/502)
<!-- Reviewable:end -->
