### PR TITLE
CAFV-475: Handle null OVDCs in dcgroup OVDC network lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52
+	github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240410051826-2250c7c54be5
 	github.com/vmware/go-vcloud-director/v2 v2.21.0
 	go.uber.org/zap v1.26.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52 h1:Bu21ENb/YH4kqDfvu6TbPyB254Di7yzI2jTx6QY6m4c=
-github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52/go.mod h1:7V/gaVSTqENxOW/9GXUrY27OF7UbTSZXEqGiq75GnK4=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240410051826-2250c7c54be5 h1:MfOUdyiui5sjUTGqQUsECT6IdZIRswXLH9E1dFPt4yI=
+github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240410051826-2250c7c54be5/go.mod h1:7V/gaVSTqENxOW/9GXUrY27OF7UbTSZXEqGiq75GnK4=
 github.com/vmware/go-vcloud-director/v2 v2.21.0 h1:zIONrJpM+Fj+rDyXmsRfMAn1sP5WAP87USL0T9GS4DY=
 github.com/vmware/go-vcloud-director/v2 v2.21.0/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,10 +83,10 @@ func GetOVDCNetwork(ctx context.Context, client *vcdsdk.Client,
 		if len(ovdcNetworks.Values) == 0 {
 			break
 		}
-
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if ovdcNetwork.Name == ovdcNetworkName && ovdcNetwork.OrgVdc != nil &&
-				(ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
+			if ovdcNetwork.Name == ovdcNetworkName &&
+				(ovdcNetwork.OrgVdc == nil ||
+					ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
 					ovdcNetwork.OrgVdc.Id == ovdcIdentifier) {
 				if networkFound {
 					return nil, fmt.Errorf(

--- a/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
+++ b/vendor/github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk/gateway.go
@@ -121,8 +121,9 @@ func (gm *GatewayManager) getOVDCNetwork(ctx context.Context, networkName string
 		}
 
 		for _, ovdcNetwork := range ovdcNetworks.Values {
-			if ovdcNetwork.Name == gm.NetworkName && ovdcNetwork.OrgVdc != nil &&
-				(ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
+			if ovdcNetwork.Name == gm.NetworkName &&
+				(ovdcNetwork.OrgVdc == nil ||
+					ovdcNetwork.OrgVdc.Name == ovdcIdentifier ||
 					ovdcNetwork.OrgVdc.Id == ovdcIdentifier) {
 				if networkFound {
 					return nil, fmt.Errorf("found more than one network with the name [%s] in the org [%s] - "+

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -268,7 +268,7 @@ github.com/spf13/cast
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240403204926-7a46afa77f52
+# github.com/vmware/cloud-provider-for-cloud-director v0.0.0-20240410051826-2250c7c54be5
 ## explicit; go 1.21
 github.com/vmware/cloud-provider-for-cloud-director/pkg/testingsdk
 github.com/vmware/cloud-provider-for-cloud-director/pkg/util


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- The OVDC in a dcgroup network is nil.

## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [X] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/640)
<!-- Reviewable:end -->
