### PR TITLE
[CAFV-235] Remove fields as per PodSecurityPolicy deprecation and removal from Kubernetes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,8 +17,6 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director

--- a/config/manager/manager.yaml.template
+++ b/config/manager/manager.yaml.template
@@ -17,8 +17,6 @@ spec:
     spec:
       securityContext:
         runAsUser: 1000
-        runAsGroup: 3000
-        fsGroup: 2000
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1877,8 +1877,6 @@ spec:
           name: cert
           readOnly: true
       securityContext:
-        fsGroup: 2000
-        runAsGroup: 3000
         runAsUser: 1000
       serviceAccountName: capvcd-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Remove fields which are not covered by PSP
  - runAsGroup
  - fsGroup
- changed done as per https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/#eliminate-non-standard-options

## Checklist
- [x] tested locally - create and resize cluster
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #311

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/503)
<!-- Reviewable:end -->
