### PR TITLE
[CAFV-399] fix a possible nil pointer dereference

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -275,7 +275,7 @@ func updateClientWithVDC(vcdCluster *infrav1beta3.VCDCluster, client *vcdsdk.Cli
 		if NameChanged {
 			ovdcName = newOvdc.Vdc.Name
 			vcdCluster.Spec.Ovdc = newOvdc.Vdc.Name
-			log.Info("updating vcdCluster with the following data", "vcdCluster.Status.VcdResourceMap[ovdc].ID", client.VDC.Vdc.ID, "vcdCluster.Status.VcdResourceMap[ovdc].Name", client.VDC.Vdc.Name)
+			log.Info("detected change in OVDC name", "ovdcID", newOvdc.Vdc.ID, "new ovdcName", newOvdc.Vdc.Name)
 		}
 	}
 	newOvdc, err := getOvdcByName(client, orgName, ovdcName)


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Verified that CAPVCD is not affected by OVDC rename
- Fixed a possible nil pointer dereference when OVDC is renamed

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [x] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/588)
<!-- Reviewable:end -->
