### PR TITLE
[CAFV-346]: comment out UsePAM variable before ssh restart in cloud init

### DIFF
--- a/controllers/cluster_scripts/cloud_init.tmpl
+++ b/controllers/cluster_scripts/cloud_init.tmpl
@@ -150,7 +150,7 @@ runcmd:
 - '[ ! -f /opt/vmware/cloud-director/metering.sh ] && sudo reboot'
 - '[ ! -f /etc/cloud/cloud.cfg.d/cse.cfg ] && sudo reboot'
 - '[ ! -f /etc/vcloud/metering ] && sudo reboot'
-- sed -i -e 's~#PermitRootLogin prohibit-password~PermitRootLogin yes~' /etc/ssh/sshd_config
+- sed -i -e 's~#PermitRootLogin prohibit-password~PermitRootLogin yes~' -e 's~UsePAM yes~#UsePAM yes~' /etc/ssh/sshd_config
 - 'service ssh restart'
 {{ if .ControlPlane }}
 - '[ ! -f /root/control_plane.sh ] && sudo reboot'


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- In TKG 2.3.0, remote console is not enabled by default, for which we need to enable ssh password based login. This was taken care by the PR https://github.com/vmware/cluster-api-provider-cloud-director/pull/535
- However, for ssh password based login to be allowed in TKG 2.3.0, UsePAM variable in sshd_config should also be commented out. This PR removes UsePAM variable from /etc/ssh/sshd_config to allow ssh password based root login for TKG 2.3.0

## Checklist
- [x] tested locally
- [x] updated any relevant dependencies
- [x] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/542)
<!-- Reviewable:end -->
