### PR TITLE
[CAFV-464][1.3.z]Add suggested CRS labels to crs.yaml files

### DIFF
--- a/templates/cluster-template-v1.20.8-crs.yaml
+++ b/templates/cluster-template-v1.20.8-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.24.10-crs.yaml
+++ b/templates/cluster-template-v1.24.10-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.24.10-crs.yaml
+++ b/templates/cluster-template-v1.24.10-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.24.10---vmware.1-tkg.2"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.24.17-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.24.17-tkgv2.3.1-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.24.17-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.24.17-tkgv2.3.1-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.24.17---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.25.13-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.25.13-tkgv2.3.1-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.25.13-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.25.13-tkgv2.3.1-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.25.13---vmware.1-tkg.2"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.25.13-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.25.13-tkgv2.4.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.25.13-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.25.13-tkgv2.4.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.25.13---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.25.7-crs.yaml
+++ b/templates/cluster-template-v1.25.7-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.25.7-crs.yaml
+++ b/templates/cluster-template-v1.25.7-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.25.7---vmware.2-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.26.11---vmware.1-tkg.1-rc.5"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.26.11-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: "v1.26.11---vmware.1-tkg.1-rc.5"
+    tanzuKubernetesRelease: "v1.26.11---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.26.8-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.26.8-tkgv2.3.1-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.26.8-tkgv2.3.1-crs.yaml
+++ b/templates/cluster-template-v1.26.8-tkgv2.3.1-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.26.8---vmware.1-tkg.2"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.26.8-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.26.8-tkgv2.4.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.26.8-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.26.8-tkgv2.4.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.26.8---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.27.5-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.27.5-tkgv2.4.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.27.5-tkgv2.4.0-crs.yaml
+++ b/templates/cluster-template-v1.27.5-tkgv2.4.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.27.5---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: "v1.27.8---vmware.1-tkg.1-rc.5"
+    tanzuKubernetesRelease: "v1.27.8---vmware.1-tkg.2"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.27.8-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.27.8---vmware.1-tkg.1-rc.5"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
@@ -7,6 +7,9 @@ metadata:
     cni: antrea
     ccm: external
     csi: external
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:

--- a/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
+    tanzuKubernetesRelease: "v1.28.4---vmware.1-tkg.1-rc.5"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
+++ b/templates/cluster-template-v1.28.4-tkgv2.5.0-crs.yaml
@@ -8,7 +8,7 @@ metadata:
     ccm: external
     csi: external
     cluster-role.tkg.tanzu.vmware.com/management: ""
-    tanzuKubernetesRelease: "v1.28.4---vmware.1-tkg.1-rc.5"
+    tanzuKubernetesRelease: "v1.28.4---vmware.1-tkg.1"
     tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -57,7 +57,7 @@ ETCD_VERSION: v3.4.13_vmware.14 # Ignore this property if you are using one of t
 DNS_VERSION: v1.7.0_vmware.12 # Ignore this property if you are using one of the existing flavors
 POD_CIDR: "100.96.0.0/11"
 SERVICE_CIDR: "100.64.0.0/13"
-TKR_VERSION: v1.20.8---vmware.1-tkg.2 # Ignore this property if you are using one of the existing flavors
+TARGET_TANZUKUBERNETESRELEASE: ""
 TKG_VERSION: v1.4.2 # Ignore this property if you are using one of the existing flavors
 HTTP_PROXY:  "http://USERNAME:PASSWORD@SERVER:PORT"
 HTTPS_PROXY:  "https://USERNAME:PASSWORD@SERVER:PORT"

--- a/templates/clusterctl.yaml
+++ b/templates/clusterctl.yaml
@@ -57,7 +57,7 @@ ETCD_VERSION: v3.4.13_vmware.14 # Ignore this property if you are using one of t
 DNS_VERSION: v1.7.0_vmware.12 # Ignore this property if you are using one of the existing flavors
 POD_CIDR: "100.96.0.0/11"
 SERVICE_CIDR: "100.64.0.0/13"
-TARGET_TANZUKUBERNETESRELEASE: ""
+TARGET_TANZUKUBERNETESRELEASE: "v1.28.4---vmware.1-tkg.1"
 TKG_VERSION: v1.4.2 # Ignore this property if you are using one of the existing flavors
 HTTP_PROXY:  "http://USERNAME:PASSWORD@SERVER:PORT"
 HTTPS_PROXY:  "https://USERNAME:PASSWORD@SERVER:PORT"


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

Add these labels to all crs template files:

```
cluster-role.tkg.tanzu.vmware.com/management: ""
tanzuKubernetesRelease: ${TARGET_TANZUKUBERNETESRELEASE}
tkg.tanzu.vmware.com/cluster-name: ${CLUSTER_NAME}
```

## Checklist
- [ ] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/638)
<!-- Reviewable:end -->
