### PR TITLE
CAFV-444: Allow ovdc name and ID to both be used by clients

### DIFF
--- a/api/v1beta3/vcdcluster_types.go
+++ b/api/v1beta3/vcdcluster_types.go
@@ -101,8 +101,8 @@ type DCGroupConfig struct {
 type Zone struct {
 	// Name defines the name of this zone.
 	Name string `json:"name"`
-	// OVDCName defines the actual name of the OVDC which corresponds to this zone.
-	OVDCName string `json:"ovdcName"`
+	// OVDC defines the name or URN-ID of the OVDC which corresponds to this zone.
+	OVDC string `json:"ovdc"`
 	// OVDCNetworkName defines the OVDC network for this zone.
 	OVDCNetworkName string `json:"ovdcNetworkName"`
 	// ControlPlaneZone defines whether a control plane node can be deployed to this zone.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclusters.yaml
@@ -678,8 +678,8 @@ spec:
                         name:
                           description: Name defines the name of this zone.
                           type: string
-                        ovdcName:
-                          description: OVDCName defines the actual name of the OVDC
+                        ovdc:
+                          description: OVDC defines the name or URN-ID of the OVDC
                             which corresponds to this zone.
                           type: string
                         ovdcNetworkName:
@@ -689,7 +689,7 @@ spec:
                       required:
                       - controlPlaneZone
                       - name
-                      - ovdcName
+                      - ovdc
                       - ovdcNetworkName
                       type: object
                     type: array
@@ -751,8 +751,6 @@ spec:
                 type: object
             required:
             - org
-            - ovdc
-            - ovdcNetwork
             - site
             - userContext
             type: object
@@ -865,8 +863,8 @@ spec:
                         name:
                           description: Name defines the name of this zone.
                           type: string
-                        ovdcName:
-                          description: OVDCName defines the actual name of the OVDC
+                        ovdc:
+                          description: OVDC defines the name or URN-ID of the OVDC
                             which corresponds to this zone.
                           type: string
                         ovdcNetworkName:
@@ -876,7 +874,7 @@ spec:
                       required:
                       - controlPlaneZone
                       - name
-                      - ovdcName
+                      - ovdc
                       - ovdcNetworkName
                       type: object
                     type: array

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_vcdclustertemplates.yaml
@@ -228,8 +228,8 @@ spec:
                                 name:
                                   description: Name defines the name of this zone.
                                   type: string
-                                ovdcName:
-                                  description: OVDCName defines the actual name of
+                                ovdc:
+                                  description: OVDC defines the name or URN-ID of
                                     the OVDC which corresponds to this zone.
                                   type: string
                                 ovdcNetworkName:
@@ -239,7 +239,7 @@ spec:
                               required:
                               - controlPlaneZone
                               - name
-                              - ovdcName
+                              - ovdc
                               - ovdcNetworkName
                               type: object
                             type: array
@@ -301,8 +301,6 @@ spec:
                         type: object
                     required:
                     - org
-                    - ovdc
-                    - ovdcNetwork
                     - site
                     - userContext
                     type: object

--- a/controllers/capi_objects_utils.go
+++ b/controllers/capi_objects_utils.go
@@ -153,7 +153,7 @@ func getOvdcByID(client *vcdsdk.Client, orgName string, ovdcID string) (*govcd.V
 	if err != nil {
 		return nil, fmt.Errorf("error occurred when getting ovdc by ID [%s]: [%v]", ovdcID, err)
 	}
-	ovdc, err := org.GetVDCById(ovdcID, true)
+	ovdc, err := org.GetVDCByNameOrId(ovdcID, true)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
 			return nil, err
@@ -171,7 +171,7 @@ func getOvdcByName(client *vcdsdk.Client, orgName string, ovdcName string) (*gov
 	if err != nil {
 		return nil, fmt.Errorf("error occurred when getting ovdc by Name [%s]: [%v]", ovdcName, err)
 	}
-	ovdc, err := org.GetVDCByName(ovdcName, true)
+	ovdc, err := org.GetVDCByNameOrId(ovdcName, true)
 	if err != nil {
 		if err == govcd.ErrorEntityNotFound {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240315171752-0c0403c006c5
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52
 	github.com/vmware/go-vcloud-director/v2 v2.21.0
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240315171752-0c0403c006c5 h1:fYf837FNNE85Rx2VFhZTDXjzCnMboIm84DpoheFr5E8=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240315171752-0c0403c006c5/go.mod h1:7V/gaVSTqENxOW/9GXUrY27OF7UbTSZXEqGiq75GnK4=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52 h1:Bu21ENb/YH4kqDfvu6TbPyB254Di7yzI2jTx6QY6m4c=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52/go.mod h1:7V/gaVSTqENxOW/9GXUrY27OF7UbTSZXEqGiq75GnK4=
 github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
 github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/capisdk/defined_entity.go
+++ b/pkg/capisdk/defined_entity.go
@@ -182,7 +182,7 @@ func (capvcdRdeManager *CapvcdRdeManager) SetIsManagementClusterInRDE(ctx contex
 	return nil
 }
 
-// PatchRDE : Update only specific fields in the RDE. Takes in a map with keys, which contain "." delimitted
+// PatchRDE : Update only specific fields in the RDE. Takes in a map with keys, which contain "." delimited
 // strings, representing the spec, metadata and cavcd status fields to be updated.
 // Example: To patch only the "spec.capiYaml", "metadata.name", "status.capvcd.version" portion of the RDE, specPatch map should be something like this -
 // specPatch["CapiYaml"] = updated-yaml

--- a/templates/infrastructure-components.yaml
+++ b/templates/infrastructure-components.yaml
@@ -701,8 +701,8 @@ spec:
                         name:
                           description: Name defines the name of this zone.
                           type: string
-                        ovdcName:
-                          description: OVDCName defines the actual name of the OVDC
+                        ovdc:
+                          description: OVDC defines the name or URN-ID of the OVDC
                             which corresponds to this zone.
                           type: string
                         ovdcNetworkName:
@@ -712,7 +712,7 @@ spec:
                       required:
                       - controlPlaneZone
                       - name
-                      - ovdcName
+                      - ovdc
                       - ovdcNetworkName
                       type: object
                     type: array
@@ -774,8 +774,6 @@ spec:
                 type: object
             required:
             - org
-            - ovdc
-            - ovdcNetwork
             - site
             - userContext
             type: object
@@ -888,8 +886,8 @@ spec:
                         name:
                           description: Name defines the name of this zone.
                           type: string
-                        ovdcName:
-                          description: OVDCName defines the actual name of the OVDC
+                        ovdc:
+                          description: OVDC defines the name or URN-ID of the OVDC
                             which corresponds to this zone.
                           type: string
                         ovdcNetworkName:
@@ -899,7 +897,7 @@ spec:
                       required:
                       - controlPlaneZone
                       - name
-                      - ovdcName
+                      - ovdc
                       - ovdcNetworkName
                       type: object
                     type: array
@@ -1225,8 +1223,8 @@ spec:
                                 name:
                                   description: Name defines the name of this zone.
                                   type: string
-                                ovdcName:
-                                  description: OVDCName defines the actual name of
+                                ovdc:
+                                  description: OVDC defines the name or URN-ID of
                                     the OVDC which corresponds to this zone.
                                   type: string
                                 ovdcNetworkName:
@@ -1236,7 +1234,7 @@ spec:
                               required:
                               - controlPlaneZone
                               - name
-                              - ovdcName
+                              - ovdc
                               - ovdcNetworkName
                               type: object
                             type: array
@@ -1298,8 +1296,6 @@ spec:
                         type: object
                     required:
                     - org
-                    - ovdc
-                    - ovdcNetwork
                     - site
                     - userContext
                     type: object

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/client.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/client.go
@@ -24,13 +24,13 @@ type TestClient struct {
 }
 
 type VCDAuthParams struct {
-	Host         string
-	OvdcName     string
-	OrgName      string
-	Username     string
-	RefreshToken string
-	UserOrg      string
-	GetVdcClient bool // This will need to be set to true as it's needed for CSI, but may not be needed for other use cases
+	Host           string
+	OvdcIdentifier string
+	OrgName        string
+	Username       string
+	RefreshToken   string
+	UserOrg        string
+	GetVdcClient   bool // This will need to be set to true as it's needed for CSI, but may not be needed for other use cases
 }
 
 type DeployParams struct {

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/vcd_utils.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk/vcd_utils.go
@@ -12,7 +12,7 @@ func getTestVCDClient(params *VCDAuthParams) (*vcdsdk.Client, error) {
 	return vcdsdk.NewVCDClientFromSecrets(
 		params.Host,
 		params.OrgName,
-		params.OvdcName,
+		params.OvdcIdentifier,
 		params.UserOrg,
 		params.Username,
 		"",

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/client.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/client.go
@@ -19,13 +19,13 @@ import (
 
 // Client :
 type Client struct {
-	VCDAuthConfig   *VCDAuthConfig // s
-	ClusterOrgName  string
-	ClusterOVDCName string
-	VCDClient       *govcd.VCDClient
-	VDC             *govcd.Vdc // TODO: Incrementally remove and test in tests
-	APIClient       *swaggerClient37.APIClient
-	RWLock          sync.RWMutex
+	VCDAuthConfig         *VCDAuthConfig
+	ClusterOrgName        string
+	ClusterOVDCIdentifier string
+	VCDClient             *govcd.VCDClient
+	VDC                   *govcd.Vdc // TODO: Incrementally remove and test in tests
+	APIClient             *swaggerClient37.APIClient
+	RWLock                sync.RWMutex
 }
 
 func GetUserAndOrg(fullUserName string, clusterOrg string, currentUserOrg string) (userOrg string, userName string, err error) {
@@ -98,7 +98,7 @@ func (client *Client) RefreshBearerToken() error {
 			return fmt.Errorf("unable to get vcd organization [%s]: [%v]",
 				client.ClusterOrgName, err)
 		}
-		vdc, err := org.GetVDCByName(client.ClusterOVDCName, true)
+		vdc, err := org.GetVDCByNameOrId(client.ClusterOVDCIdentifier, true)
 		if err != nil {
 			return fmt.Errorf("unable to get VDC from org [%s], VDC [%s]: [%v]",
 				client.ClusterOrgName, client.VCDAuthConfig.VDC, err)
@@ -138,7 +138,7 @@ func (client *Client) RefreshBearerToken() error {
 // host, orgName, userOrg, refreshToken, insecure, user, password
 
 // New method from (vdcClient, vdcName) return *govcd.Vdc
-func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOrg string,
+func NewVCDClientFromSecrets(host string, orgName string, vdcIdentifier string, userOrg string,
 	user string, password string, refreshToken string, insecure bool, getVdcClient bool) (*Client, error) {
 
 	// TODO: validation of parameters
@@ -178,11 +178,11 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 	}
 
 	client := &Client{
-		VCDAuthConfig:   vcdAuthConfig,
-		ClusterOrgName:  orgName,
-		ClusterOVDCName: vdcName,
-		VCDClient:       vcdClient,
-		APIClient:       apiClient,
+		VCDAuthConfig:         vcdAuthConfig,
+		ClusterOrgName:        orgName,
+		ClusterOVDCIdentifier: vdcIdentifier,
+		VCDClient:             vcdClient,
+		APIClient:             apiClient,
 	}
 
 	if getVdcClient {
@@ -191,9 +191,9 @@ func NewVCDClientFromSecrets(host string, orgName string, vdcName string, userOr
 			return nil, fmt.Errorf("unable to get org from name [%s]: [%v]", orgName, err)
 		}
 
-		client.VDC, err = org.GetVDCByName(vdcName, true)
+		client.VDC, err = org.GetVDCByNameOrId(vdcIdentifier, true)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get VDC [%s] from org [%s]: [%v]", vdcName, orgName, err)
+			return nil, fmt.Errorf("unable to get VDC [%s] from org [%s]: [%v]", vdcIdentifier, orgName, err)
 		}
 	}
 	client.VCDClient = vcdClient

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -268,7 +268,7 @@ github.com/spf13/cast
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240315171752-0c0403c006c5
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52
 ## explicit; go 1.21
 github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- This allows both OVDC URN ID (`urn:vcloud:vdc:<uuid>`) and OVDC name to be used in cluster creation.

## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [X] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [X] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [X] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [X] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [X] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [X] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [X] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/639)
<!-- Reviewable:end -->
