### PR TITLE
[CAFV-411] decrease sync time in main.go to 2 minutes

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -165,18 +165,18 @@ func patchVCDCluster(ctx context.Context, patchHelper *patch.Helper, vcdCluster 
 }
 
 func loginVCD(ctx context.Context, cli client.Client, vcdCluster *infrav1beta3.VCDCluster) (*vcdsdk.Client, error) {
-	workloadVCDClient, err := createVCDClientFromSecrets(ctx, cli, vcdCluster)
+	vcdClient, err := createVCDClientFromSecrets(ctx, cli, vcdCluster)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error creating VCD client to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
 	}
-	if workloadVCDClient.VDC == nil || workloadVCDClient.VDC.Vdc == nil {
-		return workloadVCDClient, errors.Wrapf(err, "failed to get the Organization VDC (OVDC) from the VCD client for reconciling infrastructure of Cluster [%s]", vcdCluster.Name)
+	if vcdClient.VDC == nil || vcdClient.VDC.Vdc == nil {
+		return vcdClient, errors.Wrapf(err, "failed to get the Organization VDC (OVDC) from the VCD client for reconciling infrastructure of Cluster [%s]", vcdCluster.Name)
 	}
-	err = updateVdcResourceToVcdCluster(vcdCluster, ResourceTypeOvdc, workloadVCDClient.VDC.Vdc.ID, workloadVCDClient.VDC.Vdc.Name)
+	err = updateVdcResourceToVcdCluster(vcdCluster, ResourceTypeOvdc, vcdClient.VDC.Vdc.ID, vcdClient.VDC.Vdc.Name)
 	if err != nil {
-		return workloadVCDClient, errors.Wrapf(err, "Error updating vcdResource into vcdcluster.status to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
+		return vcdClient, errors.Wrapf(err, "Error updating vcdResource into vcdcluster.status to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
 	}
-	return workloadVCDClient, nil
+	return vcdClient, nil
 }
 
 func addLBResourcesToVCDResourceSet(ctx context.Context, rdeManager *vcdsdk.RDEManager, resourcesAllocated *vcdsdkutil.AllocatedResourcesMap, externalIP string) error {

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -859,6 +859,21 @@ func (r *VCDMachineReconciler) reconcileLBPool(ctx context.Context, machine *clu
 	return nil
 }
 
+func (r *VCDMachineReconciler) loginVCD(ctx context.Context, vcdCluster *infrav1beta3.VCDCluster) (*vcdsdk.Client, error) {
+	workloadVCDClient, err := createVCDClientFromSecrets(ctx, r.Client, vcdCluster)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error creating VCD client to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
+	}
+	if workloadVCDClient.VDC == nil || workloadVCDClient.VDC.Vdc == nil {
+		return workloadVCDClient, errors.Wrapf(err, "failed to get the Organization VDC (OVDC) from the VCD client for reconciling infrastructure of Cluster [%s]", vcdCluster.Name)
+	}
+	err = updateVdcResourceToVcdCluster(vcdCluster, ResourceTypeOvdc, workloadVCDClient.VDC.Vdc.ID, workloadVCDClient.VDC.Vdc.Name)
+	if err != nil {
+		return workloadVCDClient, errors.Wrapf(err, "Error updating vcdResource into vcdcluster.status to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
+	}
+	return workloadVCDClient, nil
+}
+
 func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clusterv1.Cluster,
 	machine *clusterv1.Machine, vcdMachine *infrav1beta3.VCDMachine, vcdCluster *infrav1beta3.VCDCluster) (res ctrl.Result, retErr error) {
 
@@ -867,11 +882,37 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	// To avoid spamming RDEs with updates, only update the RDE with events when machine creation is ongoing
 	skipRDEEventUpdates := machine.Status.BootstrapReady
 
-	vcdClient, err := createVCDClientFromSecrets(ctx, r.Client, vcdCluster)
-	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "Error creating VCD client to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
+	if vcdMachine.Spec.ProviderID != nil && vcdMachine.Status.ProviderID != nil {
+		vcdMachine.Status.Ready = true
+		conditions.MarkTrue(vcdMachine, ContainerProvisionedCondition)
+
+		if checkIfMachineNodeIsUnhealthy(machine) {
+			// Create the workload client only if the machine is unhealthy because we would have to add an event to the RDE.
+			// Else there is no need to login to VCD
+			workloadVCDClient, err := r.loginVCD(ctx, vcdCluster)
+			// close all idle connections when reconciliation is done
+			defer func() {
+				if workloadVCDClient != nil && workloadVCDClient.VCDClient != nil {
+					workloadVCDClient.VCDClient.Client.Http.CloseIdleConnections()
+					log.Info(fmt.Sprintf("closed connection to the http client [%#v]", workloadVCDClient.VCDClient.Client.Http))
+				}
+			}()
+			if err != nil {
+				log.Error(err, "error occurred while logging in to VCD")
+				return ctrl.Result{}, errors.Wrapf(err, "error occurred while logging in to VCD: [%v]", err)
+			}
+
+			capvcdRdeManager := capisdk.NewCapvcdRdeManager(workloadVCDClient, vcdCluster.Status.InfraId)
+			if conditions.IsFalse(machine, clusterv1.MachineHealthCheckSucceededCondition) {
+				capvcdRdeManager.AddToEventSet(ctx, capisdk.NodeHealthCheckFailed, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineHealthCheckSucceededCondition), false)
+			}
+			capvcdRdeManager.AddToEventSet(ctx, capisdk.NodeUnhealthy, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineNodeHealthyCondition), false)
+		}
+
+		return ctrl.Result{}, nil
 	}
 
+	vcdClient, err := r.loginVCD(ctx, vcdCluster)
 	// close all idle connections when reconciliation is done
 	defer func() {
 		if vcdClient != nil && vcdClient.VCDClient != nil {
@@ -879,14 +920,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			log.Info(fmt.Sprintf("closed connection to the http client [%#v]", vcdClient.VCDClient.Client.Http))
 		}
 	}()
-
-	if vcdClient.VDC == nil || vcdClient.VDC.Vdc == nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to get the Organization VDC (OVDC) from the VCD client for reconciling infrastructure of Cluster [%s]", vcdCluster.Name)
-	}
-
-	err = updateVdcResourceToVcdCluster(vcdCluster, ResourceTypeOvdc, vcdClient.VDC.Vdc.ID, vcdClient.VDC.Vdc.Name)
 	if err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "Error updating vcdResource into vcdcluster.status to reconcile Cluster [%s] infrastructure", vcdCluster.Name)
