### PR TITLE
CAFV-364: fix issues with non-AZ clusters

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -395,11 +395,27 @@ func getMapOfEdgeGateways(ctx context.Context, vcdClient *vcdsdk.Client, orgName
 func (r *VCDClusterReconciler) getOvdcList(ctx context.Context, vcdOrg *govcd.Org, vcdCluster *infrav1beta3.VCDCluster,
 	vdc *govcd.Vdc) ([]rdeType.Ovdc, error) {
 
-	if vdc == nil && vcdCluster.Spec.MultiZoneSpec.Zones == nil {
+	var err error
+	if vdc == nil && vcdCluster.Spec.Ovdc == "" && vcdCluster.Spec.MultiZoneSpec.Zones == nil {
 		return nil, fmt.Errorf("VDC and Zones cannot both be nil")
 	}
 
+	// vdc passed in is highest priority, next is spec.ovdc, next is zone list
 	if vdc != nil {
+		return []rdeType.Ovdc{
+			{
+				Name:        vdc.Vdc.Name,
+				ID:          vdc.Vdc.ID,
+				OvdcNetwork: vcdCluster.Spec.OvdcNetwork,
+			},
+		}, nil
+	}
+
+	if vcdCluster.Spec.Ovdc != "" {
+		if vdc, err = vcdOrg.GetVDCByNameOrId(vcdCluster.Spec.Ovdc, false); err != nil {
+			return nil, fmt.Errorf("unable to get ovdc by identifier [%s] in org [%s]: [%v]",
+				vcdCluster.Spec.Ovdc, vcdOrg.Org.Name, err)
+		}
 		return []rdeType.Ovdc{
 			{
 				Name:        vdc.Vdc.Name,

--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -396,7 +396,7 @@ func (r *VCDClusterReconciler) getOvdcList(ctx context.Context, vcdOrg *govcd.Or
 	vdc *govcd.Vdc) ([]rdeType.Ovdc, error) {
 
 	var err error
-	if vdc == nil && vcdCluster.Spec.Ovdc == "" && vcdCluster.Spec.MultiZoneSpec.Zones == nil {
+	if vdc == nil && vcdCluster.Spec.Ovdc == "" && len(vcdCluster.Spec.MultiZoneSpec.Zones) == 0 {
 		return nil, fmt.Errorf("VDC and Zones cannot both be nil")
 	}
 


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- There was a regression which was introduced in the single-zone fix. This clears up teh regression and allows non-AZ clusters to be created again. 

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [X] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [X] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [X] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [X] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [X] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/630)
<!-- Reviewable:end -->
