### PR TITLE
CAFV-319: Properly wait for containerd to start completely. (#512)

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -82,6 +82,25 @@ write_files:
       fi
       vmtoolsd --cmd "info-set guestinfo.post_customization_cloud_init_output $CLOUD_INIT_OUTPUT"
     }
+
+    wait_for_containerd_startup() {
+      echo "Waiting for containerd to start-up completely..."
+      while :
+      do
+        crictl_output=$(crictl info)
+        runtime_ready_status=$(echo ${crictl_output} | jq ".status.conditions[] | select(.type==\"RuntimeReady\") | .status")
+        echo "RuntimeReady is [${runtime_ready_status}]."
+        if [ "${runtime_ready_status}" = "true" ]
+        then
+          echo "containerd service has started up."
+          break
+        fi
+        echo "containerd service is not yet up. Sleeping for 5s and checking again"
+        sleep 5
+      done
+      echo "containerd started-up successfully."
+    }
+
     mkdir -p /var/log/capvcd/customization
     trap 'catch $? $LINENO' ERR EXIT
     set -eEx
@@ -127,6 +146,7 @@ write_files:
     END
     systemctl daemon-reload
     systemctl restart containerd
+    wait_for_containerd_startup
     vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- end }} {{- if .NvidiaGPU }}
 
     vmtoolsd --cmd "info-set guestinfo.postcustomization.nvidia.runtime.install.status in_progress"


### PR DESCRIPTION
Wait for the RuntimeReady status using crictl to ensure that the containerd service is up.

(cherry picked from commit a441041cf8fb2a073ebcb9563007f1e6f172d1a0)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Cherry-pick

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #512

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/522)
<!-- Reviewable:end -->
