### PR TITLE
fix: Sync the VCDMachine v1beta1 CRD with the go type

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -208,8 +208,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address
@@ -388,8 +388,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -986,8 +986,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address
@@ -1166,8 +1166,8 @@ spec:
                       description: The machine address.
                       type: string
                     type:
-                      description: Machine address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
                       type: string
                   required:
                   - address


### PR DESCRIPTION
## Description
A recent PR[1] updated the godoc comment that describes the VCDMachineSpec MachineAddress field, but the change was not reflected in the v1beta1 CRD.

[1]: https://github.com/vmware/cluster-api-provider-cloud-director/pull/445

This PR does not change the CRD schema, only a comment to a field, and therefore does not make any breaking changes.

---- 

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [x] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [x] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
