### PR TITLE
[CAFV-325] Use placeholders for registry for dependencies.txt

### DIFF
--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -16,7 +16,7 @@
 			{
 				"name":"cluster-api-provider-cloud-director",
 				"version":"__VERSION__",
-				"imageRepository":"projects.registry.vmware.com/vmware-cloud-director"
+				"imageRepository":"__REGISTRY__"
 			}
 		]
 	}

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,1 +1,1 @@
-projects.registry.vmware.com/vmware-cloud-director cluster-api-provider-cloud-director __VERSION__
+__REGISTRY__ cluster-api-provider-cloud-director __VERSION__


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Updates dependency.txt.template, bom.json.template to use `__REGISTRY__` placeholders

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/520)
<!-- Reviewable:end -->
