### PR TITLE
fix: small version typo in an error message

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -216,7 +216,7 @@ func validateDerivedRDEProperties(vcdCluster *infrav1.VCDCluster, infraID string
 		}
 		newRdeVersion, err := semver.New(rdeVersionInUse)
 		if err != nil {
-			return fmt.Errorf("invalid RDE verison [%s] derived", rdeVersionInUse)
+			return fmt.Errorf("invalid RDE version [%s] derived", rdeVersionInUse)
 		}
 		if newRdeVersion.LT(*statusRdeVersion) {
 			return fmt.Errorf("derived RDE version [%s] is lesser than RDE version in VCDCluster status [%s]",

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -8,7 +8,7 @@
 4. Run `clusterctl init -i vcd:v1.0.0`
 
 ## Upgrades from CAPVCD 1.0.x to 1.0.2
-To upgrade CAPVCD from verison 1.0.x to 1.0.2, a patch for CAPVCD deployment to update the image will be needed. Please execute the following command for each management cluster:
+To upgrade CAPVCD from version 1.0.x to 1.0.2, a patch for CAPVCD deployment to update the image will be needed. Please execute the following command for each management cluster:
 
 ```kubectl patch deployment -n capvcd-system capvcd-controller-manager -p '{"spec": {"template": {"spec": {"containers": [{"name": "manager", "image": "projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:1.0.2"}]}}}}'```
 


### PR DESCRIPTION
## Description
This is solely to fix this small typo:
https://github.com/vmware/cluster-api-provider-cloud-director/issues/540

Just a typo (`verison`) in the error message when there was an invalid RDE version
The other is just a docs fix when I searched for verison

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [x] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [x] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [x] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [x] N/A

## Issue
https://github.com/vmware/cluster-api-provider-cloud-director/issues/540

Fixes #
https://github.com/vmware/cluster-api-provider-cloud-director/issues/540

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/541)
<!-- Reviewable:end -->
