### PR TITLE
650: Fix issue with CSI manifests for v1.6.0

### DIFF
--- a/templates/crs/csi/csi-controller-crs.yaml
+++ b/templates/crs/csi/csi-controller-crs.yaml
@@ -89,6 +89,43 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+# external resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-vcd-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -134,6 +171,19 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: vcd-csi-plugin
           securityContext:
             privileged: true
@@ -147,7 +197,6 @@ spec:
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
             - --endpoint=$(CSI_ENDPOINT)
             - --upgrade-rde
-            - --v=5
           env:
             - name: NODE_ID
               valueFrom:

--- a/templates/crs/csi/csi-node-crs.yaml
+++ b/templates/crs/csi/csi-node-crs.yaml
@@ -27,6 +27,7 @@ roleRef:
   kind: ClusterRole
   name: csi-nodeplugin-role
   apiGroup: rbac.authorization.k8s.io
+
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -71,6 +72,19 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: vcd-csi-plugin
           securityContext:
             privileged: true
@@ -84,7 +98,6 @@ spec:
             - --nodeid=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
-            - --v=5
           env:
             - name: NODE_ID
               valueFrom:
@@ -110,7 +123,7 @@ spec:
               mountPath: /dev
               mountPropagation: "HostToContainer"
             - name: pv-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
               mountPropagation: "Bidirectional"
             - name: vcloud-csi-config-volume
               mountPath: /etc/kubernetes/vcloud
@@ -139,7 +152,7 @@ spec:
             type: Directory
         - name: pv-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
             type: DirectoryOrCreate
         - name: vcloud-csi-config-volume
           configMap:
@@ -147,4 +160,3 @@ spec:
         - name: vcloud-basic-auth-volume
           secret:
             secretName: vcloud-basic-auth
----


### PR DESCRIPTION
## Description
Please provide a brief description of the changes proposed in this Pull Request

- CSI manifests are not updated for CSI-1.6.0 which brings in volume expansion and block support. This change updates the manifests to have the same RBAC and support containers that are present in the CSI 1.6.0 release.
Fixes #650 


## Checklist
- [X] tested locally
- [X] updated any relevant dependencies
- [ ] updated any relevant documentation or examples

## API Changes
Are there API changes?
- [ ] Yes
- [X] No

If yes, please fill in the below

1. Updated conversions?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
2. Updated CRDs?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
3. Updated infrastructure-components.yaml?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
4. Updated `./examples/capi-quickstart.yaml`?
    - [ ] Yes
    - [ ] No
    - [ ] N/A
5. Updated necessary files under `./infrastructure-vcd/v1.0.0/`?
   - [ ] Yes
   - [ ] No
   - [ ] N/A

## Issue
If applicable, please reference the relevant issue

Fixes #

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/cluster-api-provider-cloud-director/663)
<!-- Reviewable:end -->
