### PR TITLE
CAFV-326: Make EnableNvidiaGPU into a no-op

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -6,33 +6,7 @@ write_files:
 - path: /etc/cloud/cloud.cfg.d/cse.cfg
   owner: root
   content: |
-     ssh_deletekeys: false {{- if .NvidiaGPU }}
-- path: /etc/containerd/config.toml
-  owner: root
-  content: |
-    version = 2
-
-    [plugins]
-      [plugins."io.containerd.grpc.v1.cri"]
-        sandbox_image = "projects.registry.vmware.com/tkg/pause:3.4.1"
-
-        [plugins."io.containerd.grpc.v1.cri".containerd]
-          default_runtime_name = "nvidia"
-
-          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
-              privileged_without_host_devices = false
-              runtime_engine = ""
-              runtime_root = ""
-              runtime_type = "io.containerd.runc.v2"
-
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-                BinaryName = "/usr/bin/nvidia-container-runtime"
-
-        [plugins."io.containerd.grpc.v1.cri".registry]
-          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-              endpoint = ["https://registry-1.docker.io"] {{- end }}
+     ssh_deletekeys: false
 - path: /opt/vmware/cloud-director/metering.sh
   owner: root
   content: |
@@ -147,16 +121,7 @@ write_files:
     systemctl daemon-reload
     systemctl restart containerd
     wait_for_containerd_startup
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- end }} {{- if .NvidiaGPU }}
-
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.nvidia.runtime.install.status in_progress"
-    distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-    curl -s -L https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
-    curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
-
-    sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
-
-    vmtoolsd --cmd "info-set guestinfo.postcustomization.nvidia.runtime.install.status successful" {{- end }}
+    vmtoolsd --cmd "info-set guestinfo.postcustomization.proxy.setting.status successful" {{- end }}
 
     vmtoolsd --cmd "info-set {{ if .ControlPlane -}} guestinfo.postcustomization.kubeinit.status {{- else -}} guestinfo.postcustomization.kubeadm.node.join.status {{- end }} in_progress"
     for IMAGE in "coredns" "etcd" "kube-proxy" "kube-apiserver" "kube-controller-manager" "kube-scheduler"

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -208,7 +208,6 @@ const (
 	MeteringConfiguration                  = "guestinfo.metering.status"
 	KubeadmInit                            = "guestinfo.postcustomization.kubeinit.status"
 	KubeadmNodeJoin                        = "guestinfo.postcustomization.kubeadm.node.join.status"
-	NvidiaRuntimeInstall                   = "guestinfo.postcustomization.nvidia.runtime.install.status"
 	PostCustomizationScriptExecutionStatus = "guestinfo.post_customization_script_execution_status"
 	PostCustomizationScriptFailureReason   = "guestinfo.post_customization_script_execution_failure_reason"
 )
@@ -217,7 +216,6 @@ var postCustPhases = []string{
 	NetworkConfiguration,
 	MeteringConfiguration,
 	ProxyConfiguration,
-	NvidiaRuntimeInstall,
 }
 
 func removeFromSlice(remove string, arr []string) []string {
@@ -497,7 +495,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 		// TODO: After tenants has access to siteId, populate siteId to cloudInitInput as opposed to the site
 		cloudInitInput.VcdHostFormatted = strings.ReplaceAll(vcdCluster.Spec.Site, "/", "\\/")
-		cloudInitInput.NvidiaGPU = vcdMachine.Spec.EnableNvidiaGPU
+		cloudInitInput.NvidiaGPU = false
 		cloudInitInput.TKGVersion = getTKGVersion(cluster)   // needed for both worker & control plane machines for metering
 		cloudInitInput.ClusterID = vcdCluster.Status.InfraId // needed for both worker & control plane machines for metering
 		cloudInitInput.ResizedControlPlane = isResizedControlPlane
@@ -836,10 +834,6 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		phases = append(phases, KubeadmInit)
 	} else {
 		phases = append(phases, KubeadmNodeJoin)
-	}
-
-	if !vcdMachine.Spec.EnableNvidiaGPU {
-		phases = removeFromSlice(NvidiaRuntimeInstall, phases)
 	}
 
 	if vcdCluster.Spec.ProxyConfigSpec.HTTPSProxy == "" &&


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request
- Do not customize VM even if EnableNvidiaGPU is set up. The customization that we performed was (slightly) helping customers who would install GPU drivers in GPU nodes directly. However this interferes with the NVIDIA GPU operator functionality.
- Those customers who would install GPU drivers in GPU nodes directly will be impacted by this change. However they can include the customization into their workflow directly since it is a very small customization
- Note that the flag has not yet been deprecated. The next API update should begin to show the deprecation.

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #CAFV-326

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/524)
<!-- Reviewable:end -->
