### PR TITLE
[CAFV-362] Update vapp naming for multizone

### DIFF
--- a/api/v1alpha4/vcdmachine_conversion.go
+++ b/api/v1alpha4/vcdmachine_conversion.go
@@ -35,6 +35,7 @@ func (src *VCDMachine) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.EnableNvidiaGPU = restored.Spec.EnableNvidiaGPU
 	dst.Spec.ExtraOvdcNetworks = restored.Spec.ExtraOvdcNetworks
 	dst.Spec.VmNamingTemplate = restored.Spec.VmNamingTemplate
+	dst.Spec.FailureDomain = restored.Spec.FailureDomain
 
 	dst.Status.Template = restored.Status.Template
 	dst.Status.ProviderID = restored.Status.ProviderID

--- a/api/v1beta1/vcdmachine_conversion.go
+++ b/api/v1beta1/vcdmachine_conversion.go
@@ -20,6 +20,7 @@ func (src *VCDMachine) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec.ExtraOvdcNetworks = restored.Spec.ExtraOvdcNetworks
 	dst.Spec.VmNamingTemplate = restored.Spec.VmNamingTemplate
+	dst.Spec.FailureDomain = restored.Spec.FailureDomain
 	return nil
 }
 

--- a/api/v1beta3/vcdcluster_types.go
+++ b/api/v1beta3/vcdcluster_types.go
@@ -127,7 +127,6 @@ type ExternalLoadBalancerConfig struct {
 type EdgeGatewayZones []EdgeGatewayZone
 
 // EdgeGatewayZone provides the details of a zone containing an edge gateway. Used with ExternalLoadBalancer topology.
-// topology.
 type EdgeGatewayZone struct {
 	// Name is the user-defined name of the zone representing the OVDC containing an edge gateway.
 	Name string `json:"name"`

--- a/api/v1beta3/vcdmachine_types.go
+++ b/api/v1beta3/vcdmachine_types.go
@@ -83,7 +83,8 @@ type VCDMachineSpec struct {
 	// Immutable field. machine.Name is used as VM name when this field is empty.
 	// +optional
 	VmNamingTemplate string `json:"vmNamingTemplate,omitempty"`
-
+	// FailureDomain is the failure domain the machine will be created in.
+	// Must match a key in the FailureDomains map stored on the cluster object.
 	// +optional
 	FailureDomain *string `json:"failureDomain,omitempty"`
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: vcdclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -20,19 +20,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -88,37 +83,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -147,19 +142,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -223,9 +213,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -257,37 +246,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -366,19 +355,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -442,9 +426,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -476,37 +459,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -607,19 +590,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -651,9 +629,8 @@ spec:
                     type: string
                 type: object
               multiZoneSpec:
-                description: |-
-                  MultiZoneSpec provides details of the configuration of the zones in the cluster as well as the NetworkTopologyType
-                  used.
+                description: MultiZoneSpec provides details of the configuration of
+                  the zones in the cluster as well as the NetworkTopologyType used.
                 properties:
                   dcGroupConfig:
                     description: DCGroupConfig contains configuration for DCGroup
@@ -667,8 +644,8 @@ spec:
                         description: EdgeGatewayZones defines a list of zones containing
                           an edge gateway.
                         items:
-                          description: |-
-                            EdgeGatewayZone provides the details of a zone containing an edge gateway. Used with ExternalLoadBalancer topology.
+                          description: EdgeGatewayZone provides the details of a zone
+                            containing an edge gateway. Used with ExternalLoadBalancer
                             topology.
                           properties:
                             loadBalancerIP:
@@ -705,9 +682,9 @@ spec:
                     - edgeGatewayZone
                     type: object
                   zoneTopology:
-                    description: |-
-                      ZoneTopology defines the type of network topology used across zones in a Multi-AZ deployment.
-                      Valid options are DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer,
+                    description: ZoneTopology defines the type of network topology
+                      used across zones in a Multi-AZ deployment. Valid options are
+                      DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer,
                     type: string
                   zones:
                     description: Zones defines the list of zones that this cluster
@@ -742,9 +719,9 @@ spec:
               org:
                 type: string
               ovcdZoneConfigMap:
-                description: |-
-                  OVDCZoneConfigMap defines the name of a config map storing the mapping Zone -> OVDC in a Multi-AZ
-                  deployment. e.g. zone1 -> ovdc1, zone2 -> ovdc2
+                description: OVDCZoneConfigMap defines the name of a config map storing
+                  the mapping Zone -> OVDC in a Multi-AZ deployment. e.g. zone1 ->
+                  ovdc1, zone2 -> ovdc2
                 type: string
               ovdc:
                 type: string
@@ -777,9 +754,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -811,37 +787,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -851,9 +827,9 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: |-
-                    FailureDomainSpec is the Schema for Cluster API failure domains.
-                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
@@ -866,9 +842,9 @@ spec:
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object
-                description: |-
-                  FailureDomains lists the zones of this cluster. This field is parsed from the Zones field of
-                  vcdCluster.Spec.MultiZoneSpec if set up appropriately.
+                description: FailureDomains lists the zones of this cluster. This
+                  field is parsed from the Zones field of vcdCluster.Spec.MultiZoneSpec
+                  if set up appropriately.
                 type: object
               infraId:
                 type: string
@@ -899,8 +875,8 @@ spec:
                         description: EdgeGatewayZones defines a list of zones containing
                           an edge gateway.
                         items:
-                          description: |-
-                            EdgeGatewayZone provides the details of a zone containing an edge gateway. Used with ExternalLoadBalancer topology.
+                          description: EdgeGatewayZone provides the details of a zone
+                            containing an edge gateway. Used with ExternalLoadBalancer
                             topology.
                           properties:
                             loadBalancerIP:
@@ -937,9 +913,9 @@ spec:
                     - edgeGatewayZone
                     type: object
                   zoneTopology:
-                    description: |-
-                      ZoneTopology defines the type of network topology used across zones in a Multi-AZ deployment.
-                      Valid options are DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer
+                    description: ZoneTopology defines the type of network topology
+                      used across zones in a Multi-AZ deployment. Valid options are
+                      DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer
                     type: string
                   zones:
                     description: Zones defines the list of zones this cluster is configured

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclustertemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: vcdclustertemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,19 +21,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -106,9 +101,9 @@ spec:
                           refreshToken:
                             type: string
                           secretRef:
-                            description: |-
-                              SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                              in any namespace
+                            description: SecretReference represents a Secret Reference.
+                              It has enough information to retrieve secret in any
+                              namespace
                             properties:
                               name:
                                 description: name is unique within a namespace to

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -549,6 +549,8 @@ spec:
                   type: string
                 type: array
               failureDomain:
+                description: FailureDomain is the failure domain the machine will
+                  be created in.
                 type: string
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -550,7 +550,8 @@ spec:
                 type: array
               failureDomain:
                 description: FailureDomain is the failure domain the machine will
-                  be created in.
+                  be created in. Must match a key in the FailureDomains map stored
+                  on the cluster object.
                 type: string
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: vcdmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -20,19 +20,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -40,9 +35,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -89,37 +83,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -142,19 +136,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -162,9 +151,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -178,9 +166,9 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on
@@ -191,9 +179,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -233,37 +221,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -315,19 +303,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -335,9 +318,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -351,14 +333,14 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               extraOvdcNetworks:
-                description: |-
-                  ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                  VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                  that are mounted to machines. VCDClusterSpec.OvdcNetwork is always
+                  attached regardless of this field.
                 items:
                   type: string
                 type: array
@@ -371,9 +353,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -384,10 +366,10 @@ spec:
                   to be used
                 type: string
               vmNamingTemplate:
-                description: |-
-                  VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                  Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                  Immutable field. machine.Name is used as VM name when this field is empty.
+                description: VmNamingTemplate is go template to generate VM names
+                  based on Machine and VCDMachine CRs. Functions of Sprig library
+                  are supported. See https://github.com/Masterminds/sprig Immutable
+                  field. machine.Name is used as VM name when this field is empty.
                 type: string
             type: object
           status:
@@ -419,37 +401,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -501,19 +483,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -521,9 +498,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -537,14 +513,14 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               extraOvdcNetworks:
-                description: |-
-                  ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                  VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                  that are mounted to machines. VCDClusterSpec.OvdcNetwork is always
+                  attached regardless of this field.
                 items:
                   type: string
                 type: array
@@ -562,9 +538,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -575,10 +551,10 @@ spec:
                   to be used
                 type: string
               vmNamingTemplate:
-                description: |-
-                  VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                  Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                  Immutable field. machine.Name is used as VM name when this field is empty.
+                description: VmNamingTemplate is go template to generate VM names
+                  based on Machine and VCDMachine CRs. Functions of Sprig library
+                  are supported. See https://github.com/Masterminds/sprig Immutable
+                  field. machine.Name is used as VM name when this field is empty.
                 type: string
             type: object
           status:
@@ -610,37 +586,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
@@ -381,6 +381,8 @@ spec:
                           type: string
                         type: array
                       failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in.
                         type: string
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: vcdmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -21,19 +21,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -47,9 +42,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -88,19 +82,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -114,9 +103,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -130,9 +118,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be
@@ -143,9 +131,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -177,19 +165,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -199,27 +182,24 @@ spec:
               template:
                 properties:
                   metadata:
-                    description: |-
-                      Standard object's metadata.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
                   spec:
@@ -227,9 +207,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -243,14 +222,14 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       extraOvdcNetworks:
-                        description: |-
-                          ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                          VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                        description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                          that are mounted to machines. VCDClusterSpec.OvdcNetwork
+                          is always attached regardless of this field.
                         items:
                           type: string
                         type: array
@@ -263,9 +242,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -276,10 +255,11 @@ spec:
                           that is to be used
                         type: string
                       vmNamingTemplate:
-                        description: |-
-                          VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                          Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                          Immutable field. machine.Name is used as VM name when this field is empty.
+                        description: VmNamingTemplate is go template to generate VM
+                          names based on Machine and VCDMachine CRs. Functions of
+                          Sprig library are supported. See https://github.com/Masterminds/sprig
+                          Immutable field. machine.Name is used as VM name when this
+                          field is empty.
                         type: string
                     type: object
                 required:
@@ -303,19 +283,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -325,27 +300,24 @@ spec:
               template:
                 properties:
                   metadata:
-                    description: |-
-                      Standard object's metadata.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
                   spec:
@@ -353,9 +325,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -369,14 +340,14 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       extraOvdcNetworks:
-                        description: |-
-                          ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                          VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                        description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                          that are mounted to machines. VCDClusterSpec.OvdcNetwork
+                          is always attached regardless of this field.
                         items:
                           type: string
                         type: array
@@ -394,9 +365,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -407,10 +378,11 @@ spec:
                           that is to be used
                         type: string
                       vmNamingTemplate:
-                        description: |-
-                          VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                          Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                          Immutable field. machine.Name is used as VM name when this field is empty.
+                        description: VmNamingTemplate is go template to generate VM
+                          names based on Machine and VCDMachine CRs. Functions of
+                          Sprig library are supported. See https://github.com/Masterminds/sprig
+                          Immutable field. machine.Name is used as VM name when this
+                          field is empty.
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdmachinetemplates.yaml
@@ -382,7 +382,8 @@ spec:
                         type: array
                       failureDomain:
                         description: FailureDomain is the failure domain the machine
-                          will be created in.
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
                         type: string
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -310,7 +310,7 @@ func updateClientWithVDC(vcdCluster *infrav1beta3.VCDCluster, client *vcdsdk.Cli
 		if NameChanged {
 			ovdcName = newOvdc.Vdc.Name
 			vcdCluster.Spec.Ovdc = newOvdc.Vdc.Name
-			log.Info("detected change in OVDC name", "ovdcID", newOvdc.Vdc.ID, "new ovdcName", newOvdc.Vdc.Name)
+			log.Info("updating vcdCluster with the following data", "vcdCluster.Status.VcdResourceMap[ovdc].ID", client.VDC.Vdc.ID, "vcdCluster.Status.VcdResourceMap[ovdc].Name", client.VDC.Vdc.Name)
 		}
 	}
 	newOvdc, err := getOvdcByName(client, orgName, ovdcName)
@@ -327,7 +327,8 @@ func createVCDClientFromSecrets(ctx context.Context, client client.Client,
 	vcdCluster *infrav1beta3.VCDCluster, ovdcName string, ovdcScopedClient bool) (*vcdsdk.Client, error) {
 	userCreds, err := getUserCredentialsForCluster(ctx, client, vcdCluster.Spec.UserCredentialsContext)
 	if err != nil {
-		return nil, fmt.Errorf("error getting client credentials to reconcile Cluster [%s] infrastructure: [%v]", vcdCluster.Name, err)
+		return nil, fmt.Errorf("error getting client credentials to reconcile Cluster [%s] infrastructure: [%v]",
+			vcdCluster.Name, err)
 	}
 	vcdClient, err := vcdsdk.NewVCDClientFromSecrets(vcdCluster.Spec.Site, vcdCluster.Spec.Org,
 		ovdcName, vcdCluster.Spec.Org, userCreds.Username, userCreds.Password, userCreds.RefreshToken,
@@ -341,6 +342,7 @@ func createVCDClientFromSecrets(ctx context.Context, client client.Client,
 			return nil, fmt.Errorf("error updating VCD client with VDC to reconcile Cluster [%s] infrastructure: [%v]", vcdCluster.Name, err)
 		}
 	}
+
 	return vcdClient, nil
 }
 

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -415,11 +415,13 @@ func (r *VCDMachineReconciler) reconcileVMBoostrap(ctx context.Context, vcdClien
 	if err = capvcdRdeManager.RdeManager.RemoveErrorByNameOrIdFromErrorSet(ctx, vcdsdk.ComponentCAPVCD, capisdk.VCDMachineCreationError, "", ""); err != nil {
 		log.Error(err, "failed to remove VCDMachineCreationError from RDE")
 	}
-	vAppName, err := capvcdutil.CreateVAppNamePrefix(vcdCluster.Name, vdcManager.Vdc.Vdc.ID)
+
+	vAppName, err := CreateFullVAppName(ctx, r.Client, vdcManager.Vdc.Vdc.ID, vcdCluster, machine)
 	if err != nil {
-		return errors.Wrapf(err, "error occurred while creating vApp name prefix for the cluster [%s] with VDC ID [%s]",
+		return errors.Wrapf(err, "error occurred while creating vApp name for the cluster [%s] with VDC ID [%s]",
 			vcdCluster.Name, vdcManager.Vdc.Vdc.ID)
 	}
+
 	if vmStatus != "POWERED_ON" {
 		// try to power on the VM
 		b64CloudInitScript := b64.StdEncoding.EncodeToString(mergedCloudInitBytes)
@@ -589,6 +591,63 @@ func (r *VCDMachineReconciler) getOVDCDetailsForMachine(ctx context.Context, mac
 
 	default:
 		return "", "", fmt.Errorf("unknown zoneTopology [%s]", vcdCluster.Spec.MultiZoneSpec.ZoneTopology)
+	}
+}
+
+func GetMachineDeploymentName(ctx context.Context, cli client.Client, vcdCluster *infrav1beta3.VCDCluster,
+	machine *clusterv1.Machine) (string, error) {
+
+	machineList := &clusterv1.MachineList{}
+	clusterName, ok := vcdCluster.GetLabels()[clusterv1.ClusterNameLabel]
+	if !ok {
+		return "", fmt.Errorf("unable to get cluster name from the vcdCluster object [%s]", vcdCluster.Name)
+	}
+
+	machineListLabels := map[string]string{clusterv1.ClusterNameLabel: clusterName}
+	if err := cli.List(ctx, machineList, client.InNamespace(vcdCluster.Namespace),
+		client.MatchingLabels(machineListLabels)); err != nil {
+		return "", fmt.Errorf("error getting MachineList object for cluster [%s]: [%v]", vcdCluster.Name, err)
+	}
+
+	for _, machineListItem := range machineList.Items {
+		if machine.Name == machineListItem.Name {
+			if kcpNameLabel, ok := machineListItem.Labels[clusterv1.MachineControlPlaneNameLabel]; ok {
+				return kcpNameLabel, nil
+			} else {
+				if machineDeploymentNameLabel, ok := machineListItem.Labels[clusterv1.MachineDeploymentNameLabel]; ok {
+					return machineDeploymentNameLabel, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("unable to find machine deployment for cluster [%s], machine [%s]",
+		vcdCluster.Name, machine.Name)
+}
+
+func CreateFullVAppName(ctx context.Context, cli client.Client, ovdcID string,
+	vcdCluster *infrav1beta3.VCDCluster, machine *clusterv1.Machine) (string, error) {
+
+	switch vcdCluster.Spec.MultiZoneSpec.ZoneTopology {
+	case "":
+		return vcdCluster.Name, nil
+
+	case infrav1beta3.DCGroup, infrav1beta3.ExternalLoadBalancer, infrav1beta3.UserSpecifiedEdgeGateway:
+		machineDeploymentName, err := GetMachineDeploymentName(ctx, cli, vcdCluster, machine)
+		if err != nil {
+			return "", fmt.Errorf("unable to get MachineDeployment name from cluster [%s], machine [%s]: [%v]",
+				vcdCluster.Name, machine.Name, err)
+		}
+		vAppPrefix, err := capvcdutil.CreateVAppNamePrefix(vcdCluster.Name, ovdcID)
+		if err != nil {
+			return "", fmt.Errorf("unable to get vApp name from cluster name [%s], machine [%s]: [%v]",
+				vcdCluster.Name, machine.Name, err)
+		}
+		return fmt.Sprintf("%s_%s", vAppPrefix, machineDeploymentName), nil
+
+	default:
+		return "", fmt.Errorf("encountered unknown zonetype while creating vApp Name for cluster [%s]",
+			vcdCluster.Name)
 	}
 }
 
@@ -1012,8 +1071,9 @@ func (r *VCDMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	// since new zones could be added dynamically. In the non-AZ case, it can be done in the vcdCluster controller. However,
 	// we do it in one place for simplicity.
 	// TODO: should we add a field in VCDMachine to store the VApp name used for the machine ?
-	// TODO: add the node pool name to the vApp name
-	vAppName, err := capvcdutil.CreateVAppNamePrefix(vcdCluster.Name, vcdClient.VDC.Vdc.ID)
+	vAppName, err := CreateFullVAppName(ctx, r.Client, vdcManager.Vdc.Vdc.ID, vcdCluster, machine)
+	log.Info(fmt.Sprintf("Using VApp name [%s] for the machine [%s]", vAppName, machine.Name))
+
 	if err != nil {
 		log.Error(err, "error occurred while creating vApp name prefix")
 		return ctrl.Result{}, errors.Wrapf(err, "error creating vApp name prefix for the vcdMachine [%s]",

--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -588,7 +588,7 @@ func (r *VCDMachineReconciler) getOVDCDetailsForMachine(ctx context.Context, mac
 	}
 }
 
-func GetMachineDeploymentName(ctx context.Context, cli client.Client, vcdCluster *infrav1beta3.VCDCluster,
+func GetNodePoolName(ctx context.Context, cli client.Client, vcdCluster *infrav1beta3.VCDCluster,
 	machine *clusterv1.Machine) (string, error) {
 
 	machineList := &clusterv1.MachineList{}
@@ -627,7 +627,7 @@ func CreateFullVAppName(ctx context.Context, cli client.Client, ovdcID string,
 		return vcdCluster.Name, nil
 
 	case infrav1beta3.DCGroup, infrav1beta3.ExternalLoadBalancer, infrav1beta3.UserSpecifiedEdgeGateway:
-		machineDeploymentName, err := GetMachineDeploymentName(ctx, cli, vcdCluster, machine)
+		machineDeploymentName, err := GetNodePoolName(ctx, cli, vcdCluster, machine)
 		if err != nil {
 			return "", fmt.Errorf("unable to get MachineDeployment name from cluster [%s], machine [%s]: [%v]",
 				vcdCluster.Name, machine.Name, err)

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capvcd-system/capvcd-serving-cert
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-vcd
     cluster.x-k8s.io/v1alpha4: v1alpha4
@@ -43,19 +43,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -111,37 +106,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -170,19 +165,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -246,9 +236,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -280,37 +269,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -389,19 +378,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -465,9 +449,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -499,37 +482,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -630,19 +613,14 @@ spec:
         description: VCDCluster is the Schema for the vcdclusters API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -674,9 +652,8 @@ spec:
                     type: string
                 type: object
               multiZoneSpec:
-                description: |-
-                  MultiZoneSpec provides details of the configuration of the zones in the cluster as well as the NetworkTopologyType
-                  used.
+                description: MultiZoneSpec provides details of the configuration of
+                  the zones in the cluster as well as the NetworkTopologyType used.
                 properties:
                   dcGroupConfig:
                     description: DCGroupConfig contains configuration for DCGroup
@@ -690,8 +667,8 @@ spec:
                         description: EdgeGatewayZones defines a list of zones containing
                           an edge gateway.
                         items:
-                          description: |-
-                            EdgeGatewayZone provides the details of a zone containing an edge gateway. Used with ExternalLoadBalancer topology.
+                          description: EdgeGatewayZone provides the details of a zone
+                            containing an edge gateway. Used with ExternalLoadBalancer
                             topology.
                           properties:
                             loadBalancerIP:
@@ -728,9 +705,9 @@ spec:
                     - edgeGatewayZone
                     type: object
                   zoneTopology:
-                    description: |-
-                      ZoneTopology defines the type of network topology used across zones in a Multi-AZ deployment.
-                      Valid options are DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer,
+                    description: ZoneTopology defines the type of network topology
+                      used across zones in a Multi-AZ deployment. Valid options are
+                      DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer,
                     type: string
                   zones:
                     description: Zones defines the list of zones that this cluster
@@ -765,9 +742,9 @@ spec:
               org:
                 type: string
               ovcdZoneConfigMap:
-                description: |-
-                  OVDCZoneConfigMap defines the name of a config map storing the mapping Zone -> OVDC in a Multi-AZ
-                  deployment. e.g. zone1 -> ovdc1, zone2 -> ovdc2
+                description: OVDCZoneConfigMap defines the name of a config map storing
+                  the mapping Zone -> OVDC in a Multi-AZ deployment. e.g. zone1 ->
+                  ovdc1, zone2 -> ovdc2
                 type: string
               ovdc:
                 type: string
@@ -800,9 +777,8 @@ spec:
                   refreshToken:
                     type: string
                   secretRef:
-                    description: |-
-                      SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                      in any namespace
+                    description: SecretReference represents a Secret Reference. It
+                      has enough information to retrieve secret in any namespace
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -834,37 +810,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -874,9 +850,9 @@ spec:
                 type: array
               failureDomains:
                 additionalProperties:
-                  description: |-
-                    FailureDomainSpec is the Schema for Cluster API failure domains.
-                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  description: FailureDomainSpec is the Schema for Cluster API failure
+                    domains. It allows controllers to understand how many failure
+                    domains a cluster can optionally span across.
                   properties:
                     attributes:
                       additionalProperties:
@@ -889,9 +865,9 @@ spec:
                         is suitable for use by control plane machines.
                       type: boolean
                   type: object
-                description: |-
-                  FailureDomains lists the zones of this cluster. This field is parsed from the Zones field of
-                  vcdCluster.Spec.MultiZoneSpec if set up appropriately.
+                description: FailureDomains lists the zones of this cluster. This
+                  field is parsed from the Zones field of vcdCluster.Spec.MultiZoneSpec
+                  if set up appropriately.
                 type: object
               infraId:
                 type: string
@@ -922,8 +898,8 @@ spec:
                         description: EdgeGatewayZones defines a list of zones containing
                           an edge gateway.
                         items:
-                          description: |-
-                            EdgeGatewayZone provides the details of a zone containing an edge gateway. Used with ExternalLoadBalancer topology.
+                          description: EdgeGatewayZone provides the details of a zone
+                            containing an edge gateway. Used with ExternalLoadBalancer
                             topology.
                           properties:
                             loadBalancerIP:
@@ -960,9 +936,9 @@ spec:
                     - edgeGatewayZone
                     type: object
                   zoneTopology:
-                    description: |-
-                      ZoneTopology defines the type of network topology used across zones in a Multi-AZ deployment.
-                      Valid options are DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer
+                    description: ZoneTopology defines the type of network topology
+                      used across zones in a Multi-AZ deployment. Valid options are
+                      DCGroup, UserSpecifiedEdgeGateway, and ExternalLoadBalancer
                     type: string
                   zones:
                     description: Zones defines the list of zones this cluster is configured
@@ -1108,19 +1084,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1193,9 +1164,9 @@ spec:
                           refreshToken:
                             type: string
                           secretRef:
-                            description: |-
-                              SecretReference represents a Secret Reference. It has enough information to retrieve secret
-                              in any namespace
+                            description: SecretReference represents a Secret Reference.
+                              It has enough information to retrieve secret in any
+                              namespace
                             properties:
                               name:
                                 description: name is unique within a namespace to
@@ -1457,7 +1428,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capvcd-system/capvcd-serving-cert
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-vcd
     cluster.x-k8s.io/v1alpha4: v1alpha4
@@ -1490,19 +1461,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1510,9 +1476,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -1559,37 +1524,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - status
@@ -1612,19 +1577,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1632,9 +1592,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -1648,9 +1607,9 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on
@@ -1661,9 +1620,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -1703,37 +1662,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -1785,19 +1744,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1805,9 +1759,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -1821,14 +1774,14 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               extraOvdcNetworks:
-                description: |-
-                  ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                  VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                  that are mounted to machines. VCDClusterSpec.OvdcNetwork is always
+                  attached regardless of this field.
                 items:
                   type: string
                 type: array
@@ -1841,9 +1794,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -1854,10 +1807,10 @@ spec:
                   to be used
                 type: string
               vmNamingTemplate:
-                description: |-
-                  VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                  Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                  Immutable field. machine.Name is used as VM name when this field is empty.
+                description: VmNamingTemplate is go template to generate VM names
+                  based on Machine and VCDMachine CRs. Functions of Sprig library
+                  are supported. See https://github.com/Masterminds/sprig Immutable
+                  field. machine.Name is used as VM name when this field is empty.
                 type: string
             type: object
           status:
@@ -1889,37 +1842,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -1971,19 +1924,14 @@ spec:
         description: VCDMachine is the Schema for the vcdmachines API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1991,9 +1939,8 @@ spec:
             description: VCDMachineSpec defines the desired state of VCDMachine
             properties:
               bootstrapped:
-                description: |-
-                  Bootstrapped is true when the kubeadm bootstrapping has been run
-                  against this machine
+                description: Bootstrapped is true when the kubeadm bootstrapping has
+                  been run against this machine
                 type: boolean
               catalog:
                 description: Catalog hosting templates
@@ -2007,14 +1954,14 @@ spec:
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               enableNvidiaGPU:
-                description: |-
-                  EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                  If true, then an appropriate placement policy should be set
+                description: EnableNvidiaGPU is true when a VM should be created with
+                  the relevant binaries installed If true, then an appropriate placement
+                  policy should be set
                 type: boolean
               extraOvdcNetworks:
-                description: |-
-                  ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                  VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                  that are mounted to machines. VCDClusterSpec.OvdcNetwork is always
+                  attached regardless of this field.
                 items:
                   type: string
                 type: array
@@ -2032,9 +1979,9 @@ spec:
                   (vmware-cloud-director://<vm id>)
                 type: string
               sizingPolicy:
-                description: |-
-                  SizingPolicy is the sizing policy to be used on this machine.
-                  If no sizing policy is specified, default sizing policy will be used to create the nodes
+                description: SizingPolicy is the sizing policy to be used on this
+                  machine. If no sizing policy is specified, default sizing policy
+                  will be used to create the nodes
                 type: string
               storageProfile:
                 description: StorageProfile is the storage profile to be used on this
@@ -2045,10 +1992,10 @@ spec:
                   to be used
                 type: string
               vmNamingTemplate:
-                description: |-
-                  VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                  Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                  Immutable field. machine.Name is used as VM name when this field is empty.
+                description: VmNamingTemplate is go template to generate VM names
+                  based on Machine and VCDMachine CRs. Functions of Sprig library
+                  are supported. See https://github.com/Masterminds/sprig Immutable
+                  field. machine.Name is used as VM name when this field is empty.
                 type: string
             type: object
           status:
@@ -2080,37 +2027,37 @@ spec:
                     operational state.
                   properties:
                     lastTransitionTime:
-                      description: |-
-                        Last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: |-
-                        A human readable message indicating details about the transition.
-                        This field may be empty.
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
                     reason:
-                      description: |-
-                        The reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may not be empty.
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
                     severity:
-                      description: |-
-                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: |-
-                        Type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
                   required:
                   - lastTransitionTime
@@ -2162,7 +2109,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capvcd-system/capvcd-serving-cert
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     cluster.x-k8s.io/provider: infrastructure-vcd
     cluster.x-k8s.io/v1alpha4: v1alpha4
@@ -2196,19 +2143,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2222,9 +2164,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -2263,19 +2204,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2289,9 +2225,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -2305,9 +2240,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be
@@ -2318,9 +2253,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -2352,19 +2287,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2374,27 +2304,24 @@ spec:
               template:
                 properties:
                   metadata:
-                    description: |-
-                      Standard object's metadata.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
                   spec:
@@ -2402,9 +2329,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -2418,14 +2344,14 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       extraOvdcNetworks:
-                        description: |-
-                          ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                          VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                        description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                          that are mounted to machines. VCDClusterSpec.OvdcNetwork
+                          is always attached regardless of this field.
                         items:
                           type: string
                         type: array
@@ -2438,9 +2364,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -2451,10 +2377,11 @@ spec:
                           that is to be used
                         type: string
                       vmNamingTemplate:
-                        description: |-
-                          VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                          Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                          Immutable field. machine.Name is used as VM name when this field is empty.
+                        description: VmNamingTemplate is go template to generate VM
+                          names based on Machine and VCDMachine CRs. Functions of
+                          Sprig library are supported. See https://github.com/Masterminds/sprig
+                          Immutable field. machine.Name is used as VM name when this
+                          field is empty.
                         type: string
                     type: object
                 required:
@@ -2478,19 +2405,14 @@ spec:
           API
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -2500,27 +2422,24 @@ spec:
               template:
                 properties:
                   metadata:
-                    description: |-
-                      Standard object's metadata.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     properties:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: http://kubernetes.io/docs/user-guide/labels
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
                         type: object
                     type: object
                   spec:
@@ -2528,9 +2447,8 @@ spec:
                       of the machine.
                     properties:
                       bootstrapped:
-                        description: |-
-                          Bootstrapped is true when the kubeadm bootstrapping has been run
-                          against this machine
+                        description: Bootstrapped is true when the kubeadm bootstrapping
+                          has been run against this machine
                         type: boolean
                       catalog:
                         description: Catalog hosting templates
@@ -2544,14 +2462,14 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       enableNvidiaGPU:
-                        description: |-
-                          EnableNvidiaGPU is true when a VM should be created with the relevant binaries installed
-                          If true, then an appropriate placement policy should be set
+                        description: EnableNvidiaGPU is true when a VM should be created
+                          with the relevant binaries installed If true, then an appropriate
+                          placement policy should be set
                         type: boolean
                       extraOvdcNetworks:
-                        description: |-
-                          ExtraOvdcNetworks is the list of extra Ovdc Networks that are mounted to machines.
-                          VCDClusterSpec.OvdcNetwork is always attached regardless of this field.
+                        description: ExtraOvdcNetworks is the list of extra Ovdc Networks
+                          that are mounted to machines. VCDClusterSpec.OvdcNetwork
+                          is always attached regardless of this field.
                         items:
                           type: string
                         type: array
@@ -2569,9 +2487,9 @@ spec:
                           format (vmware-cloud-director://<vm id>)
                         type: string
                       sizingPolicy:
-                        description: |-
-                          SizingPolicy is the sizing policy to be used on this machine.
-                          If no sizing policy is specified, default sizing policy will be used to create the nodes
+                        description: SizingPolicy is the sizing policy to be used
+                          on this machine. If no sizing policy is specified, default
+                          sizing policy will be used to create the nodes
                         type: string
                       storageProfile:
                         description: StorageProfile is the storage profile to be used
@@ -2582,10 +2500,11 @@ spec:
                           that is to be used
                         type: string
                       vmNamingTemplate:
-                        description: |-
-                          VmNamingTemplate is go template to generate VM names based on Machine and VCDMachine CRs.
-                          Functions of Sprig library are supported. See https://github.com/Masterminds/sprig
-                          Immutable field. machine.Name is used as VM name when this field is empty.
+                        description: VmNamingTemplate is go template to generate VM
+                          names based on Machine and VCDMachine CRs. Functions of
+                          Sprig library are supported. See https://github.com/Masterminds/sprig
+                          Immutable field. machine.Name is used as VM name when this
+                          field is empty.
                         type: string
                     type: object
                 required:
@@ -2954,6 +2873,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capvcd-system/capvcd-serving-cert
+  creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-vcd
   name: capvcd-mutating-webhook-configuration
@@ -3024,6 +2944,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: capvcd-system/capvcd-serving-cert
+  creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: infrastructure-vcd
   name: capvcd-validating-webhook-configuration

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -2019,6 +2019,8 @@ spec:
                   type: string
                 type: array
               failureDomain:
+                description: FailureDomain is the failure domain the machine will
+                  be created in.
                 type: string
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on
@@ -2553,6 +2555,8 @@ spec:
                           type: string
                         type: array
                       failureDomain:
+                        description: FailureDomain is the failure domain the machine
+                          will be created in.
                         type: string
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -2020,7 +2020,8 @@ spec:
                 type: array
               failureDomain:
                 description: FailureDomain is the failure domain the machine will
-                  be created in.
+                  be created in. Must match a key in the FailureDomains map stored
+                  on the cluster object.
                 type: string
               placementPolicy:
                 description: PlacementPolicy is the placement policy to be used on
@@ -2556,7 +2557,8 @@ spec:
                         type: array
                       failureDomain:
                         description: FailureDomain is the failure domain the machine
-                          will be created in.
+                          will be created in. Must match a key in the FailureDomains
+                          map stored on the cluster object.
                         type: string
                       placementPolicy:
                         description: PlacementPolicy is the placement policy to be


### PR DESCRIPTION
## Description
- Updates vApp name in the case of a multi-AZ cluster to include node pool name and OVDC ID

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/593)
<!-- Reviewable:end -->
