### PR TITLE
[CAFV-387][Cherrypick]Remove the redundant RDEAvailable event

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -906,11 +906,6 @@ func (r *VCDClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		}
 	}
 
-	err = capvcdRdeManager.AddToEventSet(ctx, capisdk.RdeAvailable, infraID, "", "", skipRDEEventUpdates)
-	if err != nil {
-		log.Error(err, "failed to add RdeAvailable event", "rdeID", infraID)
-	}
-
 	if err := validateDerivedRDEProperties(vcdCluster, infraID, rdeVersionInUseByCluster); err != nil {
 		log.Error(err, "Error validating derived infraID and RDE version")
 		return ctrl.Result{}, errors.Wrapf(err, "error validating derived infraID and RDE version with VCDCluster status")

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -37,7 +37,6 @@ const (
 	DefaultRollingWindowSize      = 20
 
 	// VCDCluster Events
-	RdeAvailable          = "RdeAvailable"
 	RdeUpgraded           = "RdeUpgraded"
 	LoadBalancerAvailable = "LoadBalancerAvailable"
 	InfraVappAvailable    = "InfraVappAvailable"


### PR DESCRIPTION
…pose. (#556)

This was added in the beginning of CAPVCD, but doesn't add any value compared to 100 other important things capvcd does.

Signed-off-by: sayloo <sahithi.ayloo@gmail.com>
(cherry picked from commit b54607e820cc10cc69c912e4ae560ab302701809)

## Description
Please provide a brief description of the changes proposed in this Pull Request

- 

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/557)
<!-- Reviewable:end -->
