### PR TITLE
[VCDA-6992] Update dependencies.txt.template to use vmware-cloud-director for image path

### DIFF
--- a/artifacts/bom.json.template
+++ b/artifacts/bom.json.template
@@ -14,7 +14,7 @@
 		"binaries": [],
 		"dependencies": [
 			{
-				"name":"cluster-api-provider-cloud-director",
+				"name":"vmware-cloud-director/cluster-api-provider-cloud-director",
 				"version":"__VERSION__",
 				"imageRepository":"__REGISTRY__"
 			}

--- a/artifacts/dependencies.txt.template
+++ b/artifacts/dependencies.txt.template
@@ -1,1 +1,1 @@
-__REGISTRY__ cluster-api-provider-cloud-director __VERSION__
+__REGISTRY__ vmware-cloud-director/cluster-api-provider-cloud-director __VERSION__


### PR DESCRIPTION

## Description
Please provide a brief description of the changes proposed in this Pull Request

- Updates dependencies.txt.template to use 'vmware-cloud-director/cluster-api-provider-cloud-director' as part of image path for consistency

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/578)
<!-- Reviewable:end -->