+		log.Error(err, "error occurred while logging in to VCD")
+		return ctrl.Result{}, errors.Wrapf(err, "error occurred while logging in to VCD: [%v]", err)
 	}
 
 	capvcdRdeManager := capisdk.NewCapvcdRdeManager(vcdClient, vcdCluster.Status.InfraId)
@@ -895,12 +931,6 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 	if checkIfMachineNodeIsUnhealthy(machine) {
 		capvcdRdeManager.AddToEventSet(ctx, capisdk.NodeUnhealthy, getVMIDFromProviderID(vcdMachine.Status.ProviderID), machine.Name, conditions.GetMessage(machine, clusterv1.MachineNodeHealthyCondition), false)
-	}
-	if vcdMachine.Spec.ProviderID != nil && vcdMachine.Status.ProviderID != nil {
-		vcdMachine.Status.Ready = true
-		conditions.MarkTrue(vcdMachine, ContainerProvisionedCondition)
-		capvcdRdeManager.AddToEventSet(ctx, capisdk.InfraVmBootstrapped, "", machine.Name, "", skipRDEEventUpdates)
-		return ctrl.Result{}, nil
 	}
 
 	patchHelper, err := patch.NewHelper(vcdMachine, r.Client)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
+	flag.DurationVar(&syncPeriod, "sync-period", 2*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 	flag.IntVar(&concurrency, "concurrency", 10,
 		"The number of VCD machines to process simultaneously")


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Reduce sync time of the controllers to 2 mins so that the vcdcluster controller gets called more frequently
- In vcdmachine_controller, perform login only if necessary.

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/577)
<!-- Reviewable:end -->
