### PR TITLE
fix: an issue when get MachineDeployment

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -11,17 +11,18 @@ import (
 	_ "embed" // this needs go 1.16+
 	b64 "encoding/base64"
 	"fmt"
-	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
-	"github.com/vmware/cluster-api-provider-cloud-director/common"
-	vcdutil "github.com/vmware/cluster-api-provider-cloud-director/pkg/util"
 	"math"
 	"math/rand"
 	"reflect"
-	"sigs.k8s.io/yaml"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
+
+	swagger "github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdswaggerclient_36_0"
+	"github.com/vmware/cluster-api-provider-cloud-director/common"
+	vcdutil "github.com/vmware/cluster-api-provider-cloud-director/pkg/util"
+	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
@@ -384,7 +385,12 @@ func GetMachineDeploymentName(ctx context.Context, cli client.Client, vcdCluster
 	machine *clusterv1.Machine) (string, error) {
 
 	machineList := &clusterv1.MachineList{}
-	machineListLabels := map[string]string{clusterv1.ClusterNameLabel: vcdCluster.Name}
+	clusterName, ok := vcdCluster.GetLabels()[clusterv1.ClusterNameLabel]
+	if !ok {
+		return "", fmt.Errorf("unable to get cluster name from the vcdCluster object [%s]", vcdCluster.Name)
+	}
+
+	machineListLabels := map[string]string{clusterv1.ClusterNameLabel: clusterName}
 	if err := cli.List(ctx, machineList, client.InNamespace(vcdCluster.Namespace),
 		client.MatchingLabels(machineListLabels)); err != nil {
 		return "", fmt.Errorf("error getting MachineList object for cluster [%s]: [%v]", vcdCluster.Name, err)


### PR DESCRIPTION
## Description

MachineDeployment stores the cluster.Name (jose-test-2) in the "cluster.x-k8s.io/cluster-name" label instead of vcdcluster.Name (jose-test-2-grxh6) so this PR fixes this issue to prevent machine from being created

Error
```
	ERROR	unable to get vApp name from cluster name [%s], machine [%s]	{"controller": "vcdmachine", "controllerGroup": "infrastructure.cluster.x-k8s.io", "controllerKind": "VCDMachine", "VCDMachine": {"name":"j","namespace":"capi-system"}, "namespace": "capi-system", "name": "", "reconcileID": "", "cluster": "", "ovdc": "", "machine": "", "clusterName": "", "OVDC ID": "", "error": "unable to get MachineDeployment name from cluster [jose-test-2-grxh6], machine []: [unable to find machine deployment for cluster [], machine []]"
```
- 

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [x] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [x] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [x] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [x] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [x] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/561)
<!-- Reviewable:end -->
