### PR TITLE
CAFV-374: ensure that VM is RESOLVED before adding networks

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -864,7 +864,8 @@ func (r *VCDMachineReconciler) reconcileVM(
 	}
 	log.Info("Machine is in status", "status", status)
 
-	// This is the exhaustive list of statuses as of 10.5.1.1.
+	// This is the exhaustive list of statuses as of 10.5.1.1. Some information about state transitions of a VM can
+	// be found at https://kb.vmware.com/s/article/2145957
 	switch status {
 	case "FAILED_CREATION, SUSPENDED, WAITING_FOR_INPUT, UNKNOWN, UNRECOGNIZED, INCONSISTENT_STATE, REJECTED",
 		"TRANSFER_TIMEOUT":


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- Ensure that VM is in RESOLVED state or beyond, before attaching network. If not, the network may get attached improperly (there will be no network access), leading to VMs running cloud-init with no network attached.

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [X] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [X] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [X] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [X] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [X] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/629)
<!-- Reviewable:end -->
