### PR TITLE
[CAFV-466][1.3.z] bring CLUSTERCTL.md and CRS.md up to date

### DIFF
--- a/docs/CLUSTERCTL.md
+++ b/docs/CLUSTERCTL.md
@@ -38,8 +38,8 @@ Install [clusterctl](https://cluster-api.sigs.k8s.io/user/quick-start.html#insta
    - Refer to the [script to get Kubernetes, etcd, coredns versions from TKG OVA](WORKLOAD_CLUSTER.md#tkgm_bom) to fill in few variables. Note that you may skip filling
      in few of these variables if you decide to use the existing [clusterctl template flavors](#template_flavors).
    - If you decide to not use one of the existing clusterctl template flavors, please refer to the [TKG catalog management table](https://github.com/vmware/cluster-api-provider-cloud-director/blob/main/docs/TKGm_RELEASE_MATRIX.md) on the `main` branch
-3. Generate the CAPI manifest file.
-   - `clusterctl generate cluster <clusterName> -f v1.21.8-crs > <clusterName>.yaml`.
+3. Generate the CAPI manifest file. Please check the [templates](/templates) folder for relevant CRS versions.
+   - `clusterctl generate cluster <clusterName> -f v1.28.4-crs > <clusterName>.yaml`.
 4. Create the workload cluster by applying it on the (parent) management cluster.
    - `kubectl apply -f <clusterName>.yaml`
 5. [Apply CRS labels](CRS.md#apply_crs_labels) and [enable the resultant add-ons like CPI, CSI to access VCD resources](CRS.md#enable_add_ons)

--- a/docs/CRS.md
+++ b/docs/CRS.md
@@ -1,43 +1,51 @@
 # Cluster Resource Sets
 
-[ClusterResourceSets](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) will be 
+[ClusterResourceSets](https://cluster-api.sigs.k8s.io/tasks/experimental-features/cluster-resource-set.html) will be
 used to install CPI, CSI and CNI on the workload clusters.
 
 Initialize the management cluster via [clusterctl](CLUSTERCTL.md)
 
 <a name="apply_crs"></a>
+
 ## Apply CRS definitions on the (parent) management cluster
-To install CRS components on the management cluster, in CAPVCD repo, copy the contents of  [templates](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/templates/crs) 
-to the management cluster at `~/infrastructure-vcd/v1.1.0/`
+
+To install CRS components on the management cluster, in CAPVCD repo, copy the contents of [templates](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/templates/crs)
+to the management cluster anywhere at `~/infrastructure-vcd/<custom-path>`
+
 1. Apply CNI (Antrea) CRS definitions:
-   - Run `cd ~/infrastructure-vcd/v1.1.0/crs/cni`
+   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/cni`
    - kubectl create configmap antrea-crs-cm --from-file=antrea.yaml
    - kubectl apply -f antrea-crs.yaml
 2. Apply CPI CRS definitions:
-   - Run `cd ~/infrastructure-vcd/v1.1.0/crs/cpi`
+   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/cpi`
    - kubectl create configmap cloud-director-crs-cm --from-file=cloud-director-ccm.yaml
    - kubectl apply -f cloud-director-crs.yaml
 3. Apply CSI CRS definitions:
-   - Run `cd ~/infrastructure-vcd/v1.1.0/crs/csi`
+   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/csi`
    - kubectl create configmap csi-controller-crs-cm --from-file=csi-controller-crs.yaml
    - kubectl create configmap csi-node-crs-cm --from-file=csi-node-crs.yaml
    - kubectl create configmap csi-driver-crs-cm --from-file=csi-driver.yaml
    - kubectl apply -f csi-crs.yaml
 
-<a name="apply_crs_labels"></a>   
+<a name="apply_crs_labels"></a>
+
 ## Apply CRS labels on the Cluster manifests of the (children) workload cluster
+
 1. Generate the [cluster manifest](CLUSTERCTL.md#generate_cluster_manifest) via clusterctl.
 2. Ensure these labels are set under `metadata` section of `Cluster` definition in the [workload cluster manifest]. You can also use clusterctl [CRS template flavors](CLUSTERCTL.md#template_flavors) to
    [generate cluster manifests](CLUSTERCTL.md#generate_cluster_manifest) with the CRS labels preset
+
 ```yaml
 labels:
-    cni: antrea
-    ccm: external
-    csi: external
+  cni: antrea
+  ccm: external
+  csi: external
 ```
+
 3. Apply the cluster manifest - `kubectl apply -f <clusterName>.yaml`
 
 <a name="enable_add_ons"></a>
+
 ## Enable CPI and CSI on the workload cluster to access VMware Cloud Director resources
 
 0. Say parent management cluster's kubeconfig is saved in `mangement_cluster.conf`
@@ -51,7 +59,7 @@ labels:
    - `kubectl --kubeconfig=workload_cluster.conf -n kube-system create secret generic vcloud-basic-auth --from-literal=refreshToken=${REFRESH_TOKEN} --from-literal=username="" --from-literal=password=""`
 4. Create a config map for the CSI pod in the workload cluster.
    - Create a file with the following content, e.g vcloud-csi-config.yaml:
-   ```yaml
+   ````yaml
        ---
        apiVersion: v1
        kind: ConfigMap
@@ -72,9 +80,10 @@ labels:
    - Replace VCD_HOST, ORG, OVDC, VAPP, and CLUSTER_ID with the relevant values.
    - Create the config map in the workload cluster:
      `kubectl --kubeconfig=workload_cluster.conf apply -f vcloud-csi-config.yaml`
-5. Create a config map for the CCM/CPI pod in the workload cluster. 
+   ````
+5. Create a config map for the CCM/CPI pod in the workload cluster.
    - Create a file with the following content, e.g vcloud-ccm-config.yaml:
-   ```yaml
+   ````yaml
        apiVersion: v1
        kind: ConfigMap
        metadata:
@@ -104,6 +113,4 @@ labels:
    - Replace VCD_HOST, ORG, OVDC, NETWORK, VAPP, and CLUSTER_ID with the relevant values.
    - Create the config map in the workload cluster:
      `kubectl --kubeconfig=workload_cluster.conf apply -f vcloud-ccm-config.yaml`
-
-
-
+   ````

--- a/docs/CRS.md
+++ b/docs/CRS.md
@@ -9,7 +9,7 @@ Initialize the management cluster via [clusterctl](CLUSTERCTL.md)
 
 ## Apply CRS definitions on the (parent) management cluster
 
-To install CRS components on the management cluster, in CAPVCD repo, copy the contents of [templates](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/templates/crs)
+To install CRS components on the management cluster, in CAPVCD repo, copy the contents of [templates](https://github.com/vmware/cluster-api-provider-cloud-director/tree/1.3.z/templates/crs)
 to the management cluster anywhere under `$HOME`
 
 1. Apply CNI (Antrea) CRS definitions:

--- a/docs/CRS.md
+++ b/docs/CRS.md
@@ -10,18 +10,18 @@ Initialize the management cluster via [clusterctl](CLUSTERCTL.md)
 ## Apply CRS definitions on the (parent) management cluster
 
 To install CRS components on the management cluster, in CAPVCD repo, copy the contents of [templates](https://github.com/vmware/cluster-api-provider-cloud-director/tree/main/templates/crs)
-to the management cluster anywhere at `~/infrastructure-vcd/<custom-path>`
+to the management cluster anywhere under `$HOME`
 
 1. Apply CNI (Antrea) CRS definitions:
-   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/cni`
+   - Run `cd ~/<custom-path>/crs/cni`
    - kubectl create configmap antrea-crs-cm --from-file=antrea.yaml
    - kubectl apply -f antrea-crs.yaml
 2. Apply CPI CRS definitions:
-   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/cpi`
+   - Run `cd ~/<custom-path>/crs/cpi`
    - kubectl create configmap cloud-director-crs-cm --from-file=cloud-director-ccm.yaml
    - kubectl apply -f cloud-director-crs.yaml
 3. Apply CSI CRS definitions:
-   - Run `cd ~/infrastructure-vcd/<custom-path>/crs/csi`
+   - Run `cd ~/<custom-path>/crs/csi`
    - kubectl create configmap csi-controller-crs-cm --from-file=csi-controller-crs.yaml
    - kubectl create configmap csi-node-crs-cm --from-file=csi-node-crs.yaml
    - kubectl create configmap csi-driver-crs-cm --from-file=csi-driver.yaml


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- use relevant CRS versions in CLUSTERCTL.md
- CRS.md examples tell users they can use custom path

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/633)
<!-- Reviewable:end -->
