### PR TITLE
CAFV-392: Use machine.Name so that vm.VM.name will not cause panics

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -714,7 +714,7 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		if len(diskSettings) != 0 && diskSettings[0].SizeMb < diskSize {
 			log.Info(
 				fmt.Sprintf("resizing hard disk on VM for machine [%s] of cluster [%s]; resizing from [%dMB] to [%dMB]",
-					vm.VM.Name, vApp.VApp.Name, diskSettings[0].SizeMb, diskSize))
+					machine.Name, vApp.VApp.Name, diskSettings[0].SizeMb, diskSize))
 
 			diskSettings[0].SizeMb = diskSize
 			vm.VM.VmSpecSection.DiskSection.DiskSettings = diskSettings
@@ -725,7 +725,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 					log.Error(err1, "failed to add VCDMachineCreationError into RDE", "rdeID", vcdCluster.Status.InfraId)
 				}
 				return ctrl.Result{},
-					errors.Wrapf(err, "Error while provisioning the infrastructure VM for the machine [%s] of the cluster [%s]; failed to resize hard disk", vm.VM.Name, vApp.VApp.Name)
+					errors.Wrapf(err,
+						"Error while provisioning the infrastructure VM for the machine [%s] of the cluster [%s];"+
+							" failed to resize hard disk", machine.Name, vApp.VApp.Name)
 			}
 		}
 		if err = capvcdRdeManager.RdeManager.RemoveErrorByNameOrIdFromErrorSet(ctx, vcdsdk.ComponentCAPVCD, capisdk.VCDMachineCreationError, "", ""); err != nil {


### PR DESCRIPTION
for badly created VMs

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Sometimes VMs are not created correctly. So using the `vm.VM.Name` can cause panics. Changing it to `machine.Name` in one observed instance. However there needs to be a complete scan of code and a more intrusive fix later.

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/564)
<!-- Reviewable:end -->
