### PR TITLE
CAFV-393: Do not update VAppMetadataUpdated anymore

### DIFF
--- a/controllers/vcdmachine_controller.go
+++ b/controllers/vcdmachine_controller.go
@@ -752,7 +752,7 @@ func (r *VCDMachineReconciler) reconcileVAppCreation(ctx context.Context, vcdCli
 	//		"vAppID", clusterVApp.VApp.ID)
 	//}
 
-	if metadataMap != nil && !vcdCluster.Status.VAppMetadataUpdated {
+	if metadataMap != nil {
 		if err := vdcManager.AddMetadataToVApp(vAppName, metadataMap); err != nil {
 			capvcdRdeManager.AddToErrorSet(ctx, capisdk.VCDClusterError, "", vAppName,
 				fmt.Sprintf("failed to add metadata into vApp [%s]: [%v]", vcdCluster.Name, err))


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- This stops updating the vAppMetadataUpdated field. The VCDResourceSet already contains the list of vApps consumed by the cluster. This field is not needed anymore.
- This does not remove any race scenarios.
- This field can remove the number of VCD API calls _while a cluster is being created_ by 1 call per reentry to the reconciler. That is a small tax when the number of calls is considered. This can be reduced by other means as well.

## Checklist
- [X] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [X] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [X] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [X] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [X] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [X] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [X] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #
