### PR TITLE
Fix the `test` make target, and make it possible to test a subset of packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin/*
 out/*
 tools/*
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ GOLANGCI_LINT ?= bin/golangci-lint
 GOSEC ?= bin/gosec
 SHELLCHECK ?= bin/shellcheck
 
+TEST_PACKAGES := ./...
 
 .PHONY: all
 all: vendor lint dev
@@ -135,7 +136,7 @@ test: manifests generate ## Run tests.
 	source bin/testbin/setup-envtest.sh; \
 	fetch_envtest_tools bin/testbin; \
 	setup_envtest_env "$(shell pwd)/bin/testbin"; \
-	go test ./... -coverprofile cover.out
+	go test $(TEST_PACKAGES) -coverprofile cover.out
 
 .PHONY: manager
 manager: generate ## Build manager binary.

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ test: manifests generate ## Run tests.
 	curl -sSLo bin/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh; \
 	source bin/testbin/setup-envtest.sh; \
 	fetch_envtest_tools bin/testbin; \
-	setup_envtest_env bin/testbin; \
+	setup_envtest_env "$(shell pwd)/bin/testbin"; \
 	go test ./... -coverprofile cover.out
 
 .PHONY: manager

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,11 @@ build: ## Build CAPVCD binary. To be used from within a Dockerfile
 .PHONY: test
 test: manifests generate ## Run tests.
 	@mkdir -p bin/testbin
-	test -f bin/testbin/setup-envtest.sh || curl -sSLo bin/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source bin/testbin/setup-envtest.sh
-	fetch_envtest_tools bin/testbin
-	setup_envtest_env bin/testbin
+	test -f bin/testbin/setup-envtest.sh || \
+	curl -sSLo bin/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh; \
+	source bin/testbin/setup-envtest.sh; \
+	fetch_envtest_tools bin/testbin; \
+	setup_envtest_env bin/testbin; \
 	go test ./... -coverprofile cover.out
 
 .PHONY: manager


### PR DESCRIPTION
## Description
A recent PR (#466) split commands that were on the same line into multiple lines. Now, when `go test` runs, it does not have the environment variable required by envtest, and fails.

```console
> make test
bin/controller-gen crd rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
test -f bin/testbin/setup-envtest.sh || curl -sSLo bin/testbin/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
source bin/testbin/setup-envtest.sh
fetch_envtest_tools bin/testbin
bash: line 1: fetch_envtest_tools: command not found
make: *** [Makefile:133: test] Error 127
```

The same PR introduced the use of a relative path for envtest assets. The path is relative to the repository root, and this means Go tests, which run relative to their package path, cannot find the envtest assets, and fail:

```log

  Unexpected error:
      <*fmt.wrapError | 0xc0006ba800>:
      unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec bin/testbin/bin/etcd: no such file or directory
      {
          msg: "unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec bin/testbin/bin/etcd: no such file or directory",
          err: <*fmt.wrapError | 0xc0006ba7e0>{
              msg: "failed to start the controlplane. retried 5 times: fork/exec bin/testbin/bin/etcd: no such file or directory",
              err: <*fs.PathError | 0xc00011b200>{
                  Op: "fork/exec",
                  Path: "bin/testbin/bin/etcd",
                  Err: <syscall.Errno>0x2,
              },
          },
      }
  occurred
```

This PR fixes these issues.

It also introduces the make variable `TEST_PACKAGES`, to make it possible to run the `test` make target with a subset of packages. For example, we can use this variable to skip the e2e tests:

```shell
make test TEST_PACKAGES='$(shell go list ./... | grep -v 'tests/e2e')'
```

----

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [x] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/513)
<!-- Reviewable:end -->
