### PR TITLE
CAFV-377: Update manifests to point to the right versions of CPI,

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:v1.1.0
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:v1.2.0
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/templates/crs/cpi/cloud-director-ccm.yaml
+++ b/templates/crs/cpi/cloud-director-ccm.yaml
@@ -154,7 +154,7 @@ spec:
         fsGroup: 2000
       containers:
         - name: vmware-cloud-director-ccm
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:1.4.0
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-provider-for-cloud-director:1.5.0
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-provider-for-cloud-director

--- a/templates/crs/csi/csi-controller-crs.yaml
+++ b/templates/crs/csi/csi-controller-crs.yaml
@@ -140,7 +140,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.4.0
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/templates/crs/csi/csi-node-crs.yaml
+++ b/templates/crs/csi/csi-node-crs.yaml
@@ -77,7 +77,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.4.0
+          image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
           imagePullPolicy: IfNotPresent
           command :
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -1845,7 +1845,7 @@ spec:
       containers:
       - command:
         - /opt/vcloud/bin/cluster-api-provider-cloud-director
-        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:v1.1.0
+        image: projects.registry.vmware.com/vmware-cloud-director/cluster-api-provider-cloud-director:v1.2.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
CSI, CAPVCD of the 4.2 stack

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Update manifests to point to the right versions of CPI, CSI, CAPVCD of the 4.2 stack

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/549)
<!-- Reviewable:end -->
