### PR TITLE
patch to overload LB port on reconciliation loop

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -9,13 +9,14 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"github.com/google/uuid"
-	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
 	"net/http"
 	"os"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	rdeType "github.com/vmware/cluster-api-provider-cloud-director/pkg/vcdtypes/rde_type_1_1_0"
 
 	"github.com/antihax/optional"
 	"github.com/blang/semver"
@@ -958,7 +959,13 @@ func (r *VCDClusterReconciler) reconcileLoadBalancer(ctx context.Context, vcdClu
 		fmt.Sprintf("%s-tcp", virtualServiceNamePrefix), fmt.Sprintf("%s-tcp", lbPoolNamePrefix), oneArm)
 
 	// TODO: ideally we should get this port from the GetLoadBalancer function
-	controlPlanePort := TcpPort
+	// Patch to overload port on reconciliation loop
+	var controlPlanePort int
+	if vcdCluster.Spec.ControlPlaneEndpoint.Port != 0 {
+		controlPlanePort = vcdCluster.Spec.ControlPlaneEndpoint.Port
+	} else {
+		controlPlanePort = TcpPort
+	}
 
 	//TODO: Sahithi: Check if error is really because of missing virtual service.
 	// In any other error cases, force create the new load balancer with the original control plane endpoint
@@ -972,7 +979,7 @@ func (r *VCDClusterReconciler) reconcileLoadBalancer(ctx context.Context, vcdClu
 		}
 
 		if vcdCluster.Spec.ControlPlaneEndpoint.Host != "" {
-			controlPlanePort := vcdCluster.Spec.ControlPlaneEndpoint.Port
+			controlPlanePort = vcdCluster.Spec.ControlPlaneEndpoint.Port
 			log.Info("Creating load balancer for the cluster at user-specified endpoint",
 				"host", vcdCluster.Spec.ControlPlaneEndpoint.Host, "port", controlPlanePort)
 		} else {


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- The variable controlPlanePort is reset at default value at each loop. Use the vcdCluster.Spec.ControlPlaneEndpoint.Port value if it is defined

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
Fixe bug #583 