### PR TITLE
[CAFV-478] CAPVCD fails to delete all the vApps

### DIFF
--- a/controllers/vcdcluster_controller.go
+++ b/controllers/vcdcluster_controller.go
@@ -1151,7 +1151,7 @@ func (r *VCDClusterReconciler) reconcileLoadBalancer(ctx context.Context, vcdClu
 			vcdCluster.Status.FailureDomains[zone.Name] = clusterv1.FailureDomainSpec{
 				ControlPlane: zone.ControlPlaneZone,
 				Attributes: map[string]string{
-					"OVDCName":         edgeGatewayDetails.Vdc.Vdc.Name,
+					"OVDC":             edgeGatewayDetails.Vdc.Vdc.Name,
 					"OvdcId":           edgeGatewayDetails.Vdc.Vdc.ID,
 					"OVDCNetworkName":  edgeGatewayDetails.OvdcNetworkReference.Name,
 					"OVDCNetworkID":    edgeGatewayDetails.OvdcNetworkReference.Id,


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- CAPVCD fails to delete all the vApps

## Checklist
- [x] tested locally
- [ ] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [ ] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A

5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<img width="1792" alt="Screenshot 2024-04-18 at 11 53 04 AM" src="https://github.com/vmware/cluster-api-provider-cloud-director/assets/102765549/714eb759-fab6-47a5-b7d2-c3f21ea3fa44">
<img width="1524" alt="Screenshot 2024-04-18 at 11 53 10 AM" src="https://github.com/vmware/cluster-api-provider-cloud-director/assets/102765549/88e64d00-411c-4277-a325-d5fea978686b">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/642)
<!-- Reviewable:end -->
